### PR TITLE
Update the logic to check whether the block contains transactions

### DIFF
--- a/sync/src/block/downloader/body.rs
+++ b/sync/src/block/downloader/body.rs
@@ -67,11 +67,11 @@ impl BodyDownloader {
         self.downloading.shrink_to_fit();
     }
 
-    pub fn add_target(&mut self, header: &Header, is_empty: bool) {
+    pub fn add_target(&mut self, header: &Header) {
         cdebug!(SYNC, "Add download target: {}", header.hash());
         self.targets.push(Target {
             hash: header.hash(),
-            is_empty,
+            is_empty: header.is_empty(),
         });
     }
 

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -232,10 +232,8 @@ impl Extension {
         let mut body_downloader = BodyDownloader::default();
         for neighbors in hollow_headers.windows(2).rev() {
             let child = &neighbors[0];
-            let parent = &neighbors[1];
             cdebug!(SYNC, "Adding block #{} (hash: {}) for initial body download target", child.number(), child.hash());
-            let is_empty = child.transactions_root() == parent.transactions_root();
-            body_downloader.add_target(child, is_empty);
+            body_downloader.add_target(child);
         }
         cinfo!(SYNC, "Sync extension initialized");
         Extension {
@@ -715,12 +713,7 @@ impl Extension {
                 .filter(|header| self.client.block_body(&BlockId::Hash(header.hash())).is_none())
                 .collect(); // FIXME: No need to collect here if self is not borrowed.
             for header in headers {
-                let parent = self
-                    .client
-                    .block_header(&BlockId::Hash(header.parent_hash()))
-                    .expect("Enacted header must have parent");
-                let is_empty = header.transactions_root() == parent.transactions_root();
-                self.body_downloader.add_target(&header.decode(), is_empty);
+                self.body_downloader.add_target(&header.decode());
             }
             self.body_downloader.remove_target(&retracted);
         }

--- a/types/src/header.rs
+++ b/types/src/header.rs
@@ -128,6 +128,11 @@ impl Header {
         &self.transactions_root
     }
 
+    /// Get whether the block has transactions.
+    pub fn is_empty(&self) -> bool {
+        self.transactions_root() == &BLAKE_NULL_RLP
+    }
+
     /// Get the score field of the header.
     pub fn score(&self) -> &U256 {
         &self.score


### PR DESCRIPTION
The definition of transactions_root has been changed.
It should be fixed by https://github.com/CodeChain-io/foundry/pull/101, but I missed.