### PR TITLE
Change constants to enumerations

### DIFF
--- a/state/src/item/account.rs
+++ b/state/src/item/account.rs
@@ -123,7 +123,7 @@ impl CacheableItem for Account {
     }
 }
 
-const PREFIX: u8 = super::ADDRESS_PREFIX;
+const PREFIX: u8 = super::Prefix::Account as u8;
 
 impl Encodable for Account {
     fn rlp_append(&self, s: &mut RlpStream) {

--- a/state/src/item/dummy_shard_text.rs
+++ b/state/src/item/dummy_shard_text.rs
@@ -46,7 +46,7 @@ impl ShardText {
     }
 }
 
-const PREFIX: u8 = super::SHARD_TEXT_PREFIX;
+const PREFIX: u8 = super::Prefix::ShardText as u8;
 
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ShardTextAddress(H256);

--- a/state/src/item/metadata.rs
+++ b/state/src/item/metadata.rs
@@ -131,7 +131,7 @@ impl CacheableItem for Metadata {
     }
 }
 
-const PREFIX: u8 = super::METADATA_PREFIX;
+const PREFIX: u8 = super::Prefix::Metadata as u8;
 
 const INITIAL_LEN: usize = 4;
 const TERM_LEN: usize = INITIAL_LEN + 2;

--- a/state/src/item/mod.rs
+++ b/state/src/item/mod.rs
@@ -24,8 +24,12 @@ pub mod metadata;
 pub mod regular_account;
 pub mod shard;
 
-const ADDRESS_PREFIX: u8 = b'C';
-const SHARD_PREFIX: u8 = b'H';
-const METADATA_PREFIX: u8 = b'M';
-const REGULAR_ACCOUNT_PREFIX: u8 = b'R';
-const SHARD_TEXT_PREFIX: u8 = b'X';
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum Prefix {
+    Account = b'C',
+    Shard = b'H',
+    Metadata = b'M',
+    RegularAccount = b'R',
+    ShardText = b'X',
+}

--- a/state/src/item/regular_account.rs
+++ b/state/src/item/regular_account.rs
@@ -54,7 +54,7 @@ impl CacheableItem for RegularAccount {
     }
 }
 
-const PREFIX: u8 = super::REGULAR_ACCOUNT_PREFIX;
+const PREFIX: u8 = super::Prefix::RegularAccount as u8;
 
 impl Encodable for RegularAccount {
     fn rlp_append(&self, s: &mut RlpStream) {

--- a/state/src/item/shard.rs
+++ b/state/src/item/shard.rs
@@ -78,7 +78,7 @@ impl CacheableItem for Shard {
     }
 }
 
-const PREFIX: u8 = super::SHARD_PREFIX;
+const PREFIX: u8 = super::Prefix::Shard as u8;
 
 impl Encodable for Shard {
     fn rlp_append(&self, s: &mut RlpStream) {


### PR DESCRIPTION
This patch changes the state item prefixes and transaction tags to enumerations to make a compiler check duplications.
Actually, it's part of https://github.com/CodeChain-io/foundry/issues/38, but implementing and testing the issues takes more time than I expected. So I pushed it separately to avoid more conflicts.