### PR TITLE
Run cargo fix --edition-idioms

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
-
 use vergen::{ConstantsFlags, Result, Vergen};
 
 fn main() {

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-extern crate vergen;
+
 
 use vergen::{ConstantsFlags, Result, Vergen};
 

--- a/core/src/account_provider.rs
+++ b/core/src/account_provider.rs
@@ -71,7 +71,7 @@ impl From<KeystoreError> for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Error::NotUnlocked => write!(f, "Account is locked"),
             Error::NotFound => write!(f, "Account does not exist"),
@@ -199,7 +199,7 @@ impl AccountProvider {
         Ok(())
     }
 
-    pub fn get_unlocked_account(&self, address: &Address) -> Result<ScopedAccount, Error> {
+    pub fn get_unlocked_account(&self, address: &Address) -> Result<ScopedAccount<'_>, Error> {
         let mut unlocked = self.unlocked.write();
         let data = unlocked.get(address).ok_or(Error::NotUnlocked)?.clone();
         if let Unlock::OneTime = data.unlock {
@@ -220,7 +220,7 @@ impl AccountProvider {
         self.keystore.decrypt_account(address, password)
     }
 
-    pub fn get_account(&self, address: &Address, password: Option<&Password>) -> Result<ScopedAccount, Error> {
+    pub fn get_account(&self, address: &Address, password: Option<&Password>) -> Result<ScopedAccount<'_>, Error> {
         match password {
             Some(password) => Ok(ScopedAccount::from(self.decrypt_account(address, password)?)),
             None => self.get_unlocked_account(address),

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -55,7 +55,7 @@ impl Block {
 }
 
 impl Decodable for Block {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let got = rlp.as_raw().len();
         let expected = rlp.payload_info()?.total();
         if got > expected {
@@ -338,7 +338,7 @@ impl ClosedBlock {
     }
 
     /// Given an engine reference, reopen the `ClosedBlock` into an `OpenBlock`.
-    pub fn reopen(self, engine: &dyn CodeChainEngine) -> OpenBlock {
+    pub fn reopen(self, engine: &dyn CodeChainEngine) -> OpenBlock<'_> {
         // revert rewards (i.e. set state back at last transaction's state).
         let mut block = self.block;
         block.state = self.unclosed_state;

--- a/core/src/blockchain/block_info.rs
+++ b/core/src/blockchain/block_info.rs
@@ -43,7 +43,7 @@ impl BestBlockChanged {
         Some(self.best_block()?.hash())
     }
 
-    pub fn best_block(&self) -> Option<BlockView> {
+    pub fn best_block(&self) -> Option<BlockView<'_>> {
         let block = match self {
             BestBlockChanged::CanonChainAppended {
                 best_block,
@@ -82,7 +82,7 @@ impl BestHeaderChanged {
         Some(self.header()?.hash())
     }
 
-    pub fn header(&self) -> Option<HeaderView> {
+    pub fn header(&self) -> Option<HeaderView<'_>> {
         let header = match self {
             BestHeaderChanged::CanonChainAppended {
                 best_header,

--- a/core/src/blockchain/blockchain.rs
+++ b/core/src/blockchain/blockchain.rs
@@ -101,7 +101,7 @@ impl BlockChain {
     pub fn insert_header(
         &self,
         batch: &mut DBTransaction,
-        header: &HeaderView,
+        header: &HeaderView<'_>,
         engine: &dyn CodeChainEngine,
     ) -> ImportRoute {
         match self.headerchain.insert_header(batch, header, engine) {
@@ -180,7 +180,7 @@ impl BlockChain {
     }
 
     /// Calculate how best block is changed
-    fn best_block_changed(&self, new_block: &BlockView, engine: &dyn CodeChainEngine) -> BestBlockChanged {
+    fn best_block_changed(&self, new_block: &BlockView<'_>, engine: &dyn CodeChainEngine) -> BestBlockChanged {
         let new_header = new_block.header_view();
         let parent_hash_of_new_block = new_header.parent_hash();
         let parent_details_of_new_block = self.block_details(&parent_hash_of_new_block).expect("Invalid parent hash");

--- a/core/src/blockchain/body_db.rs
+++ b/core/src/blockchain/body_db.rs
@@ -50,7 +50,7 @@ type TrackerAndAddress = (Tracker, TransactionAddresses);
 
 impl BodyDB {
     /// Create new instance of blockchain from given Genesis.
-    pub fn new(genesis: &BlockView, db: Arc<dyn KeyValueDB>) -> Self {
+    pub fn new(genesis: &BlockView<'_>, db: Arc<dyn KeyValueDB>) -> Self {
         let bdb = Self {
             body_cache: Mutex::new(LruCache::new(BODY_CACHE_SIZE)),
             address_by_hash_cache: RwLock::new(HashMap::new()),
@@ -76,7 +76,7 @@ impl BodyDB {
     /// Inserts the block body into backing cache database.
     /// Expects the body to be valid and already verified.
     /// If the body is already known, does nothing.
-    pub fn insert_body(&self, batch: &mut DBTransaction, block: &BlockView) {
+    pub fn insert_body(&self, batch: &mut DBTransaction, block: &BlockView<'_>) {
         let hash = block.hash();
 
         if self.is_known_body(&hash) {
@@ -270,7 +270,7 @@ impl BodyDB {
     }
 
     /// Create a block body from a block.
-    pub fn block_to_body(block: &BlockView) -> Bytes {
+    pub fn block_to_body(block: &BlockView<'_>) -> Bytes {
         let mut body = RlpStream::new_list(1);
         body.append_raw(block.rlp().at(1).unwrap().as_raw(), 1);
         body.out()

--- a/core/src/blockchain/headerchain.rs
+++ b/core/src/blockchain/headerchain.rs
@@ -63,7 +63,7 @@ pub struct HeaderChain {
 
 impl HeaderChain {
     /// Create new instance of blockchain from given Genesis.
-    pub fn new(genesis: &HeaderView, db: Arc<dyn KeyValueDB>) -> Self {
+    pub fn new(genesis: &HeaderView<'_>, db: Arc<dyn KeyValueDB>) -> Self {
         // load best header
         let best_header_hash = match db.get(db::COL_EXTRA, BEST_HEADER_KEY).unwrap() {
             Some(hash) => H256::from_slice(&hash).into(),
@@ -122,7 +122,7 @@ impl HeaderChain {
     pub fn insert_header(
         &self,
         batch: &mut DBTransaction,
-        header: &HeaderView,
+        header: &HeaderView<'_>,
         engine: &dyn CodeChainEngine,
     ) -> Option<BestHeaderChanged> {
         let hash = header.hash();
@@ -222,7 +222,7 @@ impl HeaderChain {
 
     /// This function returns modified block details.
     /// Uses the given parent details or attempts to load them from the database.
-    fn new_detail_entries(&self, header: &HeaderView) -> HashMap<BlockHash, BlockDetails> {
+    fn new_detail_entries(&self, header: &HeaderView<'_>) -> HashMap<BlockHash, BlockDetails> {
         let parent_hash = header.parent_hash();
         let parent_details = self.block_details(&parent_hash).expect("Invalid parent hash");
 
@@ -240,7 +240,7 @@ impl HeaderChain {
     }
 
     /// Calculate how best block is changed
-    fn best_header_changed(&self, new_header: &HeaderView, engine: &dyn CodeChainEngine) -> BestHeaderChanged {
+    fn best_header_changed(&self, new_header: &HeaderView<'_>, engine: &dyn CodeChainEngine) -> BestHeaderChanged {
         let parent_hash_of_new_header = new_header.parent_hash();
         let parent_details_of_new_header = self.block_details(&parent_hash_of_new_header).expect("Invalid parent hash");
         let grandparent_hash_of_new_header = parent_details_of_new_header.parent;

--- a/core/src/blockchain/invoice_db.rs
+++ b/core/src/blockchain/invoice_db.rs
@@ -120,7 +120,7 @@ impl Encodable for TrackerInvoices {
 }
 
 impl Decodable for TrackerInvoices {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = rlp.item_count()?;
         if item_count % 2 == 1 {
             return Err(DecoderError::RlpInvalidLength {

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -306,7 +306,7 @@ impl Client {
         &self.state_db
     }
 
-    pub fn block_chain(&self) -> RwLockReadGuard<BlockChain> {
+    pub fn block_chain(&self) -> RwLockReadGuard<'_, BlockChain> {
         self.chain.read()
     }
 
@@ -872,12 +872,12 @@ impl Shard for Client {
 }
 
 impl BlockProducer for Client {
-    fn reopen_block(&self, block: ClosedBlock) -> OpenBlock {
+    fn reopen_block(&self, block: ClosedBlock) -> OpenBlock<'_> {
         let engine = &*self.engine;
         block.reopen(engine)
     }
 
-    fn prepare_open_block(&self, parent_block_id: BlockId, author: Address, extra_data: Bytes) -> OpenBlock {
+    fn prepare_open_block(&self, parent_block_id: BlockId, author: Address, extra_data: Bytes) -> OpenBlock<'_> {
         let engine = &*self.engine;
         let chain = self.block_chain();
         let parent_hash = self.block_hash(&parent_block_id).expect("parent exist always");

--- a/core/src/client/error.rs
+++ b/core/src/client/error.rs
@@ -32,7 +32,7 @@ impl From<UtilError> for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         match self {
             Error::Util(err) => write!(f, "{}", err),
         }

--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -306,7 +306,7 @@ impl Importer {
         &'a self,
         headers: impl IntoIterator<Item = &'a Header>,
         client: &Client,
-        _importer_lock: &MutexGuard<()>,
+        _importer_lock: &MutexGuard<'_, ()>,
     ) -> usize {
         let prev_best_proposal_header_hash = client.block_chain().best_proposal_header().hash();
 

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -265,10 +265,10 @@ pub type ImportResult = Result<BlockHash, Error>;
 /// Provides methods used for sealing new state
 pub trait BlockProducer {
     /// Reopens an OpenBlock and updates uncles.
-    fn reopen_block(&self, block: ClosedBlock) -> OpenBlock;
+    fn reopen_block(&self, block: ClosedBlock) -> OpenBlock<'_>;
 
     /// Returns OpenBlock prepared for closing.
-    fn prepare_open_block(&self, parent_block: BlockId, author: Address, extra_data: Bytes) -> OpenBlock;
+    fn prepare_open_block(&self, parent_block: BlockId, author: Address, extra_data: Bytes) -> OpenBlock<'_>;
 }
 
 /// Extended client interface used for mining

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -343,11 +343,11 @@ pub fn get_temp_state_db() -> StateDB {
 }
 
 impl BlockProducer for TestBlockChainClient {
-    fn reopen_block(&self, block: ClosedBlock) -> OpenBlock {
+    fn reopen_block(&self, block: ClosedBlock) -> OpenBlock<'_> {
         block.reopen(&*self.scheme.engine)
     }
 
-    fn prepare_open_block(&self, _parent_block: BlockId, author: Address, extra_data: Bytes) -> OpenBlock {
+    fn prepare_open_block(&self, _parent_block: BlockId, author: Address, extra_data: Bytes) -> OpenBlock<'_> {
         let engine = &*self.scheme.engine;
         let genesis_header = self.scheme.genesis_header();
         let db = get_temp_state_db();

--- a/core/src/consensus/bit_set.rs
+++ b/core/src/consensus/bit_set.rs
@@ -84,7 +84,7 @@ impl BitSet {
             .sum()
     }
 
-    pub fn true_index_iter(&self) -> BitSetIndexIterator {
+    pub fn true_index_iter(&self) -> BitSetIndexIterator<'_> {
         BitSetIndexIterator {
             index: 0,
             bitset: self,
@@ -99,7 +99,7 @@ impl Default for BitSet {
 }
 
 impl fmt::Debug for BitSet {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0[..].fmt(formatter)
     }
 }
@@ -122,7 +122,7 @@ impl Encodable for BitSet {
 }
 
 impl Decodable for BitSet {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         rlp.decoder().decode_value(|bytes| {
             let expected = BITSET_SIZE;
             let got = bytes.len();

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -261,7 +261,7 @@ pub trait ConsensusEngine: Sync + Send {
 
     fn register_chain_notify(&self, _: &Client) {}
 
-    fn get_best_block_from_best_proposal_header(&self, header: &HeaderView) -> BlockHash {
+    fn get_best_block_from_best_proposal_header(&self, header: &HeaderView<'_>) -> BlockHash {
         header.hash()
     }
 
@@ -327,7 +327,7 @@ pub enum EngineError {
 }
 
 impl fmt::Display for EngineError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::EngineError::*;
         let msg = match self {
             BlockNotAuthorized(address) => format!("Signer {} is not authorized.", address),

--- a/core/src/consensus/stake/action_data.rs
+++ b/core/src/consensus/stake/action_data.rs
@@ -144,20 +144,20 @@ impl Stakeholders {
         self.0.contains(address)
     }
 
-    pub fn update_by_increased_balance(&mut self, account: &StakeAccount) {
+    pub fn update_by_increased_balance(&mut self, account: &StakeAccount<'_>) {
         if account.balance > 0 {
             self.0.insert(*account.address);
         }
     }
 
-    pub fn update_by_decreased_balance(&mut self, account: &StakeAccount, delegation: &Delegation) {
+    pub fn update_by_decreased_balance(&mut self, account: &StakeAccount<'_>, delegation: &Delegation<'_>) {
         assert!(account.address == delegation.delegator);
         if account.balance == 0 && delegation.sum() == 0 {
             self.0.remove(account.address);
         }
     }
 
-    pub fn iter(&self) -> btree_set::Iter<Address> {
+    pub fn iter(&self) -> btree_set::Iter<'_, Address> {
         self.0.iter()
     }
 }
@@ -225,7 +225,7 @@ impl<'a> Delegation<'a> {
         self.delegatees.get(delegatee).cloned().unwrap_or(0)
     }
 
-    pub fn iter(&self) -> btree_map::Iter<Address, StakeQuantity> {
+    pub fn iter(&self) -> btree_map::Iter<'_, Address, StakeQuantity> {
         self.delegatees.iter()
     }
 
@@ -730,7 +730,7 @@ where
     }
 }
 
-fn decode_map_impl<K, V>(rlp: Rlp) -> BTreeMap<K, V>
+fn decode_map_impl<K, V>(rlp: Rlp<'_>) -> BTreeMap<K, V>
 where
     K: Ord + Decodable,
     V: Decodable, {

--- a/core/src/consensus/stake/actions.rs
+++ b/core/src/consensus/stake/actions.rs
@@ -241,7 +241,7 @@ impl Encodable for Action {
 }
 
 impl Decodable for Action {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let tag = rlp.val_at(0)?;
         match tag {
             ACTION_TAG_TRANSFER_CCS => {

--- a/core/src/consensus/stake/distribute.rs
+++ b/core/src/consensus/stake/distribute.rs
@@ -21,7 +21,7 @@ use ckey::Address;
 use std::collections::hash_map;
 use std::collections::HashMap;
 
-pub fn fee_distribute(total_min_fee: u64, stakes: &HashMap<Address, u64>) -> FeeDistributeIter {
+pub fn fee_distribute(total_min_fee: u64, stakes: &HashMap<Address, u64>) -> FeeDistributeIter<'_> {
     FeeDistributeIter {
         total_stakes: stakes.values().sum(),
         total_min_fee,

--- a/core/src/consensus/tendermint/backup.rs
+++ b/core/src/consensus/tendermint/backup.rs
@@ -53,7 +53,7 @@ pub struct BackupDataV1 {
     pub finalized_view_of_current_block: Option<View>,
 }
 
-pub fn backup(db: &dyn KeyValueDB, backup_data: BackupView) {
+pub fn backup(db: &dyn KeyValueDB, backup_data: BackupView<'_>) {
     let BackupView {
         height,
         view,

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -291,7 +291,7 @@ impl ConsensusEngine for Tendermint {
         client.add_notify(Arc::downgrade(&self.chain_notify) as Weak<dyn ChainNotify>);
     }
 
-    fn get_best_block_from_best_proposal_header(&self, header: &HeaderView) -> BlockHash {
+    fn get_best_block_from_best_proposal_header(&self, header: &HeaderView<'_>) -> BlockHash {
         header.parent_hash()
     }
 

--- a/core/src/consensus/tendermint/message.rs
+++ b/core/src/consensus/tendermint/message.rs
@@ -188,7 +188,7 @@ impl Encodable for TendermintMessage {
 }
 
 impl Decodable for TendermintMessage {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let id = rlp.val_at(0)?;
         Ok(match id {
             MESSAGE_ID_CONSENSUS_MESSAGE => {

--- a/core/src/consensus/tendermint/types.rs
+++ b/core/src/consensus/tendermint/types.rs
@@ -133,7 +133,7 @@ impl TendermintState {
 }
 
 impl fmt::Debug for TendermintState {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TendermintState::Propose => write!(f, "TendermintState::Propose"),
             TendermintState::ProposeWaitBlockGeneration {
@@ -179,7 +179,7 @@ impl Step {
 }
 
 impl Decodable for Step {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         match rlp.as_val()? {
             0u8 => Ok(Step::Propose),
             1 => Ok(Step::Prevote),

--- a/core/src/encoded.rs
+++ b/core/src/encoded.rs
@@ -52,13 +52,13 @@ impl Header {
 
     /// Get a borrowed header view onto the data.
     #[inline]
-    pub fn view(&self) -> views::HeaderView {
+    pub fn view(&self) -> views::HeaderView<'_> {
         views::HeaderView::new(&self.0)
     }
 
     /// Get the rlp of the header.
     #[inline]
-    pub fn rlp(&self) -> Rlp {
+    pub fn rlp(&self) -> Rlp<'_> {
         Rlp::new(&self.0)
     }
 
@@ -134,7 +134,7 @@ impl Body {
 
     /// Get a borrowed view of the data within.
     #[inline]
-    pub fn view(&self) -> views::BodyView {
+    pub fn view(&self) -> views::BodyView<'_> {
         views::BodyView::new(&self.0)
     }
 
@@ -145,7 +145,7 @@ impl Body {
 
     /// Get the RLP of this block body.
     #[inline]
-    pub fn rlp(&self) -> Rlp {
+    pub fn rlp(&self) -> Rlp<'_> {
         Rlp::new(&self.0)
     }
 
@@ -168,7 +168,7 @@ impl Body {
     }
 
     /// A view over each transaction in the block.
-    pub fn transaction_views(&self) -> Vec<views::TransactionView> {
+    pub fn transaction_views(&self) -> Vec<views::TransactionView<'_>> {
         self.view().transaction_views()
     }
 
@@ -190,13 +190,13 @@ impl Block {
 
     /// Get a borrowed view of the whole block.
     #[inline]
-    pub fn view(&self) -> views::BlockView {
+    pub fn view(&self) -> views::BlockView<'_> {
         views::BlockView::new(&self.0)
     }
 
     /// Get a borrowed view of the block header.
     #[inline]
-    pub fn header_view(&self) -> views::HeaderView {
+    pub fn header_view(&self) -> views::HeaderView<'_> {
         self.view().header_view()
     }
 
@@ -217,7 +217,7 @@ impl Block {
 
     /// Get the rlp of this block.
     #[inline]
-    pub fn rlp(&self) -> Rlp {
+    pub fn rlp(&self) -> Rlp<'_> {
         Rlp::new(&self.0)
     }
 
@@ -293,7 +293,7 @@ impl Block {
     }
 
     /// A view over each transaction in the block.
-    pub fn transaction_views(&self) -> Vec<views::TransactionView> {
+    pub fn transaction_views(&self) -> Vec<views::TransactionView<'_>> {
         self.view().transaction_views()
     }
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -44,7 +44,7 @@ pub enum ImportError {
 }
 
 impl fmt::Display for ImportError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match self {
             ImportError::AlreadyInChain => "block already in chain",
             ImportError::AlreadyQueued => "block already in the block queue",
@@ -125,7 +125,7 @@ pub enum SchemeError {
 }
 
 impl fmt::Display for SchemeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::SchemeError::*;
         let msg: String = match self {
             InvalidCommonParams => "Common params are not matched with gensis block".into(),
@@ -136,7 +136,7 @@ impl fmt::Display for SchemeError {
 }
 
 impl fmt::Display for BlockError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::BlockError::*;
 
         let msg: String = match self {
@@ -194,7 +194,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Client(err) => err.fmt(f),
             Error::Util(err) => err.fmt(f),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,31 +31,31 @@ extern crate codechain_stratum as cstratum;
 extern crate codechain_timer as ctimer;
 extern crate codechain_types as ctypes;
 extern crate codechain_vm as cvm;
-extern crate crossbeam_channel;
-extern crate cuckoo;
-extern crate kvdb;
-extern crate kvdb_memorydb;
-extern crate kvdb_rocksdb;
-extern crate linked_hash_map;
-extern crate lru_cache;
-extern crate num_rational;
-extern crate primitives;
-extern crate rand;
+
+
+
+
+
+
+
+
+
+
 #[cfg(test)]
 extern crate rand_xorshift;
-extern crate rlp;
-extern crate rlp_compress;
+
+
 #[macro_use]
 extern crate rlp_derive;
-extern crate parking_lot;
-extern crate snap;
-extern crate table;
-extern crate util_error;
+
+
+
+
 
 #[macro_use]
 extern crate log;
-extern crate core;
-extern crate hyper;
+
+
 
 mod account_provider;
 pub mod block;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,31 +31,12 @@ extern crate codechain_stratum as cstratum;
 extern crate codechain_timer as ctimer;
 extern crate codechain_types as ctypes;
 extern crate codechain_vm as cvm;
-
-
-
-
-
-
-
-
-
-
 #[cfg(test)]
 extern crate rand_xorshift;
-
-
 #[macro_use]
 extern crate rlp_derive;
-
-
-
-
-
 #[macro_use]
 extern crate log;
-
-
 
 mod account_provider;
 pub mod block;

--- a/core/src/miner/mem_pool_types.rs
+++ b/core/src/miner/mem_pool_types.rs
@@ -55,7 +55,7 @@ impl Encodable for TxOrigin {
 }
 
 impl Decodable for TxOrigin {
-    fn decode(d: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
         match d.as_val().expect("rlp decode Error") {
             LOCAL => Ok(TxOrigin::Local),
             EXTERNAL => Ok(TxOrigin::External),

--- a/core/src/miner/work_notify.rs
+++ b/core/src/miner/work_notify.rs
@@ -14,10 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-extern crate hyper;
-
 use std::io::Write;
 
+use hyper;
 use parking_lot::Mutex;
 use primitives::{H256, U256};
 
@@ -90,13 +89,13 @@ struct PostHandler {
 }
 
 impl hyper::client::Handler<HttpStream> for PostHandler {
-    fn on_request(&mut self, request: &mut Request) -> Next {
+    fn on_request(&mut self, request: &mut Request<'_>) -> Next {
         request.set_method(Method::Post);
         request.headers_mut().set(ContentType::json());
         Next::write()
     }
 
-    fn on_request_writable(&mut self, encoder: &mut hyper::Encoder<HttpStream>) -> Next {
+    fn on_request_writable(&mut self, encoder: &mut hyper::Encoder<'_, HttpStream>) -> Next {
         if let Err(e) = encoder.write_all(self.body.as_bytes()) {
             ctrace!(MINER, "Error posting work data: {}", e);
         }
@@ -108,7 +107,7 @@ impl hyper::client::Handler<HttpStream> for PostHandler {
         Next::end()
     }
 
-    fn on_response_readable(&mut self, _decoder: &mut hyper::Decoder<HttpStream>) -> Next {
+    fn on_response_readable(&mut self, _decoder: &mut hyper::Decoder<'_, HttpStream>) -> Next {
         Next::end()
     }
 

--- a/core/src/scheme/pod_account.rs
+++ b/core/src/scheme/pod_account.rs
@@ -57,7 +57,7 @@ impl From<cjson::scheme::Account> for PodAccount {
 }
 
 impl fmt::Display for PodAccount {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(bal={}; seq={})", self.balance, self.seq,)
     }
 }

--- a/core/src/scheme/pod_shard_metadata.rs
+++ b/core/src/scheme/pod_shard_metadata.rs
@@ -37,7 +37,7 @@ impl From<cjson::scheme::Shard> for PodShardMetadata {
 }
 
 impl fmt::Display for PodShardMetadata {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(#seq={}; owners={:#?}; users={:#?})", self.seq, self.owners, self.users)
     }
 }

--- a/core/src/scheme/pod_state.rs
+++ b/core/src/scheme/pod_state.rs
@@ -49,7 +49,7 @@ impl From<cjson::scheme::Accounts> for PodAccounts {
 }
 
 impl fmt::Display for PodAccounts {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (add, acc) in &self.0 {
             writeln!(f, "{} => {}", add, acc)?;
         }
@@ -78,7 +78,7 @@ impl From<cjson::scheme::Shards> for PodShards {
 }
 
 impl fmt::Display for PodShards {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (shard_id, shard) in &self.0 {
             writeln!(f, "{}: {}", shard_id, shard)?;
         }

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -51,7 +51,7 @@ impl From<UnverifiedTransaction> for Transaction {
 }
 
 impl rlp::Decodable for UnverifiedTransaction {
-    fn decode(d: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = d.item_count()?;
         if item_count != 5 {
             return Err(DecoderError::RlpIncorrectListLen {
@@ -168,7 +168,7 @@ impl rlp::Encodable for SignedTransaction {
 }
 
 impl rlp::Decodable for SignedTransaction {
-    fn decode(d: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
         let unverified_transaction: UnverifiedTransaction = UnverifiedTransaction::decode(d)?;
         match unverified_transaction.recover_public() {
             Ok(key) => Ok(SignedTransaction {

--- a/core/src/verification/canon_verifier.rs
+++ b/core/src/verification/canon_verifier.rs
@@ -32,7 +32,7 @@ impl<C: BlockChainTrait> Verifier<C> for CanonVerifier {
         header: &Header,
         parent: &Header,
         engine: &dyn CodeChainEngine,
-        do_full: Option<verification::FullFamilyParams<C>>,
+        do_full: Option<verification::FullFamilyParams<'_, C>>,
         common_params: &CommonParams,
     ) -> Result<(), Error> {
         verification::verify_block_family(block, header, parent, engine, do_full, common_params)

--- a/core/src/verification/noop_verifier.rs
+++ b/core/src/verification/noop_verifier.rs
@@ -31,7 +31,7 @@ impl<C: BlockChainTrait> Verifier<C> for NoopVerifier {
         _: &Header,
         _t: &Header,
         _: &dyn CodeChainEngine,
-        _: Option<verification::FullFamilyParams<C>>,
+        _: Option<verification::FullFamilyParams<'_, C>>,
         _common_params: &CommonParams,
     ) -> Result<(), Error> {
         Ok(())

--- a/core/src/verification/verification.rs
+++ b/core/src/verification/verification.rs
@@ -180,7 +180,7 @@ pub fn verify_block_seal(
 }
 
 /// Parameters for full verification of block family
-pub struct FullFamilyParams<'a, C: BlockChainTrait + 'a> {
+pub struct FullFamilyParams<'a, C: BlockChainTrait> {
     /// Serialized block bytes
     pub block_bytes: &'a [u8],
 
@@ -200,7 +200,7 @@ pub fn verify_block_family<C: BlockChainTrait>(
     header: &Header,
     parent: &Header,
     engine: &dyn CodeChainEngine,
-    do_full: Option<FullFamilyParams<C>>,
+    do_full: Option<FullFamilyParams<'_, C>>,
     common_params: &CommonParams,
 ) -> Result<(), Error> {
     verify_block_with_params(header, block, engine, common_params)?;

--- a/core/src/verification/verifier.rs
+++ b/core/src/verification/verifier.rs
@@ -32,7 +32,7 @@ where
         header: &Header,
         parent: &Header,
         engine: &dyn CodeChainEngine,
-        do_full: Option<verification::FullFamilyParams<C>>,
+        do_full: Option<verification::FullFamilyParams<'_, C>>,
         common_params: &CommonParams,
     ) -> Result<(), Error>;
 

--- a/core/src/views/block.rs
+++ b/core/src/views/block.rs
@@ -57,7 +57,7 @@ impl<'a> BlockView<'a> {
     }
 
     /// Return header rlp.
-    pub fn header_rlp(&self) -> Rlp {
+    pub fn header_rlp(&self) -> Rlp<'_> {
         self.rlp.at(0).unwrap()
     }
 

--- a/core/src/views/header.rs
+++ b/core/src/views/header.rs
@@ -27,7 +27,7 @@ pub struct HeaderView<'a> {
 
 impl<'a> HeaderView<'a> {
     /// Creates new view onto header from raw bytes.
-    pub fn new(bytes: &[u8]) -> HeaderView {
+    pub fn new(bytes: &[u8]) -> HeaderView<'_> {
         HeaderView {
             rlp: Rlp::new(bytes),
         }

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -18,15 +18,7 @@
 
 #[macro_use]
 extern crate log;
-
-
-
-
-
-
-
 extern crate codechain_crypto as ccrypto;
-
 #[macro_use]
 extern crate codechain_logger as clogger;
 extern crate codechain_network as cnetwork;

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -18,15 +18,15 @@
 
 #[macro_use]
 extern crate log;
-extern crate never_type;
-extern crate parking_lot;
-extern crate primitives;
-extern crate rand;
-extern crate rlp;
-extern crate time;
+
+
+
+
+
+
 
 extern crate codechain_crypto as ccrypto;
-extern crate codechain_key as ckey;
+
 #[macro_use]
 extern crate codechain_logger as clogger;
 extern crate codechain_network as cnetwork;

--- a/discovery/src/message.rs
+++ b/discovery/src/message.rs
@@ -37,7 +37,7 @@ impl Encodable for Message {
 }
 
 impl Decodable for Message {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         if rlp.is_int() {
             Ok(Message::Request(rlp.as_val()?))
         } else {

--- a/foundry/config/chain_type.rs
+++ b/foundry/config/chain_type.rs
@@ -73,7 +73,7 @@ impl<'a> Deserialize<'a> for ChainType {
         impl<'a> Visitor<'a> for ChainTypeVisitor {
             type Value = ChainType;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(formatter, "a valid chain type string")
             }
 
@@ -95,7 +95,7 @@ impl<'a> Deserialize<'a> for ChainType {
 }
 
 impl fmt::Display for ChainType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             ChainType::Mainnet => "mainnet",
             ChainType::Solo => "solo",

--- a/foundry/config/mod.rs
+++ b/foundry/config/mod.rs
@@ -341,7 +341,7 @@ impl Ipc {
         }
     }
 
-    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches) -> Result<(), String> {
+    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches<'_>) -> Result<(), String> {
         if matches.is_present("no-ipc") {
             self.disable = Some(true);
         }
@@ -377,7 +377,7 @@ impl Operating {
         }
     }
 
-    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches) -> Result<(), String> {
+    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches<'_>) -> Result<(), String> {
         if matches.is_present("quiet") {
             self.quiet = Some(true);
         }
@@ -486,7 +486,7 @@ impl Mining {
         }
     }
 
-    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches) -> Result<(), String> {
+    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches<'_>) -> Result<(), String> {
         if let Some(author) = matches.value_of("author") {
             self.author = Some(author.parse().map_err(|_| "Invalid address format")?);
         }
@@ -598,7 +598,7 @@ impl Network {
         }
     }
 
-    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches) -> Result<(), String> {
+    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches<'_>) -> Result<(), String> {
         if matches.is_present("no-network") {
             self.disable = Some(true);
         }
@@ -674,7 +674,7 @@ impl Rpc {
         }
     }
 
-    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches) -> Result<(), String> {
+    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches<'_>) -> Result<(), String> {
         if matches.is_present("no-jsonrpc") {
             self.disable = Some(true);
         }
@@ -713,7 +713,7 @@ impl Ws {
         }
     }
 
-    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches) -> Result<(), String> {
+    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches<'_>) -> Result<(), String> {
         if matches.is_present("no-ws") {
             self.disable = Some(true);
         }
@@ -741,7 +741,7 @@ impl Snapshot {
         }
     }
 
-    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches) -> Result<(), String> {
+    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches<'_>) -> Result<(), String> {
         if matches.is_present("no-snapshot") {
             self.disable = Some(true);
         }
@@ -763,7 +763,7 @@ impl Stratum {
         }
     }
 
-    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches) -> Result<(), String> {
+    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches<'_>) -> Result<(), String> {
         if matches.is_present("no-stratum") {
             self.disable = Some(true);
         }
@@ -788,7 +788,7 @@ impl EmailAlarm {
         }
     }
 
-    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches) -> Result<(), String> {
+    pub fn overwrite_with(&mut self, matches: &clap::ArgMatches<'_>) -> Result<(), String> {
         if matches.is_present("no-email-alarm") {
             self.disable = Some(true);
         }
@@ -825,7 +825,7 @@ pub fn read_preset_config() -> &'static str {
     str::from_utf8(bytes).expect("The preset config file must be valid")
 }
 
-pub fn load_config(matches: &clap::ArgMatches) -> Result<Config, String> {
+pub fn load_config(matches: &clap::ArgMatches<'_>) -> Result<Config, String> {
     let mut config: Config = {
         let toml_string = read_preset_config().to_string();
         toml::from_str(toml_string.as_ref()).expect("The preset config file must be valid")

--- a/foundry/main.rs
+++ b/foundry/main.rs
@@ -16,43 +16,22 @@
 
 #[macro_use]
 extern crate clap;
-
-
 #[macro_use]
 extern crate log;
-
-
-
 #[macro_use]
 extern crate serde_derive;
-
-
-
 extern crate codechain_core as ccore;
 extern crate codechain_discovery as cdiscovery;
 extern crate codechain_key as ckey;
 extern crate codechain_keystore as ckeystore;
 #[macro_use]
 extern crate codechain_logger as clogger;
-
 extern crate codechain_network as cnetwork;
 extern crate codechain_rpc as crpc;
-
 extern crate codechain_sync as csync;
 extern crate codechain_timer as ctimer;
 
-
-
-
-
-
-
-
 use panic_hook;
-
-
-
-
 
 mod config;
 mod constants;

--- a/foundry/main.rs
+++ b/foundry/main.rs
@@ -16,43 +16,43 @@
 
 #[macro_use]
 extern crate clap;
-extern crate futures;
+
 
 #[macro_use]
 extern crate log;
-extern crate tokio_core;
 
-extern crate serde;
+
+
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 
-extern crate app_dirs;
+
+
 extern crate codechain_core as ccore;
 extern crate codechain_discovery as cdiscovery;
 extern crate codechain_key as ckey;
 extern crate codechain_keystore as ckeystore;
 #[macro_use]
 extern crate codechain_logger as clogger;
-extern crate cidr;
+
 extern crate codechain_network as cnetwork;
 extern crate codechain_rpc as crpc;
-extern crate codechain_state as cstate;
+
 extern crate codechain_sync as csync;
 extern crate codechain_timer as ctimer;
-extern crate codechain_types as ctypes;
-extern crate ctrlc;
-extern crate env_logger;
-extern crate fdlimit;
-extern crate finally_block;
-extern crate kvdb;
-extern crate kvdb_rocksdb;
-extern crate never_type;
-extern crate panic_hook;
-extern crate parking_lot;
-extern crate primitives;
-extern crate rpassword;
-extern crate toml;
+
+
+
+
+
+
+
+
+use panic_hook;
+
+
+
+
 
 mod config;
 mod constants;

--- a/foundry/run_node.rs
+++ b/foundry/run_node.rs
@@ -221,7 +221,7 @@ pub fn open_db(cfg: &config::Operating, client_config: &ClientConfig) -> Result<
     Ok(db)
 }
 
-pub fn run_node(matches: &ArgMatches) -> Result<(), String> {
+pub fn run_node(matches: &ArgMatches<'_>) -> Result<(), String> {
     // increase max number of open files
     raise_fd_limit();
 

--- a/foundry/subcommand/account_command.rs
+++ b/foundry/subcommand/account_command.rs
@@ -30,7 +30,7 @@ use primitives::remove_0x_prefix;
 use crate::config::ChainType;
 use crate::constants::DEFAULT_KEYS_PATH;
 
-pub fn run_account_command(matches: &ArgMatches) -> Result<(), String> {
+pub fn run_account_command(matches: &ArgMatches<'_>) -> Result<(), String> {
     if matches.subcommand.is_none() {
         println!("{}", matches.usage());
         return Ok(())
@@ -141,7 +141,7 @@ fn read_password_and_confirm() -> Option<Password> {
     }
 }
 
-fn get_global_argument(matches: &ArgMatches, arg_name: &str) -> Option<String> {
+fn get_global_argument(matches: &ArgMatches<'_>, arg_name: &str) -> Option<String> {
     match matches.value_of(arg_name) {
         Some(value) => Some(value.to_string()),
         None => match matches.subcommand() {

--- a/foundry/subcommand/convert_command.rs
+++ b/foundry/subcommand/convert_command.rs
@@ -25,7 +25,7 @@ use clap::ArgMatches;
 use crate::config::ChainType;
 use primitives::remove_0x_prefix;
 
-pub fn run_convert_command(matches: &ArgMatches) -> Result<(), String> {
+pub fn run_convert_command(matches: &ArgMatches<'_>) -> Result<(), String> {
     let from = matches.value_of("from").expect("Argument 'from' is required");
     let to = matches.value_of("to").expect("Argument 'to' is required");
 
@@ -130,7 +130,7 @@ fn private_to_public(private: Private) -> Result<Public, String> {
     Ok(*keypair.public())
 }
 
-fn get_network_id(matches: &ArgMatches) -> Result<NetworkId, String> {
+fn get_network_id(matches: &ArgMatches<'_>) -> Result<NetworkId, String> {
     let chain = matches.value_of("chain").unwrap_or_else(|| "solo");
     let chain_type: ChainType = chain.parse().unwrap();
     // XXX: What should we do if the network id has been changed

--- a/foundry/subcommand/mod.rs
+++ b/foundry/subcommand/mod.rs
@@ -22,7 +22,7 @@ use clap::ArgMatches;
 use self::account_command::run_account_command;
 use self::convert_command::run_convert_command;
 
-pub fn run_subcommand(matches: &ArgMatches) -> Result<(), String> {
+pub fn run_subcommand(matches: &ArgMatches<'_>) -> Result<(), String> {
     let subcommand = matches.subcommand.as_ref().unwrap();
     match subcommand.name.as_str() {
         "account" => run_account_command(&subcommand.matches),

--- a/json/src/bytes.rs
+++ b/json/src/bytes.rs
@@ -107,7 +107,7 @@ struct BytesVisitor;
 impl<'a> Visitor<'a> for BytesVisitor {
     type Value = Bytes;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "a hex encoded string of bytes")
     }
 

--- a/json/src/hash.rs
+++ b/json/src/hash.rs
@@ -52,7 +52,7 @@ macro_rules! impl_hash {
                 impl<'b> Visitor<'b> for HashVisitor {
                     type Value = $name;
 
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                         write!(formatter, "a 0x-prefixed hex-encoded hash")
                     }
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 extern crate codechain_key as ckey;
-extern crate primitives;
-extern crate rustc_hex;
-extern crate serde;
-extern crate serde_json;
+
+
+
+
 #[macro_use]
 extern crate serde_derive;
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -15,10 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 extern crate codechain_key as ckey;
-
-
-
-
 #[macro_use]
 extern crate serde_derive;
 

--- a/json/src/uint.rs
+++ b/json/src/uint.rs
@@ -120,7 +120,7 @@ struct UintVisitor;
 impl<'a> Visitor<'a> for UintVisitor {
     type Value = Uint;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "a hex encoded or decimal uint")
     }
 

--- a/keystore/src/error.rs
+++ b/keystore/src/error.rs
@@ -48,7 +48,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let s = match *self {
             Error::Io(ref err) => err.to_string(),
             Error::InvalidPassword => "Invalid password".into(),

--- a/keystore/src/json/cipher.rs
+++ b/keystore/src/json/cipher.rs
@@ -49,7 +49,7 @@ struct CipherSerVisitor;
 impl<'a> Visitor<'a> for CipherSerVisitor {
     type Value = CipherSer;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "a valid cipher identifier")
     }
 

--- a/keystore/src/json/crypto.rs
+++ b/keystore/src/json/crypto.rs
@@ -65,7 +65,7 @@ struct CryptoFieldVisitor;
 impl<'a> Visitor<'a> for CryptoFieldVisitor {
     type Value = CryptoField;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "a valid crypto struct description")
     }
 
@@ -98,7 +98,7 @@ struct CryptoVisitor;
 impl<'a> Visitor<'a> for CryptoVisitor {
     type Value = Crypto;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "a valid crypto object")
     }
 

--- a/keystore/src/json/error.rs
+++ b/keystore/src/json/error.rs
@@ -29,7 +29,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             Error::InvalidUuid => write!(f, "Invalid Uuid"),
             Error::UnsupportedVersion => write!(f, "Unsupported version"),

--- a/keystore/src/json/hash.rs
+++ b/keystore/src/json/hash.rs
@@ -27,7 +27,7 @@ macro_rules! impl_hash {
         pub struct $name([u8; $size]);
 
         impl fmt::Debug for $name {
-            fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
                 let self_ref: &[u8] = &self.0;
                 write!(f, "{:?}", self_ref)
             }
@@ -66,7 +66,7 @@ macro_rules! impl_hash {
                 impl<'b> Visitor<'b> for HashVisitor {
                     type Value = $name;
 
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                         write!(formatter, "a hex-encoded {}", stringify!($name))
                     }
 

--- a/keystore/src/json/id.rs
+++ b/keystore/src/json/id.rs
@@ -39,7 +39,7 @@ impl From<Uuid> for [u8; 16] {
 }
 
 impl fmt::Display for Uuid {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let d1 = &self.0[0..4];
         let d2 = &self.0[4..6];
         let d3 = &self.0[6..8];
@@ -109,7 +109,7 @@ struct UuidVisitor;
 impl<'a> Visitor<'a> for UuidVisitor {
     type Value = Uuid;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "a valid hex-encoded UUID")
     }
 

--- a/keystore/src/json/kdf.rs
+++ b/keystore/src/json/kdf.rs
@@ -51,7 +51,7 @@ struct KdfSerVisitor;
 impl<'a> Visitor<'a> for KdfSerVisitor {
     type Value = KdfSer;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "a kdf algorithm identifier")
     }
 
@@ -100,7 +100,7 @@ struct PrfVisitor;
 impl<'a> Visitor<'a> for PrfVisitor {
     type Value = Prf;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "a prf algorithm identifier")
     }
 

--- a/keystore/src/json/version.rs
+++ b/keystore/src/json/version.rs
@@ -49,7 +49,7 @@ struct VersionVisitor;
 impl<'a> Visitor<'a> for VersionVisitor {
     type Value = Version;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(formatter, "a valid key version identifier")
     }
 

--- a/keystore/src/lib.rs
+++ b/keystore/src/lib.rs
@@ -32,20 +32,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
-
-
-
-
-
-
-
-
-
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_json as cjson;
 extern crate codechain_key as ckey;
-
 
 #[macro_use]
 extern crate log;

--- a/keystore/src/lib.rs
+++ b/keystore/src/lib.rs
@@ -32,20 +32,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-extern crate libc;
-extern crate parking_lot;
-extern crate rand;
-extern crate rustc_hex;
-extern crate serde;
-extern crate serde_json;
-extern crate smallvec;
-extern crate tempdir;
-extern crate time;
+
+
+
+
+
+
+
+
+
 
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_json as cjson;
 extern crate codechain_key as ckey;
-extern crate codechain_types as ctypes;
+
 
 #[macro_use]
 extern crate log;

--- a/network/src/addr.rs
+++ b/network/src/addr.rs
@@ -167,7 +167,7 @@ impl PartialOrd for SocketAddr {
 }
 
 impl fmt::Display for SocketAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         self.addr.fmt(f)
     }
 }
@@ -190,7 +190,7 @@ impl Encodable for SocketAddr {
 }
 
 impl Decodable for SocketAddr {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         match rlp.item_count()? {
             5 => {
                 let ip0 = rlp.val_at(0)?;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -16,30 +16,22 @@
 
 #![allow(deprecated)]
 
-extern crate cidr;
+
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_io as cio;
 extern crate codechain_key as ckey;
 #[macro_use]
 extern crate codechain_logger as clogger;
 extern crate codechain_timer as ctimer;
-extern crate codechain_types as ctypes;
-extern crate core;
-extern crate crossbeam_channel;
-extern crate finally_block;
 #[macro_use]
 extern crate log;
-extern crate mio;
-extern crate parking_lot;
-extern crate primitives;
-extern crate rand;
-extern crate rlp;
+
+
 #[macro_use]
 extern crate rlp_derive;
-extern crate never_type;
-extern crate table as ctable;
-extern crate time;
-extern crate token_generator;
+
+use crossbeam_channel;
+
 
 mod addr;
 mod client;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -16,7 +16,6 @@
 
 #![allow(deprecated)]
 
-
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_io as cio;
 extern crate codechain_key as ckey;
@@ -25,13 +24,10 @@ extern crate codechain_logger as clogger;
 extern crate codechain_timer as ctimer;
 #[macro_use]
 extern crate log;
-
-
 #[macro_use]
 extern crate rlp_derive;
 
 use crossbeam_channel;
-
 
 mod addr;
 mod client;

--- a/network/src/node_id.rs
+++ b/network/src/node_id.rs
@@ -33,7 +33,7 @@ impl NodeId {
 }
 
 impl fmt::Display for NodeId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let internal = &self.addr;
         let port = internal.port();
         match internal.ip() {

--- a/network/src/p2p/connection/message.rs
+++ b/network/src/p2p/connection/message.rs
@@ -75,7 +75,7 @@ impl Encodable for OutgoingMessage {
 }
 
 impl Decodable for OutgoingMessage {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         match rlp.val_at(0)? {
             SYNC1_ID => {
                 let item_count = rlp.item_count()?;
@@ -128,7 +128,7 @@ impl Encodable for IncomingMessage {
 }
 
 impl Decodable for IncomingMessage {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         match rlp.val_at(0)? {
             ACK_ID => {
                 let item_count = rlp.item_count()?;

--- a/network/src/p2p/connection/mod.rs
+++ b/network/src/p2p/connection/mod.rs
@@ -44,7 +44,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::SymmetricCipher(err) => write!(f, "{:?}", err),
             Error::Decoder(err) => err.fmt(f),

--- a/network/src/p2p/handler.rs
+++ b/network/src/p2p/handler.rs
@@ -1180,7 +1180,7 @@ enum Error {
 }
 
 impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Error::InvalidNode(_) => ::std::fmt::Debug::fmt(self, f),
             Error::SymmetricCipher(err) => ::std::fmt::Debug::fmt(&err, f),

--- a/network/src/p2p/message/extension.rs
+++ b/network/src/p2p/message/extension.rs
@@ -123,7 +123,7 @@ impl Encodable for Message {
 }
 
 impl Decodable for Message {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = rlp.item_count()?;
         if item_count != 3 {
             return Err(DecoderError::RlpInvalidLength {

--- a/network/src/p2p/message/message.rs
+++ b/network/src/p2p/message/message.rs
@@ -40,7 +40,7 @@ impl Encodable for Message {
 }
 
 impl Decodable for Message {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let protocol_id = rlp.val_at(0)?;
         match protocol_id {
             REQUEST_ID => Ok(Message::Negotiation(Decodable::decode(rlp)?)),

--- a/network/src/p2p/message/negotiation.rs
+++ b/network/src/p2p/message/negotiation.rs
@@ -70,7 +70,7 @@ impl Encodable for Message {
 }
 
 impl Decodable for Message {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = rlp.item_count()?;
         if item_count != 3 {
             return Err(DecoderError::RlpInvalidLength {

--- a/network/src/p2p/message/signed_message.rs
+++ b/network/src/p2p/message/signed_message.rs
@@ -49,7 +49,7 @@ impl Encodable for SignedMessage {
 }
 
 impl Decodable for SignedMessage {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         if rlp.item_count()? != 2 {
             return Err(DecoderError::Custom("Cannot decode a signed message"))
         }

--- a/network/src/p2p/stream.rs
+++ b/network/src/p2p/stream.rs
@@ -34,7 +34,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::IoError(err) => err.fmt(f),
             Error::DecoderError(err) => err.fmt(f),

--- a/network/src/stream.rs
+++ b/network/src/stream.rs
@@ -32,7 +32,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::IoError(err) => err.fmt(f),
             Error::DecoderError(err) => err.fmt(f),

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -25,33 +25,18 @@ extern crate codechain_network as cnetwork;
 extern crate codechain_state as cstate;
 extern crate codechain_sync as csync;
 extern crate codechain_types as ctypes;
-extern crate codechain_vm as cvm;
-pub extern crate jsonrpc_core;
-extern crate jsonrpc_http_server;
-extern crate jsonrpc_ipc_server;
-extern crate jsonrpc_ws_server;
-extern crate kvdb;
-extern crate kvdb_rocksdb as rocksdb;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-extern crate parking_lot;
-extern crate primitives;
-extern crate rand;
-extern crate rlp;
-extern crate rustc_hex;
-extern crate rustc_serialize;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate cidr;
-extern crate serde_json;
-extern crate time;
-extern crate tokio_core;
-
 #[macro_use]
 extern crate jsonrpc_derive;
+
+use cidr;
+pub use jsonrpc_core;
+use jsonrpc_http_server;
 
 pub mod rpc_server;
 pub mod v1;

--- a/rpc/src/v1/types/asset_output.rs
+++ b/rpc/src/v1/types/asset_output.rs
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-extern crate rustc_serialize;
 
 use std::convert::TryFrom;
 use std::iter::FromIterator;

--- a/state/src/cache/shard_cache.rs
+++ b/state/src/cache/shard_cache.rs
@@ -62,7 +62,7 @@ impl ShardCache {
         self.asset_scheme.get(a, db)
     }
 
-    pub fn asset_scheme_mut(&self, a: &AssetSchemeAddress, db: &dyn Trie) -> TrieResult<RefMut<AssetScheme>> {
+    pub fn asset_scheme_mut(&self, a: &AssetSchemeAddress, db: &dyn Trie) -> TrieResult<RefMut<'_, AssetScheme>> {
         self.asset_scheme.get_mut(a, db)
     }
 

--- a/state/src/cache/top_cache.rs
+++ b/state/src/cache/top_cache.rs
@@ -94,7 +94,7 @@ impl TopCache {
         self.account.get(a, db)
     }
 
-    pub fn account_mut(&self, a: &Address, db: &dyn Trie) -> TrieResult<RefMut<Account>> {
+    pub fn account_mut(&self, a: &Address, db: &dyn Trie) -> TrieResult<RefMut<'_, Account>> {
         self.account.get_mut(a, db)
     }
 
@@ -106,7 +106,7 @@ impl TopCache {
         self.regular_account.get(a, db)
     }
 
-    pub fn regular_account_mut(&self, a: &RegularAccountAddress, db: &dyn Trie) -> TrieResult<RefMut<RegularAccount>> {
+    pub fn regular_account_mut(&self, a: &RegularAccountAddress, db: &dyn Trie) -> TrieResult<RefMut<'_, RegularAccount>> {
         self.regular_account.get_mut(a, db)
     }
 
@@ -118,7 +118,7 @@ impl TopCache {
         self.metadata.get(a, db)
     }
 
-    pub fn metadata_mut(&self, a: &MetadataAddress, db: &dyn Trie) -> TrieResult<RefMut<Metadata>> {
+    pub fn metadata_mut(&self, a: &MetadataAddress, db: &dyn Trie) -> TrieResult<RefMut<'_, Metadata>> {
         self.metadata.get_mut(a, db)
     }
 
@@ -126,7 +126,7 @@ impl TopCache {
         self.shard.get(a, db)
     }
 
-    pub fn shard_mut(&self, a: &ShardAddress, db: &dyn Trie) -> TrieResult<RefMut<Shard>> {
+    pub fn shard_mut(&self, a: &ShardAddress, db: &dyn Trie) -> TrieResult<RefMut<'_, Shard>> {
         self.shard.get_mut(a, db)
     }
 
@@ -139,7 +139,7 @@ impl TopCache {
         self.text.get(a, db)
     }
 
-    pub fn text_mut(&self, a: &H256, db: &dyn Trie) -> TrieResult<RefMut<Text>> {
+    pub fn text_mut(&self, a: &H256, db: &dyn Trie) -> TrieResult<RefMut<'_, Text>> {
         self.text.get_mut(a, db)
     }
 
@@ -151,7 +151,7 @@ impl TopCache {
         self.action_data.get(a, db)
     }
 
-    pub fn action_data_mut(&self, a: &H256, db: &dyn Trie) -> TrieResult<RefMut<ActionData>> {
+    pub fn action_data_mut(&self, a: &H256, db: &dyn Trie) -> TrieResult<RefMut<'_, ActionData>> {
         self.action_data.get_mut(a, db)
     }
 

--- a/state/src/cache/top_cache.rs
+++ b/state/src/cache/top_cache.rs
@@ -106,7 +106,11 @@ impl TopCache {
         self.regular_account.get(a, db)
     }
 
-    pub fn regular_account_mut(&self, a: &RegularAccountAddress, db: &dyn Trie) -> TrieResult<RefMut<'_, RegularAccount>> {
+    pub fn regular_account_mut(
+        &self,
+        a: &RegularAccountAddress,
+        db: &dyn Trie,
+    ) -> TrieResult<RefMut<'_, RegularAccount>> {
         self.regular_account.get_mut(a, db)
     }
 

--- a/state/src/cache/write_back.rs
+++ b/state/src/cache/write_back.rs
@@ -210,7 +210,7 @@ where
 
     /// Pull item `a` in our cache from the trie DB.
     /// If it doesn't exist, make item equal the evaluation of `default`.
-    pub fn get_mut(&self, a: &Item::Address, db: &dyn Trie) -> cmerkle::Result<RefMut<Item>> {
+    pub fn get_mut(&self, a: &Item::Address, db: &dyn Trie) -> cmerkle::Result<RefMut<'_, Item>> {
         let contains_key = self.cache.borrow().contains_key(a);
         if !contains_key {
             let maybe_item = db.get(a.as_ref())?.map(|bytes| ::rlp::decode::<Item>(&bytes).unwrap());
@@ -268,7 +268,7 @@ impl<Item> fmt::Debug for WriteBack<Item>
 where
     Item: CacheableItem,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.cache.borrow().fmt(f)
     }
 }

--- a/state/src/error.rs
+++ b/state/src/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Trie(err) => err.fmt(f),
             Error::Runtime(err) => err.fmt(f),

--- a/state/src/impls/shard_level.rs
+++ b/state/src/impls/shard_level.rs
@@ -85,7 +85,7 @@ impl<'db> ShardLevelState<'db> {
         db: &RefCell<StateDB>,
         root: H256,
         cache: ShardCache,
-    ) -> cmerkle::Result<ReadOnlyShardLevelState> {
+    ) -> cmerkle::Result<ReadOnlyShardLevelState<'_>> {
         if !db.borrow().as_hashdb().contains(&root) {
             return Err(TrieError::InvalidStateRoot(root))
         }
@@ -667,7 +667,7 @@ impl<'db> ShardLevelState<'db> {
         })
     }
 
-    fn get_asset_scheme_mut(&self, shard_id: ShardId, asset_type: H160) -> cmerkle::Result<RefMut<AssetScheme>> {
+    fn get_asset_scheme_mut(&self, shard_id: ShardId, asset_type: H160) -> cmerkle::Result<RefMut<'_, AssetScheme>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
         self.cache.asset_scheme_mut(&AssetSchemeAddress::new(asset_type, shard_id), &trie)

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -631,7 +631,7 @@ impl TopLevelState {
         Ok(())
     }
 
-    fn get_account_mut(&self, a: &Address) -> TrieResult<RefMut<Account>> {
+    fn get_account_mut(&self, a: &Address) -> TrieResult<RefMut<'_, Account>> {
         debug_assert_eq!(Ok(false), self.regular_account_exists_and_not_null_by_address(a));
 
         let db = self.db.borrow();
@@ -639,21 +639,21 @@ impl TopLevelState {
         self.top_cache.account_mut(&a, &trie)
     }
 
-    fn get_regular_account_mut(&self, public: &Public) -> TrieResult<RefMut<RegularAccount>> {
+    fn get_regular_account_mut(&self, public: &Public) -> TrieResult<RefMut<'_, RegularAccount>> {
         let regular_account_address = RegularAccountAddress::new(public);
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
         self.top_cache.regular_account_mut(&regular_account_address, &trie)
     }
 
-    fn get_metadata_mut(&self) -> TrieResult<RefMut<Metadata>> {
+    fn get_metadata_mut(&self) -> TrieResult<RefMut<'_, Metadata>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
         let address = MetadataAddress::new();
         self.top_cache.metadata_mut(&address, &trie)
     }
 
-    fn get_shard_mut(&self, shard_id: ShardId) -> TrieResult<RefMut<Shard>> {
+    fn get_shard_mut(&self, shard_id: ShardId) -> TrieResult<RefMut<'_, Shard>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
         let shard_address = ShardAddress::new(shard_id);
@@ -666,13 +666,13 @@ impl TopLevelState {
         self.top_cache.text(key, &trie)
     }
 
-    fn get_text_mut(&self, key: &TxHash) -> TrieResult<RefMut<Text>> {
+    fn get_text_mut(&self, key: &TxHash) -> TrieResult<RefMut<'_, Text>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
         self.top_cache.text_mut(key, &trie)
     }
 
-    fn get_action_data_mut(&self, key: &H256) -> TrieResult<RefMut<ActionData>> {
+    fn get_action_data_mut(&self, key: &H256) -> TrieResult<RefMut<'_, ActionData>> {
         let db = self.db.borrow();
         let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
         self.top_cache.action_data_mut(key, &trie)

--- a/state/src/item/account.rs
+++ b/state/src/item/account.rs
@@ -138,7 +138,7 @@ impl Encodable for Account {
 }
 
 impl Decodable for Account {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = rlp.item_count()?;
         if item_count != 4 {
             return Err(DecoderError::RlpInvalidLength {
@@ -161,7 +161,7 @@ impl Decodable for Account {
 }
 
 impl fmt::Debug for Account {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Account").field("balance", &self.balance).field("seq", &self.seq).finish()
     }
 }

--- a/state/src/item/action_data.rs
+++ b/state/src/item/action_data.rs
@@ -52,7 +52,7 @@ impl Encodable for ActionData {
 }
 
 impl Decodable for ActionData {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         Bytes::decode(rlp).map(ActionData)
     }
 }

--- a/state/src/item/address.rs
+++ b/state/src/item/address.rs
@@ -83,13 +83,13 @@ macro_rules! impl_address {
         }
 
         impl ::std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 self.0.fmt(f)
             }
         }
 
         impl ::std::fmt::Display for $name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 self.0.fmt(f)
             }
         }

--- a/state/src/item/asset.rs
+++ b/state/src/item/asset.rs
@@ -116,7 +116,7 @@ impl Encodable for OwnedAsset {
 }
 
 impl Decodable for OwnedAsset {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = rlp.item_count()?;
         if rlp.item_count()? != 6 {
             return Err(DecoderError::RlpInvalidLength {

--- a/state/src/item/asset_scheme.rs
+++ b/state/src/item/asset_scheme.rs
@@ -178,7 +178,7 @@ impl Encodable for AssetScheme {
 }
 
 impl Decodable for AssetScheme {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let seq = match rlp.item_count()? {
             7 => 0,
             8 => rlp.val_at(7)?,

--- a/state/src/item/metadata.rs
+++ b/state/src/item/metadata.rs
@@ -163,7 +163,7 @@ impl Encodable for Metadata {
 }
 
 impl Decodable for Metadata {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let (term, seq, params) = match rlp.item_count()? {
             4 => (TermMetadata::default(), 0, None),
             6 => (

--- a/state/src/item/regular_account.rs
+++ b/state/src/item/regular_account.rs
@@ -64,7 +64,7 @@ impl Encodable for RegularAccount {
 }
 
 impl Decodable for RegularAccount {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = rlp.item_count()?;
         if item_count != 2 {
             return Err(DecoderError::RlpInvalidLength {

--- a/state/src/item/shard.rs
+++ b/state/src/item/shard.rs
@@ -88,7 +88,7 @@ impl Encodable for Shard {
 }
 
 impl Decodable for Shard {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = rlp.item_count()?;
         if item_count != 4 {
             return Err(DecoderError::RlpInvalidLength {

--- a/state/src/item/text.rs
+++ b/state/src/item/text.rs
@@ -75,7 +75,7 @@ impl Encodable for Text {
 }
 
 impl Decodable for Text {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = rlp.item_count()?;
         if item_count != 3 {
             return Err(DecoderError::RlpInvalidLength {

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -22,17 +22,10 @@ extern crate codechain_logger as clogger;
 extern crate codechain_key as ckey;
 extern crate codechain_types as ctypes;
 extern crate codechain_vm as cvm;
-
-
-
 #[macro_use]
 extern crate log;
-
-
-
 #[cfg(test)]
 extern crate rustc_hex;
-
 #[macro_use]
 extern crate rlp_derive;
 

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -22,17 +22,17 @@ extern crate codechain_logger as clogger;
 extern crate codechain_key as ckey;
 extern crate codechain_types as ctypes;
 extern crate codechain_vm as cvm;
-extern crate kvdb;
-extern crate kvdb_memorydb;
-extern crate lru_cache;
+
+
+
 #[macro_use]
 extern crate log;
-extern crate parking_lot;
-extern crate primitives;
-extern crate rlp;
+
+
+
 #[cfg(test)]
 extern crate rustc_hex;
-extern crate util_error;
+
 #[macro_use]
 extern crate rlp_derive;
 

--- a/stratum/src/lib.rs
+++ b/stratum/src/lib.rs
@@ -20,19 +20,14 @@ extern crate codechain_crypto as ccrypto;
 #[macro_use]
 extern crate codechain_logger as clogger;
 extern crate codechain_json as cjson;
-extern crate jsonrpc_core;
-extern crate jsonrpc_derive;
-extern crate jsonrpc_tcp_server;
-extern crate parking_lot;
-extern crate primitives;
-
 #[macro_use]
 extern crate log;
-
 #[cfg(test)]
 extern crate tokio_core;
 #[cfg(test)]
 extern crate tokio_io;
+
+use jsonrpc_core;
 
 mod traits;
 

--- a/sync/src/block/message/mod.rs
+++ b/sync/src/block/message/mod.rs
@@ -78,7 +78,7 @@ impl Encodable for Message {
 }
 
 impl Decodable for Message {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let id = rlp.val_at(0)?;
         if id == MESSAGE_ID_STATUS {
             let item_count = rlp.item_count()?;

--- a/sync/src/block/message/request.rs
+++ b/sync/src/block/message/request.rs
@@ -76,7 +76,7 @@ impl RequestMessage {
         }
     }
 
-    pub fn decode(id: u8, rlp: &Rlp) -> Result<Self, DecoderError> {
+    pub fn decode(id: u8, rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let message = match id {
             super::MESSAGE_ID_GET_HEADERS => {
                 let item_count = rlp.item_count()?;

--- a/sync/src/block/message/response.rs
+++ b/sync/src/block/message/response.rs
@@ -79,7 +79,7 @@ impl ResponseMessage {
         }
     }
 
-    pub fn decode(id: u8, rlp: &Rlp) -> Result<Self, DecoderError> {
+    pub fn decode(id: u8, rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let message = match id {
             super::MESSAGE_ID_HEADERS => ResponseMessage::Headers(rlp.as_list()?),
             super::MESSAGE_ID_BODIES => {

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-extern crate parking_lot;
 
 extern crate codechain_core as ccore;
 extern crate codechain_db as cdb;
@@ -26,23 +25,20 @@ extern crate codechain_state as cstate;
 extern crate codechain_timer as ctimer;
 extern crate codechain_types as ctypes;
 
-extern crate kvdb;
+
 #[cfg(test)]
 extern crate kvdb_memorydb;
 #[macro_use]
 extern crate log;
-extern crate never_type;
-extern crate primitives;
-extern crate rand;
-extern crate rlp;
-extern crate snap;
+
+
 #[cfg(test)]
 extern crate tempfile;
-extern crate time;
-extern crate token_generator;
+
+
 #[cfg(test)]
 extern crate trie_standardmap;
-extern crate util_error;
+
 
 mod block;
 mod snapshot;

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
 extern crate codechain_core as ccore;
 extern crate codechain_db as cdb;
 extern crate codechain_merkle as cmerkle;
@@ -24,21 +23,14 @@ extern crate codechain_network as cnetwork;
 extern crate codechain_state as cstate;
 extern crate codechain_timer as ctimer;
 extern crate codechain_types as ctypes;
-
-
 #[cfg(test)]
 extern crate kvdb_memorydb;
 #[macro_use]
 extern crate log;
-
-
 #[cfg(test)]
 extern crate tempfile;
-
-
 #[cfg(test)]
 extern crate trie_standardmap;
-
 
 mod block;
 mod snapshot;

--- a/sync/src/snapshot/error.rs
+++ b/sync/src/snapshot/error.rs
@@ -41,7 +41,7 @@ impl From<UtilError> for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
         match self {
             Error::NodeNotFound(key) => write!(f, "State node not found: {:x}", key),
             Error::SyncError(reason) => write!(f, "Sync error: {}", reason),

--- a/sync/src/transaction/message.rs
+++ b/sync/src/transaction/message.rs
@@ -45,7 +45,7 @@ impl Encodable for Message {
 }
 
 impl Decodable for Message {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let compressed: Vec<u8> = rlp.as_val()?;
         let uncompressed = {
             // TODO: Cache the Decoder object

--- a/types/src/block_hash.rs
+++ b/types/src/block_hash.rs
@@ -52,7 +52,7 @@ impl Encodable for BlockHash {
 }
 
 impl Decodable for BlockHash {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         Ok(H256::decode(rlp)?.into())
     }
 }

--- a/types/src/common_params.rs
+++ b/types/src/common_params.rs
@@ -386,7 +386,7 @@ impl Encodable for CommonParams {
 }
 
 impl Decodable for CommonParams {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let size = rlp.item_count()?;
         if !VALID_SIZE.contains(&size) {
             return Err(DecoderError::RlpIncorrectListLen {

--- a/types/src/errors/history_error.rs
+++ b/types/src/errors/history_error.rs
@@ -88,7 +88,7 @@ impl Encodable for Error {
 }
 
 impl Decodable for Error {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let tag = rlp.val_at::<u8>(0)?;
         let error = match tag {
             ERROR_ID_LIMIT_REACHED => Error::LimitReached,
@@ -111,7 +111,7 @@ impl Decodable for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
         match self {
             Error::LimitReached => write!(f, "Transaction limit reached"),
             Error::Old => write!(f, "No longer valid"),

--- a/types/src/errors/mod.rs
+++ b/types/src/errors/mod.rs
@@ -33,7 +33,7 @@ trait TaggedRlp {
         s.begin_list(Self::length_of(tag).unwrap()).append(&tag)
     }
 
-    fn check_size(rlp: &Rlp, tag: Self::Tag) -> Result<(), DecoderError> {
+    fn check_size(rlp: &Rlp<'_>, tag: Self::Tag) -> Result<(), DecoderError> {
         let item_count = rlp.item_count()?;
         let expected = Self::length_of(tag)?;
         if item_count != expected {

--- a/types/src/errors/runtime_error.rs
+++ b/types/src/errors/runtime_error.rs
@@ -292,7 +292,7 @@ impl Encodable for Error {
 }
 
 impl Decodable for Error {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let tag = rlp.val_at::<u8>(0)?;
         let error = match tag {
             ERROR_ID_ASSET_NOT_FOUND => Error::AssetNotFound {
@@ -374,7 +374,7 @@ impl Decodable for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
         match self {
             Error::AssetNotFound { shard_id, tracker, index } => write!(f, "Asset not found: {}:{}:{}", shard_id, tracker, index),
             Error::AssetSchemeDuplicated { tracker, shard_id} => write!(f, "Asset scheme already exists: {}:{}", shard_id, tracker),
@@ -473,7 +473,7 @@ impl Encodable for UnlockFailureReason {
 }
 
 impl Decodable for UnlockFailureReason {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         Ok(match Decodable::decode(rlp)? {
             FAILURE_REASON_ID_SCRIPT_SHOULD_BE_BURNT => UnlockFailureReason::ScriptShouldBeBurnt,
             FAILURE_REASON_ID_SCRIPT_SHOULD_NOT_BE_BURNT => UnlockFailureReason::ScriptShouldNotBeBurnt,
@@ -484,7 +484,7 @@ impl Decodable for UnlockFailureReason {
 }
 
 impl Display for UnlockFailureReason {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
         match self {
             UnlockFailureReason::ScriptShouldBeBurnt => write!(f, "Script should be burnt"),
             UnlockFailureReason::ScriptShouldNotBeBurnt => write!(f, "Script should not be burnt"),

--- a/types/src/errors/syntax_error.rs
+++ b/types/src/errors/syntax_error.rs
@@ -149,7 +149,7 @@ impl Encodable for Error {
 }
 
 impl Decodable for Error {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let tag = rlp.val_at::<u8>(0)?;
         let error = match tag {
             ERORR_ID_DUPLICATED_PREVIOUS_OUTPUT => Error::DuplicatedPreviousOutput {
@@ -182,7 +182,7 @@ impl Decodable for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> FormatResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FormatResult {
         match self {
             Error::DuplicatedPreviousOutput {
                 tracker,

--- a/types/src/header.rs
+++ b/types/src/header.rs
@@ -279,7 +279,7 @@ impl Header {
 }
 
 impl Decodable for Header {
-    fn decode(r: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(r: &Rlp<'_>) -> Result<Self, DecoderError> {
         let mut blockheader = Header {
             parent_hash: r.val_at(0)?,
             author: r.val_at(1)?,

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -17,11 +17,8 @@
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_json as cjson;
 extern crate codechain_key as ckey;
-
-
 #[macro_use]
 extern crate rlp_derive;
-
 #[macro_use]
 extern crate serde_derive;
 #[cfg(test)]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -17,11 +17,11 @@
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_json as cjson;
 extern crate codechain_key as ckey;
-extern crate primitives;
-extern crate rlp;
+
+
 #[macro_use]
 extern crate rlp_derive;
-extern crate serde;
+
 #[macro_use]
 extern crate serde_derive;
 #[cfg(test)]

--- a/types/src/tracker.rs
+++ b/types/src/tracker.rs
@@ -52,7 +52,7 @@ impl Encodable for Tracker {
 }
 
 impl Decodable for Tracker {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         Ok(H256::decode(rlp)?.into())
     }
 }

--- a/types/src/transaction/action.rs
+++ b/types/src/transaction/action.rs
@@ -639,7 +639,7 @@ impl Encodable for Action {
 }
 
 impl Decodable for Action {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         match rlp.val_at(0)? {
             MINT_ASSET => {
                 let item_count = rlp.item_count()?;

--- a/types/src/transaction/shard.rs
+++ b/types/src/transaction/shard.rs
@@ -339,7 +339,7 @@ const ASSET_SCHEME_CHANGE_ID: TransactionId = 0x15;
 const ASSET_INCREASE_SUPPLY_ID: TransactionId = 0x18;
 
 impl Decodable for ShardTransaction {
-    fn decode(d: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
         match d.val_at(0)? {
             ASSET_MINT_ID => {
                 let item_count = d.item_count()?;

--- a/types/src/transaction/timelock.rs
+++ b/types/src/transaction/timelock.rs
@@ -44,7 +44,7 @@ impl Encodable for Timelock {
 }
 
 impl Decodable for Timelock {
-    fn decode(d: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = d.item_count()?;
         if item_count != 2 {
             return Err(DecoderError::RlpIncorrectListLen {

--- a/types/src/tx_hash.rs
+++ b/types/src/tx_hash.rs
@@ -52,7 +52,7 @@ impl Encodable for TxHash {
 }
 
 impl Decodable for TxHash {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         Ok(H256::decode(rlp)?.into())
     }
 }

--- a/types/src/util/unexpected.rs
+++ b/types/src/util/unexpected.rs
@@ -30,7 +30,7 @@ pub struct Mismatch<T> {
 }
 
 impl<T: fmt::Display> fmt::Display for Mismatch<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("Expected {}, found {}", self.expected, self.found))
     }
 }
@@ -48,7 +48,7 @@ impl<T> Decodable for Mismatch<T>
 where
     T: Decodable,
 {
-    fn decode(rlp: &Rlp) -> Result<Mismatch<T>, DecoderError> {
+    fn decode(rlp: &Rlp<'_>) -> Result<Mismatch<T>, DecoderError> {
         Ok(Mismatch {
             expected: rlp.val_at(0)?,
             found: rlp.val_at(1)?,
@@ -68,7 +68,7 @@ pub struct OutOfBounds<T> {
 }
 
 impl<T: fmt::Display> fmt::Display for OutOfBounds<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match (self.min.as_ref(), self.max.as_ref()) {
             (Some(min), Some(max)) => format!("Min={}, Max={}", min, max),
             (Some(min), _) => format!("Min={}", min),

--- a/util/db/src/hashdb.rs
+++ b/util/db/src/hashdb.rs
@@ -16,8 +16,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Database of byte-slices keyed to their blake2b hash.
-extern crate primitives;
-
 use primitives::H256;
 use std::collections::HashMap;
 

--- a/util/db/src/journaldb/algorithm.rs
+++ b/util/db/src/journaldb/algorithm.rs
@@ -56,7 +56,7 @@ impl Algorithm {
 }
 
 impl fmt::Display for Algorithm {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Algorithm::Archive => write!(f, "archive"),
         }

--- a/util/db/src/lib.rs
+++ b/util/db/src/lib.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate kvdb;
-extern crate primitives;
-extern crate rlp;
+
+
+
 extern crate util_error as error;
 
 #[cfg(test)]

--- a/util/db/src/lib.rs
+++ b/util/db/src/lib.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-
-
 extern crate util_error as error;
 
 #[cfg(test)]

--- a/util/db/src/memorydb.rs
+++ b/util/db/src/memorydb.rs
@@ -16,10 +16,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Reference-counted memory-based `HashDB` implementation.
-extern crate codechain_crypto;
-extern crate plain_hasher;
-extern crate primitives;
-extern crate rlp;
+use codechain_crypto;
+use plain_hasher;
+use primitives;
+use rlp;
 
 use super::{DBValue, HashDB};
 use codechain_crypto::{blake256, BLAKE_NULL_RLP};

--- a/util/error/src/lib.rs
+++ b/util/error/src/lib.rs
@@ -22,9 +22,9 @@
 #[macro_use]
 extern crate error_chain;
 
-extern crate primitives;
-extern crate rlp;
-extern crate rustc_hex;
+
+
+
 
 use primitives::H256;
 use std::fmt;
@@ -39,7 +39,7 @@ pub enum BaseDataError {
 }
 
 impl fmt::Display for BaseDataError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             BaseDataError::NegativelyReferencedHash(hash) => {
                 write!(f, "Entry {} removed from database more times than it was added.", hash)

--- a/util/error/src/lib.rs
+++ b/util/error/src/lib.rs
@@ -22,10 +22,6 @@
 #[macro_use]
 extern crate error_chain;
 
-
-
-
-
 use primitives::H256;
 use std::fmt;
 

--- a/util/io/src/lib.rs
+++ b/util/io/src/lib.rs
@@ -62,11 +62,11 @@
 
 #[macro_use]
 extern crate codechain_logger as clogger;
-extern crate mio;
+
 #[macro_use]
 extern crate log;
-extern crate crossbeam;
-extern crate parking_lot;
+
+
 
 mod service;
 mod worker;
@@ -89,7 +89,7 @@ pub enum IoError {
 }
 
 impl fmt::Display for IoError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // just defer to the std implementation for now.
         // we can refine the formatting when more variants are added.
         match self {

--- a/util/io/src/lib.rs
+++ b/util/io/src/lib.rs
@@ -62,11 +62,8 @@
 
 #[macro_use]
 extern crate codechain_logger as clogger;
-
 #[macro_use]
 extern crate log;
-
-
 
 mod service;
 mod worker;

--- a/util/logger/src/lib.rs
+++ b/util/logger/src/lib.rs
@@ -14,23 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-extern crate atty;
-extern crate colored;
-extern crate env_logger;
-extern crate lazy_static;
-extern crate log;
-extern crate parking_lot;
-extern crate sendgrid;
-extern crate serde;
-extern crate serde_derive;
-extern crate serde_json;
-extern crate time;
-
 mod email;
 mod logger;
 mod macros;
 mod structured_logger;
 
+use log;
 use log::SetLoggerError;
 
 pub use logger::Config as LoggerConfig;

--- a/util/logger/src/logger.rs
+++ b/util/logger/src/logger.rs
@@ -69,11 +69,11 @@ impl Logger {
 }
 
 impl Log for Logger {
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         self.filter.enabled(metadata)
     }
 
-    fn log(&self, record: &Record) {
+    fn log(&self, record: &Record<'_>) {
         if self.filter.matches(record) {
             let thread_name = thread::current().name().unwrap_or_default().to_string();
             let timestamp = time::strftime("%Y-%m-%d %H:%M:%S.%f %Z", &time::now()).unwrap();

--- a/util/merkle/src/lib.rs
+++ b/util/merkle/src/lib.rs
@@ -17,8 +17,6 @@
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_db as cdb;
 
-
-
 #[cfg(test)]
 extern crate trie_standardmap as standardmap;
 

--- a/util/merkle/src/lib.rs
+++ b/util/merkle/src/lib.rs
@@ -16,8 +16,8 @@
 
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_db as cdb;
-extern crate primitives;
-extern crate rlp;
+
+
 
 #[cfg(test)]
 extern crate trie_standardmap as standardmap;
@@ -53,7 +53,7 @@ pub enum TrieError {
 }
 
 impl fmt::Display for TrieError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TrieError::InvalidStateRoot(root) => write!(f, "Invalid state root: {}", root),
             TrieError::IncompleteDatabase(missing) => write!(f, "Database missing expected key: {}", missing),

--- a/util/merkle/src/nibbleslice.rs
+++ b/util/merkle/src/nibbleslice.rs
@@ -41,7 +41,7 @@ where
     }
 
     /// Create a new nibble slice from the given HPE encoded data (e.g. output of `encoded()`).
-    pub fn from_encoded(data: &'a [u8]) -> NibbleSlice {
+    pub fn from_encoded(data: &'a [u8]) -> NibbleSlice<'_> {
         let offset = if (data[0] & 0b1_0000) == 0b1_0000 {
             1
         } else {
@@ -179,7 +179,7 @@ impl<'a> PartialOrd for NibbleSlice<'a> {
 }
 
 impl<'a> fmt::Debug for NibbleSlice<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for i in 0..self.len() {
             match i {
                 0 => write!(f, "{:01x}", self.at(i))?,

--- a/util/merkle/src/triedb.rs
+++ b/util/merkle/src/triedb.rs
@@ -68,7 +68,7 @@ impl<'db> TrieDB<'db> {
     /// Get auxiliary
     fn get_aux<T>(
         &self,
-        path: &NibbleSlice,
+        path: &NibbleSlice<'_>,
         cur_node_hash: Option<H256>,
         query: &Query<T>,
     ) -> crate::Result<Option<T>> {

--- a/util/merkle/src/triedbmut.rs
+++ b/util/merkle/src/triedbmut.rs
@@ -61,7 +61,7 @@ impl<'a> TrieDBMut<'a> {
     /// Insert auxiliary
     fn insert_aux(
         &mut self,
-        path: NibbleSlice,
+        path: NibbleSlice<'_>,
         insert_value: &[u8],
         cur_node_hash: Option<H256>,
         old_val: &mut Option<DBValue>,
@@ -172,7 +172,7 @@ impl<'a> TrieDBMut<'a> {
     /// Remove auxiliary
     fn remove_aux(
         &mut self,
-        path: &NibbleSlice,
+        path: &NibbleSlice<'_>,
         cur_node_hash: Option<H256>,
         old_val: &mut Option<DBValue>,
     ) -> crate::Result<Option<H256>> {
@@ -280,7 +280,7 @@ impl<'a> TrieDBMut<'a> {
 }
 
 impl<'a> fmt::Display for RlpNode<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RlpNode::Leaf(partial, value) => writeln!(f, "Leaf - key({:?}), value({:?})", partial, value),
             RlpNode::Branch(partial, children) => {
@@ -356,7 +356,7 @@ mod tests {
         t
     }
 
-    fn unpopulate_trie(t: &mut TrieDBMut, v: &[(Vec<u8>, Vec<u8>)]) {
+    fn unpopulate_trie(t: &mut TrieDBMut<'_>, v: &[(Vec<u8>, Vec<u8>)]) {
         for i in v {
             let key: &[u8] = &i.0;
             t.remove(key).unwrap();

--- a/util/panic_hook/src/lib.rs
+++ b/util/panic_hook/src/lib.rs
@@ -16,13 +16,13 @@
 
 //! Custom panic hook with bug report link
 
-extern crate backtrace;
+
 extern crate codechain_logger as clogger;
-extern crate get_if_addrs;
-extern crate my_internet_ip;
 
 use backtrace::Backtrace;
 use clogger::EmailAlarm;
+use get_if_addrs;
+use my_internet_ip;
 use std::panic::{self, PanicInfo};
 use std::thread;
 
@@ -41,13 +41,13 @@ This is a bug. Please report it at:
     https://github.com/CodeChain-io/codechain/issues/new
 ";
 
-fn panic_hook(info: &PanicInfo) {
+fn panic_hook(info: &PanicInfo<'_>) {
     let message = panic_message(info);
     eprintln!("{}", message);
     exit_on_debug_or_env_set_on_release();
 }
 
-fn panic_hook_with_email_alarm(email_alarm: &EmailAlarm, info: &PanicInfo) {
+fn panic_hook_with_email_alarm(email_alarm: &EmailAlarm, info: &PanicInfo<'_>) {
     let message = panic_message(info);
     eprintln!("{}", message);
     let ip_addresses = get_ip_addresses();
@@ -57,7 +57,7 @@ fn panic_hook_with_email_alarm(email_alarm: &EmailAlarm, info: &PanicInfo) {
     exit_on_debug_or_env_set_on_release();
 }
 
-fn panic_message(info: &PanicInfo) -> String {
+fn panic_message(info: &PanicInfo<'_>) -> String {
     let location = info.location();
     let file = location.as_ref().map(|l| l.file()).unwrap_or("<unknown>");
     let line = location.as_ref().map(|l| l.line()).unwrap_or(0);

--- a/util/panic_hook/src/lib.rs
+++ b/util/panic_hook/src/lib.rs
@@ -16,7 +16,6 @@
 
 //! Custom panic hook with bug report link
 
-
 extern crate codechain_logger as clogger;
 
 use backtrace::Backtrace;

--- a/util/table/src/lib.rs
+++ b/util/table/src/lib.rs
@@ -56,7 +56,7 @@ where
     }
 
     /// Returns keys iterator for this Table.
-    pub fn keys(&self) -> Keys<Row, HashMap<Col, Val>> {
+    pub fn keys(&self) -> Keys<'_, Row, HashMap<Col, Val>> {
         self.map.keys()
     }
 

--- a/util/timer/src/lib.rs
+++ b/util/timer/src/lib.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
 #[macro_use]
 extern crate log;
 #[macro_use]

--- a/util/timer/src/lib.rs
+++ b/util/timer/src/lib.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-extern crate parking_lot;
+
 #[macro_use]
 extern crate log;
 #[macro_use]

--- a/util/trie-standardmap/src/lib.rs
+++ b/util/trie-standardmap/src/lib.rs
@@ -16,9 +16,9 @@
 
 //! Key-value datastore with a modified Merkle tree.
 
-extern crate codechain_crypto;
-extern crate primitives;
-extern crate rlp;
+
+
+
 
 use codechain_crypto::blake256;
 use primitives::Bytes;

--- a/util/trie-standardmap/src/lib.rs
+++ b/util/trie-standardmap/src/lib.rs
@@ -16,10 +16,6 @@
 
 //! Key-value datastore with a modified Merkle tree.
 
-
-
-
-
 use codechain_crypto::blake256;
 use primitives::Bytes;
 use primitives::H256;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -18,8 +18,6 @@ extern crate codechain_crypto as ccrypto;
 extern crate codechain_key as ckey;
 extern crate codechain_types as ctypes;
 
-
-
 #[cfg(test)]
 extern crate secp256k1;
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -17,9 +17,9 @@
 extern crate codechain_crypto as ccrypto;
 extern crate codechain_key as ckey;
 extern crate codechain_types as ctypes;
-extern crate primitives;
 
-extern crate rlp;
+
+
 #[cfg(test)]
 extern crate secp256k1;
 


### PR DESCRIPTION
This is the result of `cargo fix --edition-idioms`. 
The command fixes the following lint errors automatically.

1. [warning: hidden lifetime parameters in types are deprecated](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#elided-lifetime-in-path)
2. [warning: `extern crate` is not idiomatic in the new edition](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html#no-more-extern-crate)
3. [warning: unused extern crate](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html?highlight=extern#unused-extern-crates)

Since the tool added an empty line after removing "extern crate". If you agree on these changes, I'll remove blank lines.