### PR TITLE
Convert constants to discriminated enum

### DIFF
--- a/core/src/consensus/stake/actions.rs
+++ b/core/src/consensus/stake/actions.rs
@@ -24,13 +24,39 @@ use primitives::{Bytes, H256};
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use std::sync::Arc;
 
-const ACTION_TAG_TRANSFER_CCS: u8 = 1;
-const ACTION_TAG_DELEGATE_CCS: u8 = 2;
-const ACTION_TAG_REVOKE: u8 = 3;
-const ACTION_TAG_SELF_NOMINATE: u8 = 4;
-const ACTION_TAG_REPORT_DOUBLE_VOTE: u8 = 5;
-const ACTION_TAG_REDELEGATE: u8 = 6;
-const ACTION_TAG_CHANGE_PARAMS: u8 = 0xFF;
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum ActionTag {
+    TransferCCS = 1,
+    DelegateCCS = 2,
+    Revoke = 3,
+    SelfNominate = 4,
+    ReportDoubleVote = 5,
+    Redelegate = 6,
+    ChangeParams = 0xFF,
+}
+
+impl Encodable for ActionTag {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.append_single_value(&(*self as u8));
+    }
+}
+
+impl Decodable for ActionTag {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let tag = rlp.as_val()?;
+        match tag {
+            1u8 => Ok(ActionTag::TransferCCS),
+            2 => Ok(ActionTag::DelegateCCS),
+            3 => Ok(ActionTag::Revoke),
+            4 => Ok(ActionTag::SelfNominate),
+            5 => Ok(ActionTag::ReportDoubleVote),
+            6 => Ok(ActionTag::Redelegate),
+            0xFF => Ok(ActionTag::ChangeParams),
+            _ => Err(DecoderError::Custom("Unexpected ActionTag Value")),
+        }
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub enum Action {
@@ -181,19 +207,19 @@ impl Encodable for Action {
                 address,
                 quantity,
             } => {
-                s.begin_list(3).append(&ACTION_TAG_TRANSFER_CCS).append(address).append(quantity);
+                s.begin_list(3).append(&ActionTag::TransferCCS).append(address).append(quantity);
             }
             Action::DelegateCCS {
                 address,
                 quantity,
             } => {
-                s.begin_list(3).append(&ACTION_TAG_DELEGATE_CCS).append(address).append(quantity);
+                s.begin_list(3).append(&ActionTag::DelegateCCS).append(address).append(quantity);
             }
             Action::Revoke {
                 address,
                 quantity,
             } => {
-                s.begin_list(3).append(&ACTION_TAG_REVOKE).append(address).append(quantity);
+                s.begin_list(3).append(&ActionTag::Revoke).append(address).append(quantity);
             }
             Action::Redelegate {
                 prev_delegatee,
@@ -201,7 +227,7 @@ impl Encodable for Action {
                 quantity,
             } => {
                 s.begin_list(4)
-                    .append(&ACTION_TAG_REDELEGATE)
+                    .append(&ActionTag::Redelegate)
                     .append(prev_delegatee)
                     .append(next_delegatee)
                     .append(quantity);
@@ -210,7 +236,7 @@ impl Encodable for Action {
                 deposit,
                 metadata,
             } => {
-                s.begin_list(3).append(&ACTION_TAG_SELF_NOMINATE).append(deposit).append(metadata);
+                s.begin_list(3).append(&ActionTag::SelfNominate).append(deposit).append(metadata);
             }
             Action::ChangeParams {
                 metadata_seq,
@@ -218,7 +244,7 @@ impl Encodable for Action {
                 signatures,
             } => {
                 s.begin_list(3 + signatures.len())
-                    .append(&ACTION_TAG_CHANGE_PARAMS)
+                    .append(&ActionTag::ChangeParams)
                     .append(metadata_seq)
                     .append(&**params);
                 for signature in signatures {
@@ -230,7 +256,7 @@ impl Encodable for Action {
                 message2,
             } => {
                 s.begin_list(3)
-                    .append(&ACTION_TAG_REPORT_DOUBLE_VOTE)
+                    .append(&ActionTag::ReportDoubleVote)
                     .append(message1.as_ref())
                     .append(message2.as_ref());
             }
@@ -242,7 +268,7 @@ impl Decodable for Action {
     fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let tag = rlp.val_at(0)?;
         match tag {
-            ACTION_TAG_TRANSFER_CCS => {
+            ActionTag::TransferCCS => {
                 let item_count = rlp.item_count()?;
                 if item_count != 3 {
                     return Err(DecoderError::RlpInvalidLength {
@@ -255,7 +281,7 @@ impl Decodable for Action {
                     quantity: rlp.val_at(2)?,
                 })
             }
-            ACTION_TAG_DELEGATE_CCS => {
+            ActionTag::DelegateCCS => {
                 let item_count = rlp.item_count()?;
                 if item_count != 3 {
                     return Err(DecoderError::RlpInvalidLength {
@@ -268,7 +294,7 @@ impl Decodable for Action {
                     quantity: rlp.val_at(2)?,
                 })
             }
-            ACTION_TAG_REVOKE => {
+            ActionTag::Revoke => {
                 let item_count = rlp.item_count()?;
                 if item_count != 3 {
                     return Err(DecoderError::RlpInvalidLength {
@@ -281,7 +307,7 @@ impl Decodable for Action {
                     quantity: rlp.val_at(2)?,
                 })
             }
-            ACTION_TAG_REDELEGATE => {
+            ActionTag::Redelegate => {
                 let item_count = rlp.item_count()?;
                 if item_count != 4 {
                     return Err(DecoderError::RlpInvalidLength {
@@ -295,7 +321,7 @@ impl Decodable for Action {
                     quantity: rlp.val_at(3)?,
                 })
             }
-            ACTION_TAG_SELF_NOMINATE => {
+            ActionTag::SelfNominate => {
                 let item_count = rlp.item_count()?;
                 if item_count != 3 {
                     return Err(DecoderError::RlpInvalidLength {
@@ -308,7 +334,7 @@ impl Decodable for Action {
                     metadata: rlp.val_at(2)?,
                 })
             }
-            ACTION_TAG_CHANGE_PARAMS => {
+            ActionTag::ChangeParams => {
                 let item_count = rlp.item_count()?;
                 if item_count < 4 {
                     return Err(DecoderError::RlpIncorrectListLen {
@@ -325,7 +351,7 @@ impl Decodable for Action {
                     signatures,
                 })
             }
-            ACTION_TAG_REPORT_DOUBLE_VOTE => {
+            ActionTag::ReportDoubleVote => {
                 let item_count = rlp.item_count()?;
                 if item_count != 3 {
                     return Err(DecoderError::RlpIncorrectListLen {
@@ -340,7 +366,6 @@ impl Decodable for Action {
                     message2,
                 })
             }
-            _ => Err(DecoderError::Custom("Unexpected Tendermint Stake Action Type")),
         }
     }
 }

--- a/core/src/consensus/tendermint/message.rs
+++ b/core/src/consensus/tendermint/message.rs
@@ -70,13 +70,39 @@ impl Ord for VoteStep {
     }
 }
 
-const MESSAGE_ID_CONSENSUS_MESSAGE: u8 = 0x01;
-const MESSAGE_ID_PROPOSAL_BLOCK: u8 = 0x02;
-const MESSAGE_ID_STEP_STATE: u8 = 0x03;
-const MESSAGE_ID_REQUEST_MESSAGE: u8 = 0x04;
-const MESSAGE_ID_REQUEST_PROPOSAL: u8 = 0x05;
-const MESSAGE_ID_REQUEST_COMMIT: u8 = 0x06;
-const MESSAGE_ID_COMMIT: u8 = 0x07;
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum MessageID {
+    ConsensusMessage = 0x01,
+    ProposalBlock = 0x02,
+    StepState = 0x03,
+    RequsetMessage = 0x04,
+    RequestProposal = 0x05,
+    RequestCommit = 0x06,
+    Commit = 0x07,
+}
+
+impl Encodable for MessageID {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.append_single_value(&(*self as u8));
+    }
+}
+
+impl Decodable for MessageID {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let tag = rlp.as_val()?;
+        match tag {
+            0x01u8 => Ok(MessageID::ConsensusMessage),
+            0x02 => Ok(MessageID::ProposalBlock),
+            0x03 => Ok(MessageID::StepState),
+            0x04 => Ok(MessageID::RequsetMessage),
+            0x05 => Ok(MessageID::RequestProposal),
+            0x06 => Ok(MessageID::RequestCommit),
+            0x07 => Ok(MessageID::Commit),
+            _ => Err(DecoderError::Custom("Unexpected MessageID Value")),
+        }
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub enum TendermintMessage {
@@ -114,7 +140,7 @@ impl Encodable for TendermintMessage {
         match self {
             TendermintMessage::ConsensusMessage(messages) => {
                 s.begin_list(2);
-                s.append(&MESSAGE_ID_CONSENSUS_MESSAGE);
+                s.append(&MessageID::ConsensusMessage);
                 s.append_list::<Bytes, Bytes>(messages);
             }
             TendermintMessage::ProposalBlock {
@@ -123,7 +149,7 @@ impl Encodable for TendermintMessage {
                 message,
             } => {
                 s.begin_list(4);
-                s.append(&MESSAGE_ID_PROPOSAL_BLOCK);
+                s.append(&MessageID::ProposalBlock);
                 s.append(signature);
                 s.append(view);
 
@@ -141,7 +167,7 @@ impl Encodable for TendermintMessage {
                 known_votes,
             } => {
                 s.begin_list(5);
-                s.append(&MESSAGE_ID_STEP_STATE);
+                s.append(&MessageID::StepState);
                 s.append(vote_step);
                 s.append(proposal);
                 s.append(lock_view);
@@ -152,7 +178,7 @@ impl Encodable for TendermintMessage {
                 requested_votes,
             } => {
                 s.begin_list(3);
-                s.append(&MESSAGE_ID_REQUEST_MESSAGE);
+                s.append(&MessageID::RequsetMessage);
                 s.append(vote_step);
                 s.append(requested_votes);
             }
@@ -161,7 +187,7 @@ impl Encodable for TendermintMessage {
                 view,
             } => {
                 s.begin_list(3);
-                s.append(&MESSAGE_ID_REQUEST_PROPOSAL);
+                s.append(&MessageID::RequestProposal);
                 s.append(height);
                 s.append(view);
             }
@@ -169,7 +195,7 @@ impl Encodable for TendermintMessage {
                 height,
             } => {
                 s.begin_list(2);
-                s.append(&MESSAGE_ID_REQUEST_COMMIT);
+                s.append(&MessageID::RequestCommit);
                 s.append(height);
             }
             TendermintMessage::Commit {
@@ -177,7 +203,7 @@ impl Encodable for TendermintMessage {
                 votes,
             } => {
                 s.begin_list(3);
-                s.append(&MESSAGE_ID_COMMIT);
+                s.append(&MessageID::Commit);
                 s.append(block);
                 s.append_list(votes);
             }
@@ -189,7 +215,7 @@ impl Decodable for TendermintMessage {
     fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let id = rlp.val_at(0)?;
         Ok(match id {
-            MESSAGE_ID_CONSENSUS_MESSAGE => {
+            MessageID::ConsensusMessage => {
                 let item_count = rlp.item_count()?;
                 if item_count != 2 {
                     return Err(DecoderError::RlpIncorrectListLen {
@@ -199,7 +225,7 @@ impl Decodable for TendermintMessage {
                 }
                 TendermintMessage::ConsensusMessage(rlp.list_at(1)?)
             }
-            MESSAGE_ID_PROPOSAL_BLOCK => {
+            MessageID::ProposalBlock => {
                 let item_count = rlp.item_count()?;
                 if item_count != 4 {
                     return Err(DecoderError::RlpIncorrectListLen {
@@ -225,7 +251,7 @@ impl Decodable for TendermintMessage {
                     message: uncompressed_message,
                 }
             }
-            MESSAGE_ID_STEP_STATE => {
+            MessageID::StepState => {
                 let item_count = rlp.item_count()?;
                 if item_count != 5 {
                     return Err(DecoderError::RlpIncorrectListLen {
@@ -244,7 +270,7 @@ impl Decodable for TendermintMessage {
                     known_votes,
                 }
             }
-            MESSAGE_ID_REQUEST_MESSAGE => {
+            MessageID::RequsetMessage => {
                 let item_count = rlp.item_count()?;
                 if item_count != 3 {
                     return Err(DecoderError::RlpIncorrectListLen {
@@ -259,7 +285,7 @@ impl Decodable for TendermintMessage {
                     requested_votes,
                 }
             }
-            MESSAGE_ID_REQUEST_PROPOSAL => {
+            MessageID::RequestProposal => {
                 let item_count = rlp.item_count()?;
                 if item_count != 3 {
                     return Err(DecoderError::RlpIncorrectListLen {
@@ -274,7 +300,7 @@ impl Decodable for TendermintMessage {
                     view,
                 }
             }
-            MESSAGE_ID_REQUEST_COMMIT => {
+            MessageID::RequestCommit => {
                 let item_count = rlp.item_count()?;
                 if item_count != 2 {
                     return Err(DecoderError::RlpIncorrectListLen {
@@ -287,7 +313,7 @@ impl Decodable for TendermintMessage {
                     height,
                 }
             }
-            MESSAGE_ID_COMMIT => {
+            MessageID::Commit => {
                 let item_count = rlp.item_count()?;
                 if item_count != 3 {
                     return Err(DecoderError::RlpIncorrectListLen {
@@ -302,7 +328,6 @@ impl Decodable for TendermintMessage {
                     votes,
                 }
             }
-            _ => return Err(DecoderError::Custom("Unknown message id detected")),
         })
     }
 }

--- a/sync/src/block/message/mod.rs
+++ b/sync/src/block/message/mod.rs
@@ -24,13 +24,39 @@ mod response;
 pub use self::request::RequestMessage;
 pub use self::response::ResponseMessage;
 
-const MESSAGE_ID_STATUS: u8 = 0x01;
-const MESSAGE_ID_GET_HEADERS: u8 = 0x02;
-const MESSAGE_ID_HEADERS: u8 = 0x03;
-const MESSAGE_ID_GET_BODIES: u8 = 0x04;
-const MESSAGE_ID_BODIES: u8 = 0x05;
-const MESSAGE_ID_GET_STATE_CHUNK: u8 = 0x0a;
-const MESSAGE_ID_STATE_CHUNK: u8 = 0x0b;
+#[derive(Clone, Copy)]
+#[repr(u8)]
+pub enum MessageID {
+    Status = 0x01,
+    GetHeaders = 0x02,
+    Headers = 0x03,
+    GetBodies = 0x04,
+    Bodies = 0x05,
+    GetStateChunk = 0x0a,
+    StateChunk = 0x0b,
+}
+
+impl Encodable for MessageID {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.append_single_value(&(*self as u8));
+    }
+}
+
+impl Decodable for MessageID {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let tag = rlp.as_val()?;
+        match tag {
+            0x01u8 => Ok(MessageID::Status),
+            0x02 => Ok(MessageID::GetHeaders),
+            0x03 => Ok(MessageID::Headers),
+            0x04 => Ok(MessageID::GetBodies),
+            0x05 => Ok(MessageID::Bodies),
+            0x0a => Ok(MessageID::GetStateChunk),
+            0x0b => Ok(MessageID::StateChunk),
+            _ => Err(DecoderError::Custom("Unexpected MessageID Value")),
+        }
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub enum Message {
@@ -52,7 +78,7 @@ impl Encodable for Message {
                 genesis_hash,
             } => {
                 s.begin_list(2);
-                s.append(&MESSAGE_ID_STATUS);
+                s.append(&MessageID::Status);
 
                 s.begin_list(3);
                 s.append(seq);
@@ -78,47 +104,51 @@ impl Encodable for Message {
 impl Decodable for Message {
     fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let id = rlp.val_at(0)?;
-        if id == MESSAGE_ID_STATUS {
-            let item_count = rlp.item_count()?;
-            if item_count != 2 {
-                return Err(DecoderError::RlpIncorrectListLen {
-                    got: item_count,
-                    expected: 2,
-                })
-            }
-            let message = rlp.at(1)?;
-
-            let message_item_count = message.item_count()?;
-            if message_item_count != 3 {
-                return Err(DecoderError::RlpIncorrectListLen {
-                    expected: 3,
-                    got: message_item_count,
-                })
-            }
-
-            Ok(Message::Status {
-                seq: message.val_at(0)?,
-                best_hash: message.val_at(1)?,
-                genesis_hash: message.val_at(2)?,
-            })
-        } else {
-            let item_count = rlp.item_count()?;
-            if item_count != 3 {
-                return Err(DecoderError::RlpIncorrectListLen {
-                    got: item_count,
-                    expected: 3,
-                })
-            }
-            let request_id = rlp.val_at(1)?;
-            let message = rlp.at(2)?;
-            match id {
-                MESSAGE_ID_GET_HEADERS | MESSAGE_ID_GET_BODIES | MESSAGE_ID_GET_STATE_CHUNK => {
-                    Ok(Message::Request(request_id, RequestMessage::decode(id, &message)?))
+        match id {
+            MessageID::Status => {
+                let item_count = rlp.item_count()?;
+                if item_count != 2 {
+                    return Err(DecoderError::RlpIncorrectListLen {
+                        got: item_count,
+                        expected: 2,
+                    })
                 }
-                MESSAGE_ID_HEADERS | MESSAGE_ID_BODIES | MESSAGE_ID_STATE_CHUNK => {
-                    Ok(Message::Response(request_id, ResponseMessage::decode(id, &message)?))
+                let message = rlp.at(1)?;
+
+                let message_item_count = message.item_count()?;
+                if message_item_count != 3 {
+                    return Err(DecoderError::RlpIncorrectListLen {
+                        expected: 3,
+                        got: message_item_count,
+                    })
                 }
-                _ => Err(DecoderError::Custom("Unknown message id detected")),
+
+                Ok(Message::Status {
+                    seq: message.val_at(0)?,
+                    best_hash: message.val_at(1)?,
+                    genesis_hash: message.val_at(2)?,
+                })
+            }
+            _ => {
+                let item_count = rlp.item_count()?;
+                if item_count != 3 {
+                    return Err(DecoderError::RlpIncorrectListLen {
+                        got: item_count,
+                        expected: 3,
+                    })
+                }
+                let request_id = rlp.val_at(1)?;
+                let message = rlp.at(2)?;
+                match id {
+                    MessageID::GetHeaders | MessageID::GetBodies | MessageID::GetStateChunk => {
+                        Ok(Message::Request(request_id, RequestMessage::decode(id, &message)?))
+                    }
+
+                    MessageID::Headers | MessageID::Bodies | MessageID::StateChunk => {
+                        Ok(Message::Response(request_id, ResponseMessage::decode(id, &message)?))
+                    }
+                    _ => Err(DecoderError::Custom("Unknown message id detected")),
+                }
             }
         }
     }

--- a/types/src/errors/history_error.rs
+++ b/types/src/errors/history_error.rs
@@ -41,26 +41,50 @@ pub enum Error {
     },
 }
 
-const ERROR_ID_LIMIT_REACHED: u8 = 2;
-const ERROR_ID_OLD: u8 = 3;
-const ERROR_ID_TIMELOCKED: u8 = 5;
-const ERROR_ID_TOO_CHEAP_TO_REPLACE: u8 = 6;
-const ERROR_ID_TX_ALREADY_IMPORTED: u8 = 7;
-const ERROR_ID_TRANSFER_EXPIRED: u8 = 8;
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum ErrorID {
+    LimitReached = 2,
+    Old = 3,
+    Timelocked = 5,
+    TooCheapToReplace = 6,
+    TxAlreadyImported = 7,
+    TransferExpired = 8,
+}
+
+impl Encodable for ErrorID {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.append_single_value(&(*self as u8));
+    }
+}
+
+impl Decodable for ErrorID {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let tag = rlp.as_val()?;
+        match tag {
+            2u8 => Ok(ErrorID::LimitReached),
+            3 => Ok(ErrorID::Old),
+            5 => Ok(ErrorID::Timelocked),
+            6 => Ok(ErrorID::TooCheapToReplace),
+            7 => Ok(ErrorID::TxAlreadyImported),
+            8 => Ok(ErrorID::TransferExpired),
+            _ => Err(DecoderError::Custom("Unexpected ErrorID Value")),
+        }
+    }
+}
 
 struct RlpHelper;
 impl TaggedRlp for RlpHelper {
-    type Tag = u8;
+    type Tag = ErrorID;
 
-    fn length_of(tag: u8) -> Result<usize, DecoderError> {
+    fn length_of(tag: ErrorID) -> Result<usize, DecoderError> {
         Ok(match tag {
-            ERROR_ID_LIMIT_REACHED => 1,
-            ERROR_ID_OLD => 1,
-            ERROR_ID_TIMELOCKED => 3,
-            ERROR_ID_TOO_CHEAP_TO_REPLACE => 1,
-            ERROR_ID_TX_ALREADY_IMPORTED => 1,
-            ERROR_ID_TRANSFER_EXPIRED => 3,
-            _ => return Err(DecoderError::Custom("Invalid HistoryError")),
+            ErrorID::LimitReached => 1,
+            ErrorID::Old => 1,
+            ErrorID::Timelocked => 3,
+            ErrorID::TooCheapToReplace => 1,
+            ErrorID::TxAlreadyImported => 1,
+            ErrorID::TransferExpired => 3,
         })
     }
 }
@@ -68,39 +92,38 @@ impl TaggedRlp for RlpHelper {
 impl Encodable for Error {
     fn rlp_append(&self, s: &mut RlpStream) {
         match self {
-            Error::LimitReached => RlpHelper::new_tagged_list(s, ERROR_ID_LIMIT_REACHED),
-            Error::Old => RlpHelper::new_tagged_list(s, ERROR_ID_OLD),
+            Error::LimitReached => RlpHelper::new_tagged_list(s, ErrorID::LimitReached),
+            Error::Old => RlpHelper::new_tagged_list(s, ErrorID::Old),
             Error::Timelocked {
                 timelock,
                 remaining_time,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_TIMELOCKED).append(timelock).append(remaining_time),
-            Error::TooCheapToReplace => RlpHelper::new_tagged_list(s, ERROR_ID_TOO_CHEAP_TO_REPLACE),
-            Error::TransactionAlreadyImported => RlpHelper::new_tagged_list(s, ERROR_ID_TX_ALREADY_IMPORTED),
+            } => RlpHelper::new_tagged_list(s, ErrorID::Timelocked).append(timelock).append(remaining_time),
+            Error::TooCheapToReplace => RlpHelper::new_tagged_list(s, ErrorID::TooCheapToReplace),
+            Error::TransactionAlreadyImported => RlpHelper::new_tagged_list(s, ErrorID::TxAlreadyImported),
             Error::TransferExpired {
                 expiration,
                 timestamp,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_TRANSFER_EXPIRED).append(expiration).append(timestamp),
+            } => RlpHelper::new_tagged_list(s, ErrorID::TransferExpired).append(expiration).append(timestamp),
         };
     }
 }
 
 impl Decodable for Error {
     fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
-        let tag = rlp.val_at::<u8>(0)?;
+        let tag = rlp.val_at(0)?;
         let error = match tag {
-            ERROR_ID_LIMIT_REACHED => Error::LimitReached,
-            ERROR_ID_OLD => Error::Old,
-            ERROR_ID_TIMELOCKED => Error::Timelocked {
+            ErrorID::LimitReached => Error::LimitReached,
+            ErrorID::Old => Error::Old,
+            ErrorID::Timelocked => Error::Timelocked {
                 timelock: rlp.val_at(1)?,
                 remaining_time: rlp.val_at(2)?,
             },
-            ERROR_ID_TOO_CHEAP_TO_REPLACE => Error::TooCheapToReplace,
-            ERROR_ID_TX_ALREADY_IMPORTED => Error::TransactionAlreadyImported,
-            ERROR_ID_TRANSFER_EXPIRED => Error::TransferExpired {
+            ErrorID::TooCheapToReplace => Error::TooCheapToReplace,
+            ErrorID::TxAlreadyImported => Error::TransactionAlreadyImported,
+            ErrorID::TransferExpired => Error::TransferExpired {
                 expiration: rlp.val_at(1)?,
                 timestamp: rlp.val_at(2)?,
             },
-            _ => return Err(DecoderError::Custom("Invalid HistoryError")),
         };
         RlpHelper::check_size(rlp, tag)?;
         Ok(error)

--- a/types/src/errors/runtime_error.rs
+++ b/types/src/errors/runtime_error.rs
@@ -107,78 +107,124 @@ pub enum Error {
     },
 }
 
-const ERROR_ID_ASSET_NOT_FOUND: u8 = 1;
-const ERROR_ID_ASSET_SCHEME_DUPLICATED: u8 = 2;
-const ERROR_ID_ASSET_SCHEME_NOT_FOUND: u8 = 3;
-const ERROR_ID_CANNOT_BURN_REGULATED_ASSET: u8 = 4;
-/// Deprecated
-//const ERROR_ID_CANNOT_COMPOSE_REGULATED_ASSET: u8 = 5;
-const ERROR_ID_FAILED_TO_UNLOCK: u8 = 6;
-const ERROR_ID_INVALID_SEQ_OF_ASSET_SCHEME: u8 = 7;
-const ERROR_ID_INSUFFICIENT_BALANCE: u8 = 8;
-const ERROR_ID_INSUFFICIENT_PERMISSION: u8 = 9;
-const ERROR_ID_INVALID_ASSET_QUANTITY: u8 = 10;
-const ERROR_ID_UNEXPECTED_ASSET_TYPE: u8 = 11;
-/// Deprecated
-//const ERROR_ID_INVALID_DECOMPOSED_INPUT: u8 = 13;
-/// Deprecated
-//const ERROR_ID_INVALID_DECOMPOSED_OUTPUT: u8 = 14;
-const ERROR_ID_INVALID_SHARD_ID: u8 = 15;
-const ERROR_ID_INVALID_TRANSFER_DESTINATION: u8 = 16;
-const ERROR_ID_NEW_OWNERS_MUST_CONTAIN_SENDER: u8 = 17;
-const ERROR_ID_NOT_APPROVED: u8 = 18;
-const ERROR_ID_REGULAR_KEY_ALREADY_IN_USE: u8 = 19;
-const ERROR_ID_REGULAR_KEY_ALREADY_IN_USE_AS_PLATFORM: u8 = 20;
-const ERROR_ID_SCRIPT_HASH_MISMATCH: u8 = 21;
-const ERROR_ID_SCRIPT_NOT_ALLOWED: u8 = 22;
-const ERROR_ID_TEXT_NOT_EXIST: u8 = 23;
-const ERROR_ID_TEXT_VERIFICATION_FAIL: u8 = 24;
-const ERROR_ID_CANNOT_USE_MASTER_KEY: u8 = 25;
-const ERROR_ID_INVALID_SCRIPT: u8 = 27;
-const ERROR_ID_INVALID_SEQ: u8 = 28;
-const ERROR_ID_ASSET_SUPPLY_OVERFLOW: u8 = 29;
-const ERROR_ID_NON_ACTIVE_ACCOUNT: u8 = 30;
-const ERROR_ID_FAILED_TO_HANDLE_CUSTOM_ACTION: u8 = 31;
-const ERROR_ID_SIGNATURE_OF_INVALID_ACCOUNT: u8 = 32;
-const ERROR_ID_INSUFFICIENT_STAKES: u8 = 33;
-const ERROR_ID_INVALID_VALIDATOR_INDEX: u8 = 34;
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum ErrorID {
+    AssetNotFound = 1,
+    AssetSchemeDuplicated = 2,
+    AssetSchemeNotFound = 3,
+    CannotBurnRegulatedAsset = 4,
+    /// Deprecated
+    // CANNOT_COMPOSE_REGULATED_ASSET = 5,
+    FailedToUnlock = 6,
+    InvalidSeqOfAssetScheme = 7,
+    InsufficientBalance = 8,
+    InsufficientPermission = 9,
+    InvalidAssetQuantity = 10,
+    UnexpectedAssetType = 11,
+    /// Deprecated
+    // INVALID_DECOMPOSED_INPUT = 13,
+    // INVALID_DECOMPOSED_OUTPUT = 14,
+    InvalidShardID = 15,
+    InvalidTransferDestination = 16,
+    NewOwnersMustContainSender = 17,
+    NotApproved = 18,
+    RegularKeyAlreadyInUse = 19,
+    RegularKeyAlreadyInUseAsPlatform = 20,
+    ScriptHashMismatch = 21,
+    ScriptNotAllowed = 22,
+    TextNotExist = 23,
+    TextVerificationFail = 24,
+    CannotUseMasterKey = 25,
+    InvalidScript = 27,
+    InvalidSeq = 28,
+    AssetSupplyOverflow = 29,
+    NonActiveAccount = 30,
+    FailedToHandleCustomAction = 31,
+    SignatureOfInvalid = 32,
+    InsufficientStakes = 33,
+    InvalidValidatorIndex = 34,
+}
+
+impl Encodable for ErrorID {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.append_single_value(&(*self as u8));
+    }
+}
+
+impl Decodable for ErrorID {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let tag = rlp.as_val()?;
+        match tag {
+            1u8 => Ok(ErrorID::AssetNotFound),
+            2 => Ok(ErrorID::AssetSchemeDuplicated),
+            3 => Ok(ErrorID::AssetSchemeNotFound),
+            4 => Ok(ErrorID::InvalidSeqOfAssetScheme),
+            6 => Ok(ErrorID::AssetSupplyOverflow),
+            7 => Ok(ErrorID::CannotBurnRegulatedAsset),
+            8 => Ok(ErrorID::FailedToHandleCustomAction),
+            9 => Ok(ErrorID::FailedToUnlock),
+            10 => Ok(ErrorID::InsufficientBalance),
+            11 => Ok(ErrorID::InsufficientPermission),
+            15 => Ok(ErrorID::InvalidAssetQuantity),
+            16 => Ok(ErrorID::UnexpectedAssetType),
+            17 => Ok(ErrorID::InvalidScript),
+            18 => Ok(ErrorID::InvalidSeq),
+            19 => Ok(ErrorID::InvalidShardID),
+            20 => Ok(ErrorID::InvalidTransferDestination),
+            21 => Ok(ErrorID::NewOwnersMustContainSender),
+            22 => Ok(ErrorID::NotApproved),
+            23 => Ok(ErrorID::RegularKeyAlreadyInUse),
+            24 => Ok(ErrorID::RegularKeyAlreadyInUseAsPlatform),
+            25 => Ok(ErrorID::ScriptHashMismatch),
+            27 => Ok(ErrorID::ScriptNotAllowed),
+            28 => Ok(ErrorID::TextNotExist),
+            29 => Ok(ErrorID::TextVerificationFail),
+            30 => Ok(ErrorID::CannotUseMasterKey),
+            31 => Ok(ErrorID::NonActiveAccount),
+            32 => Ok(ErrorID::SignatureOfInvalid),
+            33 => Ok(ErrorID::InsufficientStakes),
+            34 => Ok(ErrorID::InvalidValidatorIndex),
+            _ => Err(DecoderError::Custom("Unexpected ActionTag Value")),
+        }
+    }
+}
 
 struct RlpHelper;
 impl TaggedRlp for RlpHelper {
-    type Tag = u8;
+    type Tag = ErrorID;
 
-    fn length_of(tag: u8) -> Result<usize, DecoderError> {
+    fn length_of(tag: ErrorID) -> Result<usize, DecoderError> {
         Ok(match tag {
-            ERROR_ID_ASSET_NOT_FOUND => 4,
-            ERROR_ID_ASSET_SCHEME_DUPLICATED => 3,
-            ERROR_ID_ASSET_SCHEME_NOT_FOUND => 3,
-            ERROR_ID_INVALID_SEQ_OF_ASSET_SCHEME => 5,
-            ERROR_ID_ASSET_SUPPLY_OVERFLOW => 1,
-            ERROR_ID_CANNOT_BURN_REGULATED_ASSET => 1,
-            ERROR_ID_FAILED_TO_HANDLE_CUSTOM_ACTION => 2,
-            ERROR_ID_FAILED_TO_UNLOCK => 5,
-            ERROR_ID_INSUFFICIENT_BALANCE => 4,
-            ERROR_ID_INSUFFICIENT_PERMISSION => 1,
-            ERROR_ID_INVALID_ASSET_QUANTITY => 6,
-            ERROR_ID_UNEXPECTED_ASSET_TYPE => 3,
-            ERROR_ID_INVALID_SCRIPT => 1,
-            ERROR_ID_INVALID_SEQ => 2,
-            ERROR_ID_INVALID_SHARD_ID => 2,
-            ERROR_ID_INVALID_TRANSFER_DESTINATION => 1,
-            ERROR_ID_NEW_OWNERS_MUST_CONTAIN_SENDER => 1,
-            ERROR_ID_NOT_APPROVED => 2,
-            ERROR_ID_REGULAR_KEY_ALREADY_IN_USE => 1,
-            ERROR_ID_REGULAR_KEY_ALREADY_IN_USE_AS_PLATFORM => 1,
-            ERROR_ID_SCRIPT_HASH_MISMATCH => 2,
-            ERROR_ID_SCRIPT_NOT_ALLOWED => 2,
-            ERROR_ID_TEXT_NOT_EXIST => 1,
-            ERROR_ID_TEXT_VERIFICATION_FAIL => 2,
-            ERROR_ID_CANNOT_USE_MASTER_KEY => 1,
-            ERROR_ID_NON_ACTIVE_ACCOUNT => 3,
-            ERROR_ID_SIGNATURE_OF_INVALID_ACCOUNT => 2,
-            ERROR_ID_INSUFFICIENT_STAKES => 3,
-            ERROR_ID_INVALID_VALIDATOR_INDEX => 3,
-            _ => return Err(DecoderError::Custom("Invalid RuntimeError")),
+            ErrorID::AssetNotFound => 4,
+            ErrorID::AssetSchemeDuplicated => 3,
+            ErrorID::AssetSchemeNotFound => 3,
+            ErrorID::InvalidSeqOfAssetScheme => 5,
+            ErrorID::AssetSupplyOverflow => 1,
+            ErrorID::CannotBurnRegulatedAsset => 1,
+            ErrorID::FailedToHandleCustomAction => 2,
+            ErrorID::FailedToUnlock => 5,
+            ErrorID::InsufficientBalance => 4,
+            ErrorID::InsufficientPermission => 1,
+            ErrorID::InvalidAssetQuantity => 6,
+            ErrorID::UnexpectedAssetType => 3,
+            ErrorID::InvalidScript => 1,
+            ErrorID::InvalidSeq => 2,
+            ErrorID::InvalidShardID => 2,
+            ErrorID::InvalidTransferDestination => 1,
+            ErrorID::NewOwnersMustContainSender => 1,
+            ErrorID::NotApproved => 2,
+            ErrorID::RegularKeyAlreadyInUse => 1,
+            ErrorID::RegularKeyAlreadyInUseAsPlatform => 1,
+            ErrorID::ScriptHashMismatch => 2,
+            ErrorID::ScriptNotAllowed => 2,
+            ErrorID::TextNotExist => 1,
+            ErrorID::TextVerificationFail => 2,
+            ErrorID::CannotUseMasterKey => 1,
+            ErrorID::NonActiveAccount => 3,
+            ErrorID::SignatureOfInvalid => 2,
+            ErrorID::InsufficientStakes => 3,
+            ErrorID::InvalidValidatorIndex => 3,
         })
     }
 }
@@ -190,36 +236,36 @@ impl Encodable for Error {
                 shard_id,
                 tracker,
                 index,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_ASSET_NOT_FOUND).append(shard_id).append(tracker).append(index),
+            } => RlpHelper::new_tagged_list(s, ErrorID::AssetNotFound).append(shard_id).append(tracker).append(index),
             Error::AssetSchemeDuplicated {
                 tracker,
                 shard_id,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_ASSET_SCHEME_DUPLICATED).append(tracker).append(shard_id),
+            } => RlpHelper::new_tagged_list(s, ErrorID::AssetSchemeDuplicated).append(tracker).append(shard_id),
             Error::AssetSchemeNotFound {
                 asset_type,
                 shard_id,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_ASSET_SCHEME_NOT_FOUND).append(asset_type).append(shard_id),
+            } => RlpHelper::new_tagged_list(s, ErrorID::AssetSchemeNotFound).append(asset_type).append(shard_id),
             Error::InvalidSeqOfAssetScheme {
                 asset_type,
                 shard_id,
                 expected,
                 actual,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_SEQ_OF_ASSET_SCHEME)
+            } => RlpHelper::new_tagged_list(s, ErrorID::InvalidSeqOfAssetScheme)
                 .append(asset_type)
                 .append(shard_id)
                 .append(expected)
                 .append(actual),
-            Error::AssetSupplyOverflow => RlpHelper::new_tagged_list(s, ERROR_ID_ASSET_SUPPLY_OVERFLOW),
-            Error::CannotBurnRegulatedAsset => RlpHelper::new_tagged_list(s, ERROR_ID_CANNOT_BURN_REGULATED_ASSET),
+            Error::AssetSupplyOverflow => RlpHelper::new_tagged_list(s, ErrorID::AssetSupplyOverflow),
+            Error::CannotBurnRegulatedAsset => RlpHelper::new_tagged_list(s, ErrorID::CannotBurnRegulatedAsset),
             Error::FailedToHandleCustomAction(detail) => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_FAILED_TO_HANDLE_CUSTOM_ACTION).append(detail)
+                RlpHelper::new_tagged_list(s, ErrorID::FailedToHandleCustomAction).append(detail)
             }
             Error::FailedToUnlock {
                 shard_id,
                 tracker,
                 index,
                 reason,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_FAILED_TO_UNLOCK)
+            } => RlpHelper::new_tagged_list(s, ErrorID::FailedToUnlock)
                 .append(shard_id)
                 .append(tracker)
                 .append(index)
@@ -228,18 +274,17 @@ impl Encodable for Error {
                 address,
                 balance,
                 cost,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_INSUFFICIENT_BALANCE)
-                .append(address)
-                .append(balance)
-                .append(cost),
-            Error::InsufficientPermission => RlpHelper::new_tagged_list(s, ERROR_ID_INSUFFICIENT_PERMISSION),
+            } => {
+                RlpHelper::new_tagged_list(s, ErrorID::InsufficientBalance).append(address).append(balance).append(cost)
+            }
+            Error::InsufficientPermission => RlpHelper::new_tagged_list(s, ErrorID::InsufficientPermission),
             Error::InvalidAssetQuantity {
                 shard_id,
                 tracker,
                 index,
                 expected,
                 got,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_ASSET_QUANTITY)
+            } => RlpHelper::new_tagged_list(s, ErrorID::InvalidAssetQuantity)
                 .append(shard_id)
                 .append(tracker)
                 .append(index)
@@ -248,123 +293,120 @@ impl Encodable for Error {
             Error::UnexpectedAssetType {
                 index,
                 mismatch,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_UNEXPECTED_ASSET_TYPE).append(index).append(mismatch),
-            Error::InvalidScript => RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_SCRIPT),
-            Error::InvalidSeq(mismatch) => RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_SEQ).append(mismatch),
-            Error::InvalidShardId(shard_id) => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_SHARD_ID).append(shard_id)
-            }
-            Error::InvalidTransferDestination => RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_TRANSFER_DESTINATION),
-            Error::NewOwnersMustContainSender => RlpHelper::new_tagged_list(s, ERROR_ID_NEW_OWNERS_MUST_CONTAIN_SENDER),
-            Error::NotApproved(address) => RlpHelper::new_tagged_list(s, ERROR_ID_NOT_APPROVED).append(address),
-            Error::RegularKeyAlreadyInUse => RlpHelper::new_tagged_list(s, ERROR_ID_REGULAR_KEY_ALREADY_IN_USE),
+            } => RlpHelper::new_tagged_list(s, ErrorID::UnexpectedAssetType).append(index).append(mismatch),
+            Error::InvalidScript => RlpHelper::new_tagged_list(s, ErrorID::InvalidScript),
+            Error::InvalidSeq(mismatch) => RlpHelper::new_tagged_list(s, ErrorID::InvalidSeq).append(mismatch),
+            Error::InvalidShardId(shard_id) => RlpHelper::new_tagged_list(s, ErrorID::InvalidShardID).append(shard_id),
+            Error::InvalidTransferDestination => RlpHelper::new_tagged_list(s, ErrorID::InvalidTransferDestination),
+            Error::NewOwnersMustContainSender => RlpHelper::new_tagged_list(s, ErrorID::NewOwnersMustContainSender),
+            Error::NotApproved(address) => RlpHelper::new_tagged_list(s, ErrorID::NotApproved).append(address),
+            Error::RegularKeyAlreadyInUse => RlpHelper::new_tagged_list(s, ErrorID::RegularKeyAlreadyInUse),
             Error::RegularKeyAlreadyInUseAsPlatformAccount => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_REGULAR_KEY_ALREADY_IN_USE_AS_PLATFORM)
+                RlpHelper::new_tagged_list(s, ErrorID::RegularKeyAlreadyInUseAsPlatform)
             }
             Error::ScriptHashMismatch(mismatch) => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_SCRIPT_HASH_MISMATCH).append(mismatch)
+                RlpHelper::new_tagged_list(s, ErrorID::ScriptHashMismatch).append(mismatch)
             }
-            Error::ScriptNotAllowed(hash) => RlpHelper::new_tagged_list(s, ERROR_ID_SCRIPT_NOT_ALLOWED).append(hash),
-            Error::TextNotExist => RlpHelper::new_tagged_list(s, ERROR_ID_TEXT_NOT_EXIST),
+            Error::ScriptNotAllowed(hash) => RlpHelper::new_tagged_list(s, ErrorID::ScriptNotAllowed).append(hash),
+            Error::TextNotExist => RlpHelper::new_tagged_list(s, ErrorID::TextNotExist),
             Error::TextVerificationFail(err) => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_TEXT_VERIFICATION_FAIL).append(err)
+                RlpHelper::new_tagged_list(s, ErrorID::TextVerificationFail).append(err)
             }
-            Error::CannotUseMasterKey => RlpHelper::new_tagged_list(s, ERROR_ID_CANNOT_USE_MASTER_KEY),
+            Error::CannotUseMasterKey => RlpHelper::new_tagged_list(s, ErrorID::CannotUseMasterKey),
             Error::NonActiveAccount {
                 address,
                 name,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_NON_ACTIVE_ACCOUNT).append(address).append(name),
+            } => RlpHelper::new_tagged_list(s, ErrorID::NonActiveAccount).append(address).append(name),
             Error::SignatureOfInvalidAccount(address) => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_SIGNATURE_OF_INVALID_ACCOUNT).append(address)
+                RlpHelper::new_tagged_list(s, ErrorID::SignatureOfInvalid).append(address)
             }
             Error::InsufficientStakes(Mismatch {
                 expected,
                 found,
-            }) => RlpHelper::new_tagged_list(s, ERROR_ID_INSUFFICIENT_STAKES).append(expected).append(found),
+            }) => RlpHelper::new_tagged_list(s, ErrorID::InsufficientStakes).append(expected).append(found),
             Error::InvalidValidatorIndex {
                 idx,
                 parent_height,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_VALIDATOR_INDEX).append(idx).append(parent_height),
+            } => RlpHelper::new_tagged_list(s, ErrorID::InvalidValidatorIndex).append(idx).append(parent_height),
         };
     }
 }
 
 impl Decodable for Error {
     fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
-        let tag = rlp.val_at::<u8>(0)?;
+        let tag = rlp.val_at(0)?;
         let error = match tag {
-            ERROR_ID_ASSET_NOT_FOUND => Error::AssetNotFound {
+            ErrorID::AssetNotFound => Error::AssetNotFound {
                 shard_id: rlp.val_at(1)?,
                 tracker: rlp.val_at(2)?,
                 index: rlp.val_at(3)?,
             },
-            ERROR_ID_ASSET_SCHEME_DUPLICATED => Error::AssetSchemeDuplicated {
+            ErrorID::AssetSchemeDuplicated => Error::AssetSchemeDuplicated {
                 tracker: rlp.val_at(1)?,
                 shard_id: rlp.val_at(2)?,
             },
-            ERROR_ID_ASSET_SCHEME_NOT_FOUND => Error::AssetSchemeNotFound {
+            ErrorID::AssetSchemeNotFound => Error::AssetSchemeNotFound {
                 asset_type: rlp.val_at(1)?,
                 shard_id: rlp.val_at(2)?,
             },
-            ERROR_ID_INVALID_SEQ_OF_ASSET_SCHEME => Error::InvalidSeqOfAssetScheme {
+            ErrorID::InvalidSeqOfAssetScheme => Error::InvalidSeqOfAssetScheme {
                 asset_type: rlp.val_at(1)?,
                 shard_id: rlp.val_at(2)?,
                 expected: rlp.val_at(3)?,
                 actual: rlp.val_at(4)?,
             },
-            ERROR_ID_ASSET_SUPPLY_OVERFLOW => Error::AssetSupplyOverflow,
-            ERROR_ID_CANNOT_BURN_REGULATED_ASSET => Error::CannotBurnRegulatedAsset,
-            ERROR_ID_FAILED_TO_HANDLE_CUSTOM_ACTION => Error::FailedToHandleCustomAction(rlp.val_at(1)?),
-            ERROR_ID_FAILED_TO_UNLOCK => Error::FailedToUnlock {
+            ErrorID::AssetSupplyOverflow => Error::AssetSupplyOverflow,
+            ErrorID::CannotBurnRegulatedAsset => Error::CannotBurnRegulatedAsset,
+            ErrorID::FailedToHandleCustomAction => Error::FailedToHandleCustomAction(rlp.val_at(1)?),
+            ErrorID::FailedToUnlock => Error::FailedToUnlock {
                 shard_id: rlp.val_at(1)?,
                 tracker: rlp.val_at(2)?,
                 index: rlp.val_at(3)?,
                 reason: rlp.val_at(4)?,
             },
-            ERROR_ID_INSUFFICIENT_BALANCE => Error::InsufficientBalance {
+            ErrorID::InsufficientBalance => Error::InsufficientBalance {
                 address: rlp.val_at(1)?,
                 balance: rlp.val_at(2)?,
                 cost: rlp.val_at(3)?,
             },
-            ERROR_ID_INSUFFICIENT_PERMISSION => Error::InsufficientPermission,
-            ERROR_ID_INVALID_ASSET_QUANTITY => Error::InvalidAssetQuantity {
+            ErrorID::InsufficientPermission => Error::InsufficientPermission,
+            ErrorID::InvalidAssetQuantity => Error::InvalidAssetQuantity {
                 shard_id: rlp.val_at(1)?,
                 tracker: rlp.val_at(2)?,
                 index: rlp.val_at(3)?,
                 expected: rlp.val_at(4)?,
                 got: rlp.val_at(5)?,
             },
-            ERROR_ID_UNEXPECTED_ASSET_TYPE => Error::UnexpectedAssetType {
+            ErrorID::UnexpectedAssetType => Error::UnexpectedAssetType {
                 index: rlp.val_at(1)?,
                 mismatch: rlp.val_at(2)?,
             },
-            ERROR_ID_INVALID_SCRIPT => Error::InvalidScript,
-            ERROR_ID_INVALID_SEQ => Error::InvalidSeq(rlp.val_at(1)?),
-            ERROR_ID_INVALID_SHARD_ID => Error::InvalidShardId(rlp.val_at(1)?),
-            ERROR_ID_INVALID_TRANSFER_DESTINATION => Error::InvalidTransferDestination,
-            ERROR_ID_NEW_OWNERS_MUST_CONTAIN_SENDER => Error::NewOwnersMustContainSender,
-            ERROR_ID_NOT_APPROVED => Error::NotApproved(rlp.val_at(1)?),
-            ERROR_ID_REGULAR_KEY_ALREADY_IN_USE => Error::RegularKeyAlreadyInUse,
-            ERROR_ID_REGULAR_KEY_ALREADY_IN_USE_AS_PLATFORM => Error::RegularKeyAlreadyInUseAsPlatformAccount,
-            ERROR_ID_SCRIPT_HASH_MISMATCH => Error::ScriptHashMismatch(rlp.val_at(1)?),
-            ERROR_ID_SCRIPT_NOT_ALLOWED => Error::ScriptNotAllowed(rlp.val_at(1)?),
-            ERROR_ID_TEXT_NOT_EXIST => Error::TextNotExist,
-            ERROR_ID_TEXT_VERIFICATION_FAIL => Error::TextVerificationFail(rlp.val_at(1)?),
-            ERROR_ID_CANNOT_USE_MASTER_KEY => Error::CannotUseMasterKey,
-            ERROR_ID_NON_ACTIVE_ACCOUNT => Error::NonActiveAccount {
+            ErrorID::InvalidScript => Error::InvalidScript,
+            ErrorID::InvalidSeq => Error::InvalidSeq(rlp.val_at(1)?),
+            ErrorID::InvalidShardID => Error::InvalidShardId(rlp.val_at(1)?),
+            ErrorID::InvalidTransferDestination => Error::InvalidTransferDestination,
+            ErrorID::NewOwnersMustContainSender => Error::NewOwnersMustContainSender,
+            ErrorID::NotApproved => Error::NotApproved(rlp.val_at(1)?),
+            ErrorID::RegularKeyAlreadyInUse => Error::RegularKeyAlreadyInUse,
+            ErrorID::RegularKeyAlreadyInUseAsPlatform => Error::RegularKeyAlreadyInUseAsPlatformAccount,
+            ErrorID::ScriptHashMismatch => Error::ScriptHashMismatch(rlp.val_at(1)?),
+            ErrorID::ScriptNotAllowed => Error::ScriptNotAllowed(rlp.val_at(1)?),
+            ErrorID::TextNotExist => Error::TextNotExist,
+            ErrorID::TextVerificationFail => Error::TextVerificationFail(rlp.val_at(1)?),
+            ErrorID::CannotUseMasterKey => Error::CannotUseMasterKey,
+            ErrorID::NonActiveAccount => Error::NonActiveAccount {
                 address: rlp.val_at(1)?,
                 name: rlp.val_at(2)?,
             },
-            ERROR_ID_SIGNATURE_OF_INVALID_ACCOUNT => Error::SignatureOfInvalidAccount(rlp.val_at(1)?),
-            ERROR_ID_INSUFFICIENT_STAKES => Error::InsufficientStakes(Mismatch {
+            ErrorID::SignatureOfInvalid => Error::SignatureOfInvalidAccount(rlp.val_at(1)?),
+            ErrorID::InsufficientStakes => Error::InsufficientStakes(Mismatch {
                 expected: rlp.val_at(1)?,
                 found: rlp.val_at(2)?,
             }),
-            ERROR_ID_INVALID_VALIDATOR_INDEX => Error::InvalidValidatorIndex {
+            ErrorID::InvalidValidatorIndex => Error::InvalidValidatorIndex {
                 idx: rlp.val_at(1)?,
                 parent_height: rlp.val_at(2)?,
             },
-            _ => return Err(DecoderError::Custom("Invalid RuntimeError")),
         };
         RlpHelper::check_size(rlp, tag)?;
         Ok(error)
@@ -455,16 +497,38 @@ pub enum UnlockFailureReason {
     ScriptError,
 }
 
-const FAILURE_REASON_ID_SCRIPT_SHOULD_BE_BURNT: u8 = 1u8;
-const FAILURE_REASON_ID_SCRIPT_SHOULD_NOT_BE_BURNT: u8 = 2u8;
-const FAILURE_REASON_ID_SCRIPT_ERROR: u8 = 3u8;
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum ScriptFailureReasonID {
+    ShouldBeBurnt = 1u8,
+    ShouldNotBeBurnt = 2u8,
+    Error = 3u8,
+}
+
+impl Encodable for ScriptFailureReasonID {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.append_single_value(&(*self as u8));
+    }
+}
+
+impl Decodable for ScriptFailureReasonID {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let tag = rlp.as_val()?;
+        match tag {
+            1u8 => Ok(ScriptFailureReasonID::ShouldBeBurnt),
+            2 => Ok(ScriptFailureReasonID::ShouldNotBeBurnt),
+            3 => Ok(ScriptFailureReasonID::Error),
+            _ => Err(DecoderError::Custom("Unexpected ScriptFailureReasonID Value")),
+        }
+    }
+}
 
 impl Encodable for UnlockFailureReason {
     fn rlp_append(&self, s: &mut RlpStream) {
         match self {
-            UnlockFailureReason::ScriptShouldBeBurnt => FAILURE_REASON_ID_SCRIPT_SHOULD_BE_BURNT.rlp_append(s),
-            UnlockFailureReason::ScriptShouldNotBeBurnt => FAILURE_REASON_ID_SCRIPT_SHOULD_NOT_BE_BURNT.rlp_append(s),
-            UnlockFailureReason::ScriptError => FAILURE_REASON_ID_SCRIPT_ERROR.rlp_append(s),
+            UnlockFailureReason::ScriptShouldBeBurnt => (ScriptFailureReasonID::ShouldBeBurnt).rlp_append(s),
+            UnlockFailureReason::ScriptShouldNotBeBurnt => (ScriptFailureReasonID::ShouldNotBeBurnt).rlp_append(s),
+            UnlockFailureReason::ScriptError => (ScriptFailureReasonID::Error).rlp_append(s),
         };
     }
 }
@@ -472,10 +536,9 @@ impl Encodable for UnlockFailureReason {
 impl Decodable for UnlockFailureReason {
     fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         Ok(match Decodable::decode(rlp)? {
-            FAILURE_REASON_ID_SCRIPT_SHOULD_BE_BURNT => UnlockFailureReason::ScriptShouldBeBurnt,
-            FAILURE_REASON_ID_SCRIPT_SHOULD_NOT_BE_BURNT => UnlockFailureReason::ScriptShouldNotBeBurnt,
-            FAILURE_REASON_ID_SCRIPT_ERROR => UnlockFailureReason::ScriptError,
-            _ => return Err(DecoderError::Custom("Invalid failure reason tag")),
+            ScriptFailureReasonID::ShouldBeBurnt => UnlockFailureReason::ScriptShouldBeBurnt,
+            ScriptFailureReasonID::ShouldNotBeBurnt => UnlockFailureReason::ScriptShouldNotBeBurnt,
+            ScriptFailureReasonID::Error => UnlockFailureReason::ScriptError,
         })
     }
 }

--- a/types/src/errors/syntax_error.rs
+++ b/types/src/errors/syntax_error.rs
@@ -57,52 +57,87 @@ pub enum Error {
     InvalidSignerOfWrapCCC,
 }
 
-const ERORR_ID_DUPLICATED_PREVIOUS_OUTPUT: u8 = 1;
-/// Deprecated
-//const ERROR_ID_EMPTY_INPUT: u8 = 2;
-//const ERROR_ID_EMPTY_OUTPUT: u8 = 3;
-const ERROR_ID_EMPTY_SHARD_OWNERS: u8 = 4;
-const ERROR_ID_INCONSISTENT_TRANSACTION_IN_OUT: u8 = 5;
-const ERROR_ID_INSUFFICIENT_FEE: u8 = 7;
-const ERROR_ID_INVALID_ASSET_TYPE: u8 = 8;
-/// Deprecated
-//const ERROR_ID_INVALID_COMPOSED_OUTPUT_AMOUNT: u8 = 9;
-//const ERROR_ID_INVALID_DECOMPOSED_INPUT_AMOUNT: u8 = 10;
-const ERROR_ID_INVALID_NETWORK_ID: u8 = 11;
-const ERROR_ID_INVALID_APPROVAL: u8 = 21;
-const ERROR_ID_METADATA_TOO_BIG: u8 = 22;
-const ERROR_ID_TEXT_CONTENT_TOO_BIG: u8 = 24;
-const ERROR_ID_TOO_MANY_OUTPUTS: u8 = 26;
-const ERROR_ID_TX_IS_TOO_BIG: u8 = 27;
-const ERROR_ID_ZERO_QUANTITY: u8 = 28;
-const ERROR_ID_CANNOT_CHANGE_WCCC_ASSET_SCHEME: u8 = 29;
-const ERROR_ID_DISABLED_TRANSACTION: u8 = 30;
-const ERROR_ID_INVALID_SIGNER_OF_WRAP_CCC: u8 = 31;
-const ERROR_ID_INVALID_CUSTOM_ACTION: u8 = 32;
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum ErrorID {
+    DuplicatedPreviousOutput = 1,
+    /// Deprecated
+    // EMPTY_INPUT = 2,
+    // EMPTY_OUTPUT = 3,
+    EmptyShardOwners = 4,
+    InconsistentTransactionInOut = 5,
+    InsufficientFee = 7,
+    InvalidAssetType = 8,
+    /// Deprecated
+    // INVALID_COMPOSED_OUTPUT_AMOUNT = 9,
+    // INVALID_DECOMPOSED_INPUT_AMOUNT = 10,
+    InvalidNetworkID = 11,
+    InvalidApproval = 21,
+    MetadataTooBig = 22,
+    TextContentTooBig = 24,
+    TooManyOutputs = 26,
+    TxIsTooBig = 27,
+    ZeroQuantity = 28,
+    CannotChangeWCCCAssetScheme = 29,
+    DisabledTransaction = 30,
+    InvalidSignerOfWRAPCCC = 31,
+    InvalidCustomAction = 32,
+}
+
+impl Encodable for ErrorID {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.append_single_value(&(*self as u8));
+    }
+}
+
+impl Decodable for ErrorID {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let tag = rlp.as_val()?;
+        match tag {
+            1u8 => Ok(ErrorID::DuplicatedPreviousOutput),
+            4 => Ok(ErrorID::EmptyShardOwners),
+            5 => Ok(ErrorID::InconsistentTransactionInOut),
+            7 => Ok(ErrorID::InsufficientFee),
+            8 => Ok(ErrorID::InvalidAssetType),
+            11 => Ok(ErrorID::InvalidNetworkID),
+            21 => Ok(ErrorID::InvalidApproval),
+            22 => Ok(ErrorID::MetadataTooBig),
+            24 => Ok(ErrorID::TextContentTooBig),
+            26 => Ok(ErrorID::TooManyOutputs),
+            27 => Ok(ErrorID::TxIsTooBig),
+            28 => Ok(ErrorID::ZeroQuantity),
+            29 => Ok(ErrorID::CannotChangeWCCCAssetScheme),
+            30 => Ok(ErrorID::DisabledTransaction),
+            31 => Ok(ErrorID::InvalidSignerOfWRAPCCC),
+            32 => Ok(ErrorID::InvalidCustomAction),
+            _ => Err(DecoderError::Custom("Unexpected ErrorID Value")),
+        }
+    }
+}
+
 
 struct RlpHelper;
 impl TaggedRlp for RlpHelper {
-    type Tag = u8;
+    type Tag = ErrorID;
 
-    fn length_of(tag: u8) -> Result<usize, DecoderError> {
+    fn length_of(tag: ErrorID) -> Result<usize, DecoderError> {
         Ok(match tag {
-            ERORR_ID_DUPLICATED_PREVIOUS_OUTPUT => 3,
-            ERROR_ID_EMPTY_SHARD_OWNERS => 2,
-            ERROR_ID_INCONSISTENT_TRANSACTION_IN_OUT => 1,
-            ERROR_ID_INSUFFICIENT_FEE => 3,
-            ERROR_ID_INVALID_ASSET_TYPE => 2,
-            ERROR_ID_INVALID_CUSTOM_ACTION => 2,
-            ERROR_ID_INVALID_NETWORK_ID => 2,
-            ERROR_ID_INVALID_APPROVAL => 2,
-            ERROR_ID_METADATA_TOO_BIG => 1,
-            ERROR_ID_TEXT_CONTENT_TOO_BIG => 1,
-            ERROR_ID_TOO_MANY_OUTPUTS => 2,
-            ERROR_ID_TX_IS_TOO_BIG => 1,
-            ERROR_ID_ZERO_QUANTITY => 1,
-            ERROR_ID_CANNOT_CHANGE_WCCC_ASSET_SCHEME => 1,
-            ERROR_ID_DISABLED_TRANSACTION => 1,
-            ERROR_ID_INVALID_SIGNER_OF_WRAP_CCC => 1,
-            _ => return Err(DecoderError::Custom("Invalid SyntaxError")),
+            ErrorID::DuplicatedPreviousOutput => 3,
+            ErrorID::EmptyShardOwners => 2,
+            ErrorID::InconsistentTransactionInOut => 1,
+            ErrorID::InsufficientFee => 3,
+            ErrorID::InvalidAssetType => 2,
+            ErrorID::InvalidCustomAction => 2,
+            ErrorID::InvalidNetworkID => 2,
+            ErrorID::InvalidApproval => 2,
+            ErrorID::MetadataTooBig => 1,
+            ErrorID::TextContentTooBig => 1,
+            ErrorID::TooManyOutputs => 2,
+            ErrorID::TxIsTooBig => 1,
+            ErrorID::ZeroQuantity => 1,
+            ErrorID::CannotChangeWCCCAssetScheme => 1,
+            ErrorID::DisabledTransaction => 1,
+            ErrorID::InvalidSignerOfWRAPCCC => 1,
         })
     }
 }
@@ -113,66 +148,59 @@ impl Encodable for Error {
             Error::DuplicatedPreviousOutput {
                 tracker,
                 index,
-            } => RlpHelper::new_tagged_list(s, ERORR_ID_DUPLICATED_PREVIOUS_OUTPUT).append(tracker).append(index),
+            } => RlpHelper::new_tagged_list(s, ErrorID::DuplicatedPreviousOutput).append(tracker).append(index),
             Error::EmptyShardOwners(shard_id) => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_EMPTY_SHARD_OWNERS).append(shard_id)
+                RlpHelper::new_tagged_list(s, ErrorID::EmptyShardOwners).append(shard_id)
             }
-            Error::InconsistentTransactionInOut => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_INCONSISTENT_TRANSACTION_IN_OUT)
-            }
+            Error::InconsistentTransactionInOut => RlpHelper::new_tagged_list(s, ErrorID::InconsistentTransactionInOut),
             Error::InsufficientFee {
                 minimal,
                 got,
-            } => RlpHelper::new_tagged_list(s, ERROR_ID_INSUFFICIENT_FEE).append(minimal).append(got),
-            Error::InvalidAssetType(addr) => RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_ASSET_TYPE).append(addr),
-            Error::InvalidCustomAction(err) => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_CUSTOM_ACTION).append(err)
-            }
+            } => RlpHelper::new_tagged_list(s, ErrorID::InsufficientFee).append(minimal).append(got),
+            Error::InvalidAssetType(addr) => RlpHelper::new_tagged_list(s, ErrorID::InvalidAssetType).append(addr),
+            Error::InvalidCustomAction(err) => RlpHelper::new_tagged_list(s, ErrorID::InvalidCustomAction).append(err),
             Error::InvalidNetworkId(network_id) => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_NETWORK_ID).append(network_id)
+                RlpHelper::new_tagged_list(s, ErrorID::InvalidNetworkID).append(network_id)
             }
-            Error::InvalidApproval(err) => RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_APPROVAL).append(err),
-            Error::MetadataTooBig => RlpHelper::new_tagged_list(s, ERROR_ID_METADATA_TOO_BIG),
-            Error::TextContentTooBig => RlpHelper::new_tagged_list(s, ERROR_ID_TEXT_CONTENT_TOO_BIG),
-            Error::TooManyOutputs(num) => RlpHelper::new_tagged_list(s, ERROR_ID_TOO_MANY_OUTPUTS).append(num),
-            Error::TransactionIsTooBig => RlpHelper::new_tagged_list(s, ERROR_ID_TX_IS_TOO_BIG),
-            Error::ZeroQuantity => RlpHelper::new_tagged_list(s, ERROR_ID_ZERO_QUANTITY),
-            Error::CannotChangeWcccAssetScheme => {
-                RlpHelper::new_tagged_list(s, ERROR_ID_CANNOT_CHANGE_WCCC_ASSET_SCHEME)
-            }
-            Error::DisabledTransaction => RlpHelper::new_tagged_list(s, ERROR_ID_DISABLED_TRANSACTION),
-            Error::InvalidSignerOfWrapCCC => RlpHelper::new_tagged_list(s, ERROR_ID_INVALID_SIGNER_OF_WRAP_CCC),
+            Error::InvalidApproval(err) => RlpHelper::new_tagged_list(s, ErrorID::InvalidApproval).append(err),
+            Error::MetadataTooBig => RlpHelper::new_tagged_list(s, ErrorID::MetadataTooBig),
+            Error::TextContentTooBig => RlpHelper::new_tagged_list(s, ErrorID::TextContentTooBig),
+            Error::TooManyOutputs(num) => RlpHelper::new_tagged_list(s, ErrorID::TooManyOutputs).append(num),
+            Error::TransactionIsTooBig => RlpHelper::new_tagged_list(s, ErrorID::TxIsTooBig),
+            Error::ZeroQuantity => RlpHelper::new_tagged_list(s, ErrorID::ZeroQuantity),
+            Error::CannotChangeWcccAssetScheme => RlpHelper::new_tagged_list(s, ErrorID::CannotChangeWCCCAssetScheme),
+            Error::DisabledTransaction => RlpHelper::new_tagged_list(s, ErrorID::DisabledTransaction),
+            Error::InvalidSignerOfWrapCCC => RlpHelper::new_tagged_list(s, ErrorID::InvalidSignerOfWRAPCCC),
         };
     }
 }
 
 impl Decodable for Error {
     fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
-        let tag = rlp.val_at::<u8>(0)?;
+        let tag = rlp.val_at(0)?;
         let error = match tag {
-            ERORR_ID_DUPLICATED_PREVIOUS_OUTPUT => Error::DuplicatedPreviousOutput {
+            ErrorID::DuplicatedPreviousOutput => Error::DuplicatedPreviousOutput {
                 tracker: rlp.val_at(1)?,
                 index: rlp.val_at(2)?,
             },
-            ERROR_ID_EMPTY_SHARD_OWNERS => Error::EmptyShardOwners(rlp.val_at(1)?),
-            ERROR_ID_INCONSISTENT_TRANSACTION_IN_OUT => Error::InconsistentTransactionInOut,
-            ERROR_ID_INSUFFICIENT_FEE => Error::InsufficientFee {
+            ErrorID::EmptyShardOwners => Error::EmptyShardOwners(rlp.val_at(1)?),
+            ErrorID::InconsistentTransactionInOut => Error::InconsistentTransactionInOut,
+            ErrorID::InsufficientFee => Error::InsufficientFee {
                 minimal: rlp.val_at(1)?,
                 got: rlp.val_at(2)?,
             },
-            ERROR_ID_INVALID_ASSET_TYPE => Error::InvalidAssetType(rlp.val_at(1)?),
-            ERROR_ID_INVALID_CUSTOM_ACTION => Error::InvalidCustomAction(rlp.val_at(1)?),
-            ERROR_ID_INVALID_NETWORK_ID => Error::InvalidNetworkId(rlp.val_at(1)?),
-            ERROR_ID_INVALID_APPROVAL => Error::InvalidApproval(rlp.val_at(1)?),
-            ERROR_ID_METADATA_TOO_BIG => Error::MetadataTooBig,
-            ERROR_ID_TEXT_CONTENT_TOO_BIG => Error::TextContentTooBig,
-            ERROR_ID_TOO_MANY_OUTPUTS => Error::TooManyOutputs(rlp.val_at(1)?),
-            ERROR_ID_TX_IS_TOO_BIG => Error::TransactionIsTooBig,
-            ERROR_ID_ZERO_QUANTITY => Error::ZeroQuantity,
-            ERROR_ID_CANNOT_CHANGE_WCCC_ASSET_SCHEME => Error::CannotChangeWcccAssetScheme,
-            ERROR_ID_DISABLED_TRANSACTION => Error::DisabledTransaction,
-            ERROR_ID_INVALID_SIGNER_OF_WRAP_CCC => Error::InvalidSignerOfWrapCCC,
-            _ => return Err(DecoderError::Custom("Invalid SyntaxError")),
+            ErrorID::InvalidAssetType => Error::InvalidAssetType(rlp.val_at(1)?),
+            ErrorID::InvalidCustomAction => Error::InvalidCustomAction(rlp.val_at(1)?),
+            ErrorID::InvalidNetworkID => Error::InvalidNetworkId(rlp.val_at(1)?),
+            ErrorID::InvalidApproval => Error::InvalidApproval(rlp.val_at(1)?),
+            ErrorID::MetadataTooBig => Error::MetadataTooBig,
+            ErrorID::TextContentTooBig => Error::TextContentTooBig,
+            ErrorID::TooManyOutputs => Error::TooManyOutputs(rlp.val_at(1)?),
+            ErrorID::TxIsTooBig => Error::TransactionIsTooBig,
+            ErrorID::ZeroQuantity => Error::ZeroQuantity,
+            ErrorID::CannotChangeWCCCAssetScheme => Error::CannotChangeWcccAssetScheme,
+            ErrorID::DisabledTransaction => Error::DisabledTransaction,
+            ErrorID::InvalidSignerOfWRAPCCC => Error::InvalidSignerOfWrapCCC,
         };
         RlpHelper::check_size(rlp, tag)?;
         Ok(error)

--- a/vm/src/decoder.rs
+++ b/vm/src/decoder.rs
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+use crate::executor::TimelockType;
 use crate::instruction::Instruction;
 use crate::opcode;
 
@@ -80,10 +80,15 @@ pub fn decode(bytes: &[u8]) -> Result<Vec<Instruction>, DecoderError> {
             opcode::BLAKE160 => result.push(Instruction::Blake160),
             opcode::CHKTIMELOCK => {
                 let val = *iter.next().ok_or(DecoderError::ScriptTooShort)?;
-                if val < 1 || val > 4 {
-                    return Err(DecoderError::InvalidImmediateValue(val))
+                let timelock_type: TimelockType;
+                match val {
+                    1 => timelock_type = TimelockType::Block,
+                    2 => timelock_type = TimelockType::BlockAge,
+                    3 => timelock_type = TimelockType::Time,
+                    4 => timelock_type = TimelockType::TimeAge,
+                    _ => return Err(DecoderError::InvalidImmediateValue(val)),
                 }
-                result.push(Instruction::ChkTimelock(val));
+                result.push(Instruction::ChkTimelock(timelock_type));
             }
             invalid_opcode => return Err(DecoderError::InvalidOpCode(invalid_opcode)),
         }
@@ -166,14 +171,14 @@ mod tests {
         assert_eq!(decode(&[opcode::CHKTIMELOCK]), Err(DecoderError::ScriptTooShort));
         assert_eq!(decode(&[opcode::CHKTIMELOCK, 0]), Err(DecoderError::InvalidImmediateValue(0)));
         assert_eq!(decode(&[opcode::CHKTIMELOCK, 5]), Err(DecoderError::InvalidImmediateValue(5)));
-        assert_eq!(decode(&[opcode::CHKTIMELOCK, 1]), Ok(vec![Instruction::ChkTimelock(1)]));
-        assert_eq!(decode(&[opcode::CHKTIMELOCK, 2]), Ok(vec![Instruction::ChkTimelock(2)]));
-        assert_eq!(decode(&[opcode::CHKTIMELOCK, 3]), Ok(vec![Instruction::ChkTimelock(3)]));
-        assert_eq!(decode(&[opcode::CHKTIMELOCK, 4]), Ok(vec![Instruction::ChkTimelock(4)]));
+        assert_eq!(decode(&[opcode::CHKTIMELOCK, 1]), Ok(vec![Instruction::ChkTimelock(TimelockType::Block)]));
+        assert_eq!(decode(&[opcode::CHKTIMELOCK, 2]), Ok(vec![Instruction::ChkTimelock(TimelockType::BlockAge)]));
+        assert_eq!(decode(&[opcode::CHKTIMELOCK, 3]), Ok(vec![Instruction::ChkTimelock(TimelockType::Time)]));
+        assert_eq!(decode(&[opcode::CHKTIMELOCK, 4]), Ok(vec![Instruction::ChkTimelock(TimelockType::TimeAge)]));
         assert_eq!(decode(&[opcode::CHKTIMELOCK, 1, opcode::CHKTIMELOCK]), Err(DecoderError::ScriptTooShort));
         assert_eq!(
             decode(&[opcode::CHKTIMELOCK, 1, opcode::CHKTIMELOCK, 2]),
-            Ok(vec![Instruction::ChkTimelock(1), Instruction::ChkTimelock(2)])
+            Ok(vec![Instruction::ChkTimelock(TimelockType::Block), Instruction::ChkTimelock(TimelockType::BlockAge)])
         );
     }
 }

--- a/vm/src/executor.rs
+++ b/vm/src/executor.rs
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 use ccrypto::{blake256, keccak256, ripemd160, sha256, Blake};
 use ckey::{verify, Public, Signature, SIGNATURE_LENGTH};
 use ctypes::transaction::{AssetTransferInput, HashingError, PartialHashing};
@@ -25,10 +24,14 @@ use crate::instruction::{has_expensive_opcodes, is_valid_unlock_script, Instruct
 
 const DEFAULT_MAX_MEMORY: usize = 1024;
 
-const TIMELOCK_TYPE_BLOCK: u8 = 0x01;
-const TIMELOCK_TYPE_BLOCK_AGE: u8 = 0x02;
-const TIMELOCK_TYPE_TIME: u8 = 0x03;
-const TIMELOCK_TYPE_TIME_AGE: u8 = 0x04;
+#[derive(Debug, Clone, PartialEq)]
+#[repr(u8)]
+pub enum TimelockType {
+    Block = 0x01,
+    BlockAge = 0x02,
+    Time = 0x03,
+    TimeAge = 0x04,
+}
 
 pub struct Config {
     pub max_memory: usize,
@@ -307,27 +310,26 @@ where
                 let value_item = stack.pop()?;
                 let value = read_u64(value_item)?;
                 match *timelock_type {
-                    TIMELOCK_TYPE_BLOCK => {
+                    TimelockType::Block => {
                         stack.push(Item::from(parent_block_number >= value))?;
                     }
-                    TIMELOCK_TYPE_BLOCK_AGE => {
+                    TimelockType::BlockAge => {
                         stack.push(Item::from(
                             client
                                 .transaction_block_age(&cur.prev_out.tracker, parent_block_number)
                                 .map_or(false, |age| age >= value),
                         ))?;
                     }
-                    TIMELOCK_TYPE_TIME => {
+                    TimelockType::Time => {
                         stack.push(Item::from(parent_block_timestamp >= value))?;
                     }
-                    TIMELOCK_TYPE_TIME_AGE => {
+                    TimelockType::TimeAge => {
                         stack.push(Item::from(
                             client
                                 .transaction_time_age(&cur.prev_out.tracker, parent_block_timestamp)
                                 .map_or(false, |age| age >= value),
                         ))?;
                     }
-                    _ => return Err(RuntimeError::InvalidTimelockType),
                 }
             }
         }

--- a/vm/src/instruction.rs
+++ b/vm/src/instruction.rs
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
+use crate::executor::TimelockType;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Instruction {
@@ -39,7 +40,7 @@ pub enum Instruction {
     Ripemd160,
     Keccak256,
     Blake160,
-    ChkTimelock(u8),
+    ChkTimelock(TimelockType),
 }
 
 pub fn is_valid_unlock_script(instrs: &[Instruction]) -> bool {

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -27,5 +27,5 @@ mod instruction;
 mod opcode;
 
 pub use crate::decoder::{decode, DecoderError};
-pub use crate::executor::{execute, ChainTimeInfo, Config as VMConfig, RuntimeError, ScriptResult};
+pub use crate::executor::{execute, ChainTimeInfo, Config as VMConfig, RuntimeError, ScriptResult, TimelockType};
 pub use crate::instruction::Instruction;

--- a/vm/tests/executor.rs
+++ b/vm/tests/executor.rs
@@ -26,8 +26,8 @@ use ccrypto::{BLAKE_EMPTY, BLAKE_NULL_RLP};
 use ckey::NetworkId;
 use common::TestClient;
 use ctypes::transaction::{AssetOutPoint, AssetTransferInput, ShardTransaction};
-use cvm::Instruction;
 use cvm::{execute, RuntimeError, ScriptResult, VMConfig};
+use cvm::{Instruction, TimelockType};
 use primitives::{H160, H256};
 
 #[test]
@@ -655,31 +655,12 @@ fn dummy_input() -> AssetTransferInput {
 }
 
 #[test]
-fn timelock_invalid_type() {
-    assert_eq!(
-        execute(
-            &[],
-            &[],
-            &[Instruction::Push(0), Instruction::ChkTimelock(5)],
-            &dummy_tx(),
-            VMConfig::default(),
-            &dummy_input(),
-            false,
-            &TestClient::default(),
-            0,
-            0
-        ),
-        Err(RuntimeError::InvalidTimelockType)
-    )
-}
-
-#[test]
 fn timelock_invalid_value() {
     assert_eq!(
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![0, 0, 0, 0, 0, 0, 0, 0, 0]), Instruction::ChkTimelock(1)],
+            &[Instruction::PushB(vec![0, 0, 0, 0, 0, 0, 0, 0, 0]), Instruction::ChkTimelock(TimelockType::Block)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),
@@ -699,7 +680,7 @@ fn timelock_block_number_success() {
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![10]), Instruction::ChkTimelock(1)],
+            &[Instruction::PushB(vec![10]), Instruction::ChkTimelock(TimelockType::Block)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),
@@ -719,7 +700,7 @@ fn timelock_block_number_fail() {
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![10]), Instruction::ChkTimelock(1)],
+            &[Instruction::PushB(vec![10]), Instruction::ChkTimelock(TimelockType::Block)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),
@@ -740,7 +721,7 @@ fn timelock_block_timestamp_success() {
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![0x00, 0x5B, 0xD0, 0x2B, 0xF2]), Instruction::ChkTimelock(3)],
+            &[Instruction::PushB(vec![0x00, 0x5B, 0xD0, 0x2B, 0xF2]), Instruction::ChkTimelock(TimelockType::Time)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),
@@ -761,7 +742,7 @@ fn timelock_block_timestamp_fail() {
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![0x00, 0x5B, 0xD0, 0x2B, 0xF2]), Instruction::ChkTimelock(3)],
+            &[Instruction::PushB(vec![0x00, 0x5B, 0xD0, 0x2B, 0xF2]), Instruction::ChkTimelock(TimelockType::Time)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),
@@ -781,7 +762,7 @@ fn timelock_block_age_fail_due_to_none() {
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![1]), Instruction::ChkTimelock(2)],
+            &[Instruction::PushB(vec![1]), Instruction::ChkTimelock(TimelockType::BlockAge)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),
@@ -801,7 +782,7 @@ fn timelock_block_age_fail() {
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![5]), Instruction::ChkTimelock(2)],
+            &[Instruction::PushB(vec![5]), Instruction::ChkTimelock(TimelockType::BlockAge)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),
@@ -821,7 +802,7 @@ fn timelock_block_age_success() {
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![5]), Instruction::ChkTimelock(2)],
+            &[Instruction::PushB(vec![5]), Instruction::ChkTimelock(TimelockType::BlockAge)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),
@@ -841,7 +822,7 @@ fn timelock_time_age_fail_due_to_none() {
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![0x27, 0x8D, 0x00]), Instruction::ChkTimelock(4)],
+            &[Instruction::PushB(vec![0x27, 0x8D, 0x00]), Instruction::ChkTimelock(TimelockType::TimeAge)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),
@@ -862,7 +843,7 @@ fn timelock_time_age_fail() {
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![0x27, 0x8D, 0x00]), Instruction::ChkTimelock(4)],
+            &[Instruction::PushB(vec![0x27, 0x8D, 0x00]), Instruction::ChkTimelock(TimelockType::TimeAge)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),
@@ -882,7 +863,7 @@ fn timelock_time_age_success() {
         execute(
             &[],
             &[],
-            &[Instruction::PushB(vec![0x27, 0x8D, 0x00]), Instruction::ChkTimelock(4)],
+            &[Instruction::PushB(vec![0x27, 0x8D, 0x00]), Instruction::ChkTimelock(TimelockType::TimeAge)],
             &dummy_tx(),
             VMConfig::default(),
             &dummy_input(),


### PR DESCRIPTION
I implemented the Encodable/Decodable in the enum type so that
the RLP code will receive enum type directly.
The compiler will warn programmers if there are missing enum values in a
match statement by using discriminated enums instead of constant type.
Using an enum type rather than constant type provides more safety
against type error.