### PR TITLE
Calculate the transactions root with the transactions on the block

### DIFF
--- a/core/src/consensus/simple_poa/mod.rs
+++ b/core/src/consensus/simple_poa/mod.rs
@@ -183,7 +183,7 @@ mod tests {
         let genesis_header = scheme.genesis_header();
         let b = OpenBlock::try_new(engine, db, &genesis_header, Default::default(), vec![]).unwrap();
         let term_common_params = CommonParams::default_for_test();
-        let b = b.close_and_lock(&genesis_header, Some(&term_common_params)).unwrap();
+        let b = b.close_and_lock(Some(&term_common_params)).unwrap();
         assert_eq!(None, engine.generate_seal(Some(b.block()), &genesis_header).seal_fields());
     }
 

--- a/core/src/consensus/solo/mod.rs
+++ b/core/src/consensus/solo/mod.rs
@@ -203,7 +203,7 @@ mod tests {
         let genesis_header = client.scheme.genesis_header();
         let b = OpenBlock::try_new(&*engine, db, &genesis_header, Default::default(), vec![]).unwrap();
         let term_common_params = CommonParams::default_for_test();
-        let b = b.close_and_lock(&genesis_header, Some(&term_common_params)).unwrap();
+        let b = b.close_and_lock(Some(&term_common_params)).unwrap();
         if let Some(seal) = engine.generate_seal(Some(b.block()), &genesis_header).seal_fields() {
             b.seal_block(seal);
         }

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -464,13 +464,9 @@ impl Miner {
         }
         cdebug!(MINER, "Pushed {}/{} transactions", tx_count, tx_total);
 
-        let (parent_header, parent_hash) = {
-            let parent_hash = *open_block.header().parent_hash();
-            let parent_header = chain.block_header(&parent_hash.into()).expect("Parent header MUST exist");
-            (parent_header.decode(), parent_hash)
-        };
+        let parent_hash = *open_block.header().parent_hash();
         let term_common_params = chain.term_common_params(parent_hash.into());
-        let block = open_block.close(&parent_header, term_common_params.as_ref())?;
+        let block = open_block.close(term_common_params.as_ref())?;
 
         let fetch_seq = |p: &Public| {
             let address = public_to_address(p);


### PR DESCRIPTION
Currently, the transactions root was the skewed merkle root of all
accumulated transactions from the genesis block. It changes the
definition of the transactions root to the skewed merkle root of
transactions in the block.

This change makes the node be able to verify a block's transactions
root without the parent header.