### PR TITLE
Re-send a body request when the body is corrupted

### DIFF
--- a/sync/src/block/downloader/body.rs
+++ b/sync/src/block/downloader/body.rs
@@ -122,4 +122,26 @@ impl BodyDownloader {
         self.targets.shrink_to_fit();
         result
     }
+
+    pub fn re_request(
+        &mut self,
+        hash: BlockHash,
+        is_empty: bool,
+        remains: Vec<(BlockHash, Vec<UnverifiedTransaction>)>,
+    ) {
+        let mut new_targets = vec![Target {
+            hash,
+            is_empty,
+        }];
+        new_targets.extend(remains.into_iter().map(|(hash, transactions)| {
+            let is_empty = transactions.is_empty();
+            self.downloaded.insert(hash, transactions);
+            Target {
+                hash,
+                is_empty,
+            }
+        }));
+        new_targets.append(&mut self.targets);
+        self.targets = new_targets;
+    }
 }

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -1038,7 +1038,7 @@ impl Extension {
     }
 
     fn on_body_response(&mut self, hashes: Vec<BlockHash>, bodies: Vec<Vec<UnverifiedTransaction>>) {
-        ctrace!(SYNC, "Received body response with lenth({}) {:?}", hashes.len(), hashes);
+        ctrace!(SYNC, "Received body response with length({}) {:?}", hashes.len(), hashes);
 
         match &self.state {
             State::SnapshotBody {

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -1037,6 +1037,32 @@ impl Extension {
         }
     }
 
+    fn import_blocks(&self, blocks: Vec<(BlockHash, Vec<UnverifiedTransaction>)>) {
+        for (hash, transactions) in blocks {
+            let header =
+                self.client.block_header(&BlockId::Hash(hash)).expect("Downloaded body's header must exist").decode();
+            let block = Block {
+                header,
+                transactions,
+            };
+            cdebug!(SYNC, "Body download completed for #{}({})", block.header.number(), hash);
+            match self.client.import_block(block.rlp_bytes(&Seal::With)) {
+                Err(BlockImportError::Import(ImportError::AlreadyInChain)) => {
+                    cwarn!(SYNC, "Downloaded already existing block({})", hash)
+                }
+                Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {
+                    cwarn!(SYNC, "Downloaded already queued in the verification queue({})", hash)
+                }
+                Err(err) => {
+                    // FIXME: handle import errors
+                    cwarn!(SYNC, "Cannot import block({}): {:?}", hash, err);
+                    break
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn on_body_response(&mut self, hashes: Vec<BlockHash>, bodies: Vec<Vec<UnverifiedTransaction>>) {
         ctrace!(SYNC, "Received body response with length({}) {:?}", hashes.len(), hashes);
 
@@ -1064,36 +1090,9 @@ impl Extension {
                 }
             }
             State::Full => {
-                {
-                    self.body_downloader.import_bodies(hashes, bodies);
-                    let completed = self.body_downloader.drain();
-                    for (hash, transactions) in completed {
-                        let header = self
-                            .client
-                            .block_header(&BlockId::Hash(hash))
-                            .expect("Downloaded body's header must exist")
-                            .decode();
-                        let block = Block {
-                            header,
-                            transactions,
-                        };
-                        cdebug!(SYNC, "Body download completed for #{}({})", block.header.number(), hash);
-                        match self.client.import_block(block.rlp_bytes(&Seal::With)) {
-                            Err(BlockImportError::Import(ImportError::AlreadyInChain)) => {
-                                cwarn!(SYNC, "Downloaded already existing block({})", hash)
-                            }
-                            Err(BlockImportError::Import(ImportError::AlreadyQueued)) => {
-                                cwarn!(SYNC, "Downloaded already queued in the verification queue({})", hash)
-                            }
-                            Err(err) => {
-                                // FIXME: handle import errors
-                                cwarn!(SYNC, "Cannot import block({}): {:?}", hash, err);
-                                break
-                            }
-                            _ => {}
-                        }
-                    }
-                }
+                self.body_downloader.import_bodies(hashes, bodies);
+                let completed = self.body_downloader.drain();
+                self.import_blocks(completed);
 
                 let mut peer_ids: Vec<_> = self.header_downloaders.keys().cloned().collect();
                 peer_ids.shuffle(&mut thread_rng());

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -1037,10 +1037,24 @@ impl Extension {
         }
     }
 
-    fn import_blocks(&self, blocks: Vec<(BlockHash, Vec<UnverifiedTransaction>)>) {
+    fn import_blocks(&mut self, blocks: Vec<(BlockHash, Vec<UnverifiedTransaction>)>) {
+        let mut remains = Vec::new();
+        let mut error_target = None;
         for (hash, transactions) in blocks {
+            if error_target.is_some() {
+                remains.push((hash, transactions));
+                continue
+            }
             let header =
                 self.client.block_header(&BlockId::Hash(hash)).expect("Downloaded body's header must exist").decode();
+            let calculated_transactions_root =
+                skewed_merkle_root(BLAKE_NULL_RLP, transactions.iter().map(Encodable::rlp_bytes));
+            if *header.transactions_root() != calculated_transactions_root {
+                cwarn!(SYNC, "Received corrupted body for ${}({}", header.number(), hash);
+                error_target = Some((hash, transactions.is_empty()));
+                continue
+            }
+
             let block = Block {
                 header,
                 transactions,
@@ -1060,6 +1074,9 @@ impl Extension {
                 }
                 _ => {}
             }
+        }
+        if let Some((hash, is_empty)) = error_target {
+            self.body_downloader.re_request(hash, is_empty, remains);
         }
     }
 


### PR DESCRIPTION
Currently, Foundry doesn't mark the block as bad when the block is corrupted, but it doesn't re-request the body. This patch makes it re-send the request for the body.

~~It depends on https://github.com/CodeChain-io/foundry/pull/114.~~ #114 has been merged.