### PR TITLE
Introduce PreviousValidators and fix tendermint bugs

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -481,6 +481,10 @@ impl StateInfo for Client {
 }
 
 impl EngineInfo for Client {
+    fn network_id(&self) -> NetworkId {
+        self.common_params(BlockId::Earliest).expect("Genesis state must exist").network_id()
+    }
+
     fn common_params(&self, block_id: BlockId) -> Option<CommonParams> {
         self.state_info(block_id.into()).map(|state| {
             state
@@ -518,7 +522,7 @@ impl EngineInfo for Client {
     }
 
     fn possible_authors(&self, block_number: Option<u64>) -> Result<Option<Vec<PlatformAddress>>, EngineError> {
-        let network_id = self.common_params(BlockId::Latest).unwrap().network_id();
+        let network_id = self.network_id();
         if block_number == Some(0) {
             let genesis_author = self.block_header(&0.into()).expect("genesis block").author();
             return Ok(Some(vec![PlatformAddress::new_v1(network_id, genesis_author)]))
@@ -572,8 +576,7 @@ impl BlockChainTrait for Client {
     }
 
     fn genesis_accounts(&self) -> Vec<PlatformAddress> {
-        // XXX: What should we do if the network id has been changed
-        let network_id = self.common_params(BlockId::Latest).unwrap().network_id();
+        let network_id = self.network_id();
         self.genesis_accounts.iter().map(|addr| PlatformAddress::new_v1(network_id, *addr)).collect()
     }
 
@@ -895,10 +898,6 @@ impl MiningBlockChainClient for Client {
 
     fn register_immune_users(&self, immune_user_vec: Vec<Address>) {
         self.importer.miner.register_immune_users(immune_user_vec)
-    }
-
-    fn get_network_id(&self) -> NetworkId {
-        self.common_params(BlockId::Latest).unwrap().network_id()
     }
 }
 

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -88,6 +88,7 @@ pub trait BlockChainTrait {
 }
 
 pub trait EngineInfo: Send + Sync {
+    fn network_id(&self) -> NetworkId;
     fn common_params(&self, block_id: BlockId) -> Option<CommonParams>;
     fn metadata_seq(&self, block_id: BlockId) -> Option<u64>;
     fn block_reward(&self, block_number: u64) -> u64;
@@ -284,9 +285,6 @@ pub trait MiningBlockChainClient: BlockChainClient + BlockProducer + FindActionH
 
     /// Append designated users to the immune user list.
     fn register_immune_users(&self, immune_user_vec: Vec<Address>);
-
-    /// Returns network id.
-    fn get_network_id(&self) -> NetworkId;
 }
 
 /// Provides methods to access database.

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -380,10 +380,6 @@ impl MiningBlockChainClient for TestBlockChainClient {
     fn register_immune_users(&self, immune_user_vec: Vec<Address>) {
         self.miner.register_immune_users(immune_user_vec)
     }
-
-    fn get_network_id(&self) -> NetworkId {
-        NetworkId::default()
-    }
 }
 
 impl AccountData for TestBlockChainClient {
@@ -636,6 +632,10 @@ impl super::EngineClient for TestBlockChainClient {
 }
 
 impl EngineInfo for TestBlockChainClient {
+    fn network_id(&self) -> NetworkId {
+        self.scheme.engine.machine().genesis_common_params().network_id()
+    }
+
     fn common_params(&self, _block_id: BlockId) -> Option<CommonParams> {
         Some(*self.scheme.engine.machine().genesis_common_params())
     }

--- a/core/src/consensus/stake/action_data.rs
+++ b/core/src/consensus/stake/action_data.rs
@@ -433,6 +433,10 @@ impl CurrentValidators {
     pub fn update(&mut self, validators: Vec<Validator>) {
         self.0 = validators;
     }
+
+    pub fn addresses(&self) -> Vec<Address> {
+        self.0.iter().rev().map(|v| public_to_address(&v.pubkey)).collect()
+    }
 }
 
 impl Deref for CurrentValidators {
@@ -479,6 +483,12 @@ impl Deref for PreviousValidators {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl From<PreviousValidators> for Vec<Validator> {
+    fn from(val: PreviousValidators) -> Self {
+        val.0
     }
 }
 

--- a/core/src/consensus/stake/action_data.rs
+++ b/core/src/consensus/stake/action_data.rs
@@ -449,6 +449,39 @@ impl From<CurrentValidators> for Vec<Validator> {
     }
 }
 
+#[derive(Debug)]
+pub struct PreviousValidators(Vec<Validator>);
+impl PreviousValidators {
+    pub fn load_from_state(state: &TopLevelState) -> StateResult<Self> {
+        let key = &*CURRENT_VALIDATORS_KEY;
+        let validators = state.action_data(&key)?.map(|data| decode_list(&data)).unwrap_or_default();
+
+        Ok(Self(validators))
+    }
+
+    pub fn save_to_state(&self, state: &mut TopLevelState) -> StateResult<()> {
+        let key = &*CURRENT_VALIDATORS_KEY;
+        if !self.is_empty() {
+            state.update_action_data(&key, encode_list(&self.0).to_vec())?;
+        } else {
+            state.remove_action_data(&key);
+        }
+        Ok(())
+    }
+
+    pub fn update(&mut self, validators: Vec<Validator>) {
+        self.0 = validators;
+    }
+}
+
+impl Deref for PreviousValidators {
+    type Target = Vec<Validator>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Default, Debug, PartialEq)]
 pub struct IntermediateRewards {
     current: BTreeMap<Address, u64>,

--- a/core/src/consensus/stake/mod.rs
+++ b/core/src/consensus/stake/mod.rs
@@ -33,7 +33,7 @@ use parking_lot::RwLock;
 use primitives::{Bytes, H256};
 use rlp::{Decodable, Rlp};
 
-pub use self::action_data::{Banned, CurrentValidators, NextValidators, Validator};
+pub use self::action_data::{Banned, CurrentValidators, NextValidators, PreviousValidators, Validator};
 use self::action_data::{Candidates, Delegation, IntermediateRewards, Jail, ReleaseResult, StakeAccount, Stakeholders};
 pub use self::actions::Action;
 pub use self::distribute::fee_distribute;

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -165,7 +165,7 @@ impl ConsensusEngine for Tendermint {
 
         if block_number == metadata.last_term_finished_block_num() + 1 {
             match term {
-                0 => {}
+                0 | 1 => {}
                 _ => {
                     let rewards = stake::drain_current_rewards(block.state_mut())?;
                     let banned = stake::Banned::load_from_state(block.state())?;

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -400,20 +400,21 @@ fn aggregate_work_info(
         end_of_the_last_term + 1
     };
     let mut header = start_of_the_next_term_header;
-    let mut parent_validators = validators.current_addresses(&header.parent_hash());
     while start_of_the_current_term != header.number() {
+        let parent = chain.block_header(&header.parent_hash().into()).unwrap();
+        let current_validators = validators.current_addresses(&parent.hash());
+        let previous_validators = validators.previous_addresses(&parent.hash());
         for index in TendermintSealView::new(&header.seal()).bitset()?.true_index_iter() {
-            let signer = *parent_validators.get(index).expect("The seal must be the signature of the validator");
+            let signer = *current_validators.get(index).expect("The seal must be the signature of the validator");
             work_info.entry(signer).or_default().signed += 1;
         }
 
-        header = chain.block_header(&header.parent_hash().into()).unwrap();
-        parent_validators = validators.current_addresses(&header.parent_hash());
-
-        let author = header.author();
+        let author = parent.author();
         let info = work_info.entry(author).or_default();
         info.proposed += 1;
-        info.missed += parent_validators.len() - TendermintSealView::new(&header.seal()).bitset()?.count();
+        info.missed += previous_validators.len() - TendermintSealView::new(&header.seal()).bitset()?.count();
+
+        header = parent;
     }
 
     Ok(work_info)

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -153,9 +153,13 @@ impl ConsensusEngine for Tendermint {
         match term {
             0 => {}
             _ => {
-                let mut validators = stake::CurrentValidators::load_from_state(block.state())?;
-                validators.update(stake::NextValidators::load_from_state(block.state())?.clone());
-                validators.save_to_state(block.state_mut())?;
+                let mut previous_validators = stake::PreviousValidators::load_from_state(block.state())?;
+                previous_validators.update(stake::CurrentValidators::load_from_state(block.state())?.clone());
+                previous_validators.save_to_state(block.state_mut())?;
+
+                let mut current_validators = stake::CurrentValidators::load_from_state(block.state())?;
+                current_validators.update(stake::NextValidators::load_from_state(block.state())?.clone());
+                current_validators.save_to_state(block.state_mut())?;
             }
         }
 

--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -1475,7 +1475,7 @@ impl Worker {
     }
 
     fn report_double_vote(&self, double: &DoubleVote) {
-        let network_id = self.client().common_params(BlockId::Latest).unwrap().network_id();
+        let network_id = self.client().network_id();
         let seq = match self.signer.address() {
             Some(address) => self.client().latest_seq(address),
             None => {

--- a/core/src/consensus/validator_set/mod.rs
+++ b/core/src/consensus/validator_set/mod.rs
@@ -57,6 +57,8 @@ pub trait ValidatorSet: Send + Sync {
     /// Allows blockchain state access.
     fn register_client(&self, _client: Weak<dyn ConsensusClient>) {}
 
+    fn previous_addresses(&self, _hash: &BlockHash) -> Vec<Address>;
+
     fn current_addresses(&self, _hash: &BlockHash) -> Vec<Address>;
 
     fn next_addresses(&self, _hash: &BlockHash) -> Vec<Address>;

--- a/core/src/consensus/validator_set/validator_list.rs
+++ b/core/src/consensus/validator_set/validator_list.rs
@@ -105,6 +105,10 @@ impl ValidatorSet for RoundRobinValidator {
         *self.client.write() = Some(client);
     }
 
+    fn previous_addresses(&self, _hash: &BlockHash) -> Vec<Address> {
+        self.validators.iter().map(public_to_address).collect()
+    }
+
     fn current_addresses(&self, _hash: &BlockHash) -> Vec<Address> {
         self.validators.iter().map(public_to_address).collect()
     }

--- a/foundry/run_node.rs
+++ b/foundry/run_node.rs
@@ -21,8 +21,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use ccore::snapshot_notify;
 use ccore::{
-    AccountProvider, AccountProviderError, BlockId, ChainNotify, ClientConfig, ClientService, EngineInfo, EngineType,
-    Miner, MinerService, Scheme, NUM_COLUMNS,
+    AccountProvider, AccountProviderError, ChainNotify, ClientConfig, ClientService, EngineInfo, EngineType, Miner,
+    MinerService, Scheme, NUM_COLUMNS,
 };
 use cdiscovery::{Config, Discovery};
 use ckey::{Address, NetworkId, PlatformAddress};
@@ -264,7 +264,7 @@ pub fn run_node(matches: &ArgMatches<'_>) -> Result<(), String> {
             let network_config = config.network_config()?;
             // XXX: What should we do if the network id has been changed.
             let c = client.client();
-            let network_id = c.common_params(BlockId::Number(0)).unwrap().network_id();
+            let network_id = c.network_id();
             let routing_table = RoutingTable::new();
             let service = network_start(network_id, timer_loop, &network_config, Arc::clone(&routing_table))?;
 

--- a/rpc/src/v1/impls/engine.rs
+++ b/rpc/src/v1/impls/engine.rs
@@ -62,7 +62,7 @@ where
             Ok(None)
         } else {
             // XXX: What should we do if the network id has been changed
-            let network_id = self.client.common_params(BlockId::Latest).unwrap().network_id();
+            let network_id = self.client.network_id();
             Ok(Some(PlatformAddress::new_v1(network_id, author)))
         }
     }

--- a/rpc/src/v1/impls/mempool.rs
+++ b/rpc/src/v1/impls/mempool.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use ccore::{BlockChainClient, MiningBlockChainClient, SignedTransaction};
+use ccore::{BlockChainClient, EngineInfo, MiningBlockChainClient, SignedTransaction};
 use cjson::bytes::Bytes;
 use ckey::{Address, PlatformAddress};
 use ctypes::{Tracker, TxHash};
@@ -42,7 +42,7 @@ impl<C> MempoolClient<C> {
 
 impl<C> Mempool for MempoolClient<C>
 where
-    C: BlockChainClient + MiningBlockChainClient + 'static,
+    C: BlockChainClient + MiningBlockChainClient + EngineInfo + 'static,
 {
     fn send_signed_transaction(&self, raw: Bytes) -> Result<TxHash> {
         Rlp::new(&raw.into_vec())
@@ -82,7 +82,7 @@ where
 
     fn get_banned_accounts(&self) -> Result<Vec<PlatformAddress>> {
         let malicious_user_vec = self.client.get_malicious_users();
-        let network_id = self.client.get_network_id();
+        let network_id = self.client.network_id();
         Ok(malicious_user_vec.into_iter().map(|address| PlatformAddress::new_v1(network_id, address)).collect())
     }
 
@@ -102,7 +102,7 @@ where
 
     fn get_immune_accounts(&self) -> Result<Vec<PlatformAddress>> {
         let immune_user_vec = self.client.get_immune_users();
-        let network_id = self.client.get_network_id();
+        let network_id = self.client.network_id();
         Ok(immune_user_vec.into_iter().map(|address| PlatformAddress::new_v1(network_id, address)).collect())
     }
 


### PR DESCRIPTION
The patches in https://github.com/CodeChain-io/foundry/pull/27 were originally ported from the CodeChain's snapshot branch, which includes CurrentValidators patch in CodeChain-io/codechain#1922. I found out that there was something wrong about the previous implementation, and introduced PreviousValidator state value to solve this.
It's almost the same as the CurrentValidators, except that it is updated with the values from CurrentValidators.
The fee calculation function is changed a bit to utilize this state value. Please take a look at it carefully.

Some other patches not related to the fee calculation are included too. A detailed explanation is written in the commit messages.