### PR TITLE
Suggest to improve PeerDb

### DIFF
--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -34,10 +34,8 @@ pub const COL_EXTRA: Option<u32> = Some(3);
 pub const COL_MEMPOOL: Option<u32> = Some(4);
 /// Column for Transaction error hints
 pub const COL_ERROR_HINT: Option<u32> = Some(5);
-/// Column for Storing Peer list
-pub const COL_PEER: Option<u32> = Some(6);
 /// Number of columns in DB
-pub const NUM_COLUMNS: Option<u32> = Some(7);
+pub const NUM_COLUMNS: Option<u32> = Some(6);
 
 /// Modes for updating caches.
 #[derive(Clone, Copy)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -73,7 +73,7 @@ pub use crate::client::{
 pub use crate::consensus::signer::EngineSigner;
 pub use crate::consensus::stake;
 pub use crate::consensus::{EngineType, TimeGapParams};
-pub use crate::db::{COL_PEER, COL_STATE, NUM_COLUMNS};
+pub use crate::db::{COL_STATE, NUM_COLUMNS};
 pub use crate::error::{BlockImportError, Error, ImportError};
 pub use crate::miner::{MemPoolFees, Miner, MinerOptions, MinerService};
 pub use crate::peer_db::PeerDb;

--- a/core/src/peer_db.rs
+++ b/core/src/peer_db.rs
@@ -13,38 +13,87 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-use crate::db::COL_PEER;
+use crate::db::COL_EXTRA;
 use cnetwork::{ManagingPeerdb, SocketAddr};
 use kvdb::{DBTransaction, KeyValueDB};
+use parking_lot::Mutex;
+use rlp::RlpStream;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-const COLUMN_TO_WRITE: Option<u32> = COL_PEER;
 
 pub struct PeerDb {
     db: Arc<dyn KeyValueDB>,
+    peers_and_count: Mutex<(HashMap<SocketAddr, u64>, usize)>,
 }
 
 impl PeerDb {
     pub fn new(database: Arc<dyn KeyValueDB>) -> Arc<Self> {
         Arc::new(Self {
             db: database,
+            peers_and_count: Default::default(),
         })
     }
 }
 
 impl ManagingPeerdb for PeerDb {
-    fn insert(&self, key: &SocketAddr) {
-        let mut batch = DBTransaction::new();
-        let s = rlp::encode(key);
-        let time: u64 = SystemTime::now().duration_since(UNIX_EPOCH).expect("There is no time machine.").as_secs();
-        let value = rlp::encode(&time);
-        batch.put(COLUMN_TO_WRITE, &s, &value);
-        self.db.write(batch).expect("The key is not valid");
+    fn insert(&self, key: SocketAddr) {
+        let (peers, count) = &mut *self.peers_and_count.lock();
+        peers.entry(key).or_insert_with(|| {
+            *count += 1;
+            SystemTime::now().duration_since(UNIX_EPOCH).expect("There is no time machine.").as_secs()
+        });
+
+        if let Some(batch) = get_db_transaction_if_enough_hit(peers, count) {
+            self.db.write(batch).expect("The DB must alive");
+        }
     }
+
     fn delete(&self, key: &SocketAddr) {
-        let mut batch = DBTransaction::new();
-        let s = rlp::encode(key);
-        batch.delete(COLUMN_TO_WRITE, &s);
-        self.db.write(batch).expect("The key is not valid");
+        let (peers, count) = &mut *self.peers_and_count.lock();
+        if peers.remove(key).is_some() {
+            *count += 1;
+        }
+
+        if let Some(batch) = get_db_transaction_if_enough_hit(peers, count) {
+            self.db.write(batch).expect("The DB must alive");
+        }
     }
+}
+
+// XXX: It may not be needed. Generally, in the p2p networks, the old node lives longer.
+// Exaggeratedly, the new node does not affect the stability of the network. In other words, it
+// doesn't matter even we don't restore the fresh updated nodes.
+impl Drop for PeerDb {
+    fn drop(&mut self) {
+        let (peers, _) = &*self.peers_and_count.lock();
+        let batch = get_db_transaction(peers);
+        self.db.write(batch).expect("The DB must alive");
+    }
+}
+
+fn get_db_transaction_if_enough_hit(peers: &HashMap<SocketAddr, u64>, count: &mut usize) -> Option<DBTransaction> {
+    const UPDATE_AT: usize = 10;
+    if *count < UPDATE_AT {
+        return None
+    }
+
+    *count = 0;
+
+    Some(get_db_transaction(peers))
+}
+
+fn get_db_transaction(peers: &HashMap<SocketAddr, u64>) -> DBTransaction {
+    let mut s = RlpStream::new_list(peers.len());
+    for (address, time) in peers {
+        s.begin_list(2).append(address).append(time);
+    }
+    let encoded = s.drain();
+
+    let mut batch = DBTransaction::new();
+
+    const COLUMN_TO_WRITE: Option<u32> = COL_EXTRA;
+    const PEER_DB_KEY: &[u8] = b"peer-list";
+    batch.put(COLUMN_TO_WRITE, PEER_DB_KEY, &encoded);
+    batch
 }

--- a/core/src/peer_db.rs
+++ b/core/src/peer_db.rs
@@ -28,8 +28,8 @@ pub struct PeerDb {
 }
 
 impl PeerDb {
-    pub fn new(database: Arc<dyn KeyValueDB>) -> Arc<Self> {
-        Arc::new(Self {
+    pub fn new(database: Arc<dyn KeyValueDB>) -> Box<Self> {
+        Box::new(Self {
             db: database,
             peers_and_count: Default::default(),
         })

--- a/foundry/run_node.rs
+++ b/foundry/run_node.rs
@@ -51,7 +51,7 @@ fn network_start(
     timer_loop: TimerLoop,
     cfg: &NetworkConfig,
     routing_table: Arc<RoutingTable>,
-    peer_db: Arc<dyn ManagingPeerdb>,
+    peer_db: Box<dyn ManagingPeerdb>,
 ) -> Result<Arc<NetworkService>, String> {
     let addr = cfg.address.parse().map_err(|_| format!("Invalid NETWORK listen host given: {}", cfg.address))?;
     let sockaddress = SocketAddr::new(addr, cfg.port);

--- a/network/src/p2p/handler.rs
+++ b/network/src/p2p/handler.rs
@@ -79,7 +79,7 @@ const RTT: Duration = Duration::from_secs(10); // T2
 const WAIT_SYNC: Duration = Duration::from_secs(30); // T3 >> T1 + RTT
 
 pub trait ManagingPeerdb: Send + Sync {
-    fn insert(&self, key: &SocketAddr);
+    fn insert(&self, key: SocketAddr);
     fn delete(&self, key: &SocketAddr);
 }
 
@@ -498,7 +498,7 @@ impl IoHandler<Message> for Handler {
             } => {
                 let mut inbound_connections = self.inbound_connections.write();
                 let target = connection.peer_addr();
-                self.peer_db.insert(&target);
+                self.peer_db.insert(*target);
                 if let Some(token) = self.inbound_tokens.lock().gen() {
                     let remote_node_id = connection.peer_addr().into();
                     assert_eq!(

--- a/network/src/p2p/handler.rs
+++ b/network/src/p2p/handler.rs
@@ -118,7 +118,7 @@ pub struct Handler {
 
     min_peers: usize,
     max_peers: usize,
-    peer_db: Arc<dyn (ManagingPeerdb)>,
+    peer_db: Box<dyn (ManagingPeerdb)>,
     rng: Mutex<OsRng>,
 }
 
@@ -133,7 +133,7 @@ impl Handler {
         bootstrap_addresses: Vec<SocketAddr>,
         min_peers: usize,
         max_peers: usize,
-        db: Arc<dyn ManagingPeerdb>,
+        peer_db: Box<dyn ManagingPeerdb>,
     ) -> ::std::result::Result<Self, String> {
         if MAX_INBOUND_CONNECTIONS + MAX_OUTBOUND_CONNECTIONS < max_peers {
             return Err(format!("Max peers must be less than {}", MAX_INBOUND_CONNECTIONS + MAX_OUTBOUND_CONNECTIONS))
@@ -172,7 +172,7 @@ impl Handler {
             bootstrap_addresses,
             min_peers,
             max_peers,
-            peer_db: db,
+            peer_db,
             rng: Mutex::new(OsRng::new().unwrap()),
         })
     }

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -46,7 +46,7 @@ impl Service {
         max_peers: usize,
         filters_control: Arc<dyn FiltersControl>,
         routing_table: Arc<RoutingTable>,
-        peer_db: Arc<dyn ManagingPeerdb>,
+        peer_db: Box<dyn ManagingPeerdb>,
     ) -> Result<Arc<Self>, Error> {
         let p2p = IoService::start("P2P")?;
 


### PR DESCRIPTION
Hi @majecty and @MSNTCS,
I propose to improve PeerDb.
This PR includes 3 changes.
1. Change `Arc` to `Box`.
It's because there is only one holder of `PeerDb`.

2. Update disk once per 10 updates.
Since the current implementation update disk every time, it will query very much at the booting time.
I think we don't need it strongly consistent with the database since the purpose of PeerDb is backup addresses.

3. Store peer lists in one field.
Because we don't update db every time, we can use only one row to store the peer lists.
It also makes that the implementation of PeerDb corresponds between CodeChain and Foundry because it doesn't need to add a column.