### PR TITLE
Store the peer list on the DB of a node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "codechain-types",
  "crossbeam-channel",
  "finally-block",
+ "kvdb",
  "log 0.4.6",
  "mio",
  "never-type",

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -34,8 +34,10 @@ pub const COL_EXTRA: Option<u32> = Some(3);
 pub const COL_MEMPOOL: Option<u32> = Some(4);
 /// Column for Transaction error hints
 pub const COL_ERROR_HINT: Option<u32> = Some(5);
+/// Column for Storing Peer list
+pub const COL_PEER: Option<u32> = Some(6);
 /// Number of columns in DB
-pub const NUM_COLUMNS: Option<u32> = Some(6);
+pub const NUM_COLUMNS: Option<u32> = Some(7);
 
 /// Modes for updating caches.
 #[derive(Clone, Copy)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -50,6 +50,7 @@ pub mod encoded;
 mod error;
 mod invoice;
 mod miner;
+mod peer_db;
 mod scheme;
 mod service;
 mod transaction;
@@ -69,9 +70,10 @@ pub use crate::client::{
     TermInfo, TestBlockChainClient, TextClient,
 };
 pub use crate::consensus::{EngineType, TimeGapParams};
-pub use crate::db::{COL_STATE, NUM_COLUMNS};
+pub use crate::db::{COL_PEER, COL_STATE, NUM_COLUMNS};
 pub use crate::error::{BlockImportError, Error, ImportError};
 pub use crate::miner::{MemPoolFees, Miner, MinerOptions, MinerService};
+pub use crate::peer_db::PeerDb;
 pub use crate::scheme::Scheme;
 pub use crate::service::ClientService;
 pub use crate::transaction::{

--- a/core/src/peer_db.rs
+++ b/core/src/peer_db.rs
@@ -1,0 +1,50 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+use crate::db::COL_PEER;
+use cnetwork::{ManagingPeerdb, SocketAddr};
+use kvdb::{DBTransaction, KeyValueDB};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+const COLUMN_TO_WRITE: Option<u32> = COL_PEER;
+
+pub struct PeerDb {
+    db: Arc<dyn KeyValueDB>,
+}
+
+impl PeerDb {
+    pub fn new(database: Arc<dyn KeyValueDB>) -> Arc<Self> {
+        Arc::new(Self {
+            db: database,
+        })
+    }
+}
+
+impl ManagingPeerdb for PeerDb {
+    fn insert(&self, key: &SocketAddr) {
+        let mut batch = DBTransaction::new();
+        let s = rlp::encode(key);
+        let time: u64 = SystemTime::now().duration_since(UNIX_EPOCH).expect("There is no time machine.").as_secs();
+        let value = rlp::encode(&time);
+        batch.put(COLUMN_TO_WRITE, &s, &value);
+        self.db.write(batch).expect("The key is not valid");
+    }
+    fn delete(&self, key: &SocketAddr) {
+        let mut batch = DBTransaction::new();
+        let s = rlp::encode(key);
+        batch.delete(COLUMN_TO_WRITE, &s);
+        self.db.write(batch).expect("The key is not valid");
+    }
+}

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -15,6 +15,7 @@ crossbeam-channel = "0.3"
 finally-block = "0.1"
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
 log = "0.4.6"
+kvdb="0.1"
 mio = "0.6.16"
 never-type = "0.1.0"
 parking_lot = "0.6.0"

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -26,6 +26,7 @@ extern crate codechain_timer as ctimer;
 extern crate log;
 #[macro_use]
 extern crate rlp_derive;
+extern crate kvdb;
 
 use crossbeam_channel;
 
@@ -43,6 +44,7 @@ pub mod control;
 mod p2p;
 pub mod session;
 
+pub use self::p2p::{Handler, ManagingPeerdb};
 pub use crate::addr::SocketAddr;
 pub use crate::config::Config as NetworkConfig;
 pub use crate::control::{Control as NetworkControl, Error as NetworkControlError};

--- a/network/src/p2p/handler.rs
+++ b/network/src/p2p/handler.rs
@@ -78,6 +78,11 @@ const RETRY_SYNC_MAX: Duration = Duration::from_secs(10); // T1
 const RTT: Duration = Duration::from_secs(10); // T2
 const WAIT_SYNC: Duration = Duration::from_secs(30); // T3 >> T1 + RTT
 
+pub trait ManagingPeerdb: Send + Sync {
+    fn insert(&self, key: &SocketAddr);
+    fn delete(&self, key: &SocketAddr);
+}
+
 pub struct Handler {
     connecting_lock: Mutex<()>,
     channel: IoChannel<Message>,
@@ -113,7 +118,7 @@ pub struct Handler {
 
     min_peers: usize,
     max_peers: usize,
-
+    peer_db: Arc<dyn (ManagingPeerdb)>,
     rng: Mutex<OsRng>,
 }
 
@@ -128,6 +133,7 @@ impl Handler {
         bootstrap_addresses: Vec<SocketAddr>,
         min_peers: usize,
         max_peers: usize,
+        db: Arc<dyn ManagingPeerdb>,
     ) -> ::std::result::Result<Self, String> {
         if MAX_INBOUND_CONNECTIONS + MAX_OUTBOUND_CONNECTIONS < max_peers {
             return Err(format!("Max peers must be less than {}", MAX_INBOUND_CONNECTIONS + MAX_OUTBOUND_CONNECTIONS))
@@ -166,7 +172,7 @@ impl Handler {
             bootstrap_addresses,
             min_peers,
             max_peers,
-
+            peer_db: db,
             rng: Mutex::new(OsRng::new().unwrap()),
         })
     }
@@ -491,6 +497,8 @@ impl IoHandler<Message> for Handler {
                 is_inbound: true,
             } => {
                 let mut inbound_connections = self.inbound_connections.write();
+                let target = connection.peer_addr();
+                self.peer_db.insert(&target);
                 if let Some(token) = self.inbound_tokens.lock().gen() {
                     let remote_node_id = connection.peer_addr().into();
                     assert_eq!(
@@ -1052,6 +1060,8 @@ impl IoHandler<Message> for Handler {
                         unreachable!("{} has no node id", stream);
                     }
                     con.deregister(event_loop)?;
+                    let remove_target = con.peer_addr();
+                    self.peer_db.delete(&remove_target);
                     self.routing_table.remove(con.peer_addr());
                     self.inbound_tokens.lock().restore(stream);
                     ctrace!(NETWORK, "Inbound connect({}) removed", stream);
@@ -1069,6 +1079,8 @@ impl IoHandler<Message> for Handler {
                         unreachable!("{} has no node id", stream);
                     }
                     con.deregister(event_loop)?;
+                    let remove_target = con.peer_addr();
+                    self.peer_db.delete(&remove_target);
                     self.routing_table.remove(con.peer_addr());
                     self.outbound_tokens.lock().restore(stream);
                     ctrace!(NETWORK, "Outbound connect({}) removed", stream);

--- a/network/src/p2p/mod.rs
+++ b/network/src/p2p/mod.rs
@@ -20,5 +20,5 @@ mod listener;
 mod message;
 mod stream;
 
-pub use self::handler::{Handler, Message};
+pub use self::handler::{Handler, ManagingPeerdb, Message};
 use self::message::{ExtensionMessage, Message as NetworkMessage, NegotiationMessage, SignedMessage};

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -18,7 +18,7 @@ use crate::client::Client;
 use crate::control::{Control, Error as ControlError};
 use crate::filters::{FilterEntry, FiltersControl};
 use crate::routing_table::RoutingTable;
-use crate::{p2p, Api, NetworkExtension, SocketAddr};
+use crate::{p2p, Api, ManagingPeerdb, NetworkExtension, SocketAddr};
 use cidr::IpCidr;
 use cio::{IoError, IoService};
 use ckey::{NetworkId, Public};
@@ -46,6 +46,7 @@ impl Service {
         max_peers: usize,
         filters_control: Arc<dyn FiltersControl>,
         routing_table: Arc<RoutingTable>,
+        peer_db: Arc<dyn ManagingPeerdb>,
     ) -> Result<Arc<Self>, Error> {
         let p2p = IoService::start("P2P")?;
 
@@ -61,6 +62,7 @@ impl Service {
             bootstrap_addresses,
             min_peers,
             max_peers,
+            peer_db,
         )?);
         p2p.register_handler(p2p_handler.clone())?;
 


### PR DESCRIPTION
To reduce the burden of bootstrap nodes, codecahin needs to save the received peer list
in the disk. In order to save the peer list of a node in the disk, a procedure is designed
a database to store nodes that are connected to the node. 