### PR TITLE
Reorder state_root and transactions_root

### DIFF
--- a/core/src/scheme/genesis.rs
+++ b/core/src/scheme/genesis.rs
@@ -33,10 +33,10 @@ pub struct Genesis {
     pub timestamp: u64,
     /// Parent hash.
     pub parent_hash: BlockHash,
-    /// Transactions root.
-    pub transactions_root: H256,
     /// State root.
     pub state_root: Option<H256>,
+    /// Transactions root.
+    pub transactions_root: H256,
     /// The genesis block's extra data field.
     pub extra_data: Bytes,
 }
@@ -49,8 +49,8 @@ impl From<cjson::scheme::Genesis> for Genesis {
             author: g.author.map_or_else(Address::default, PlatformAddress::into_address),
             timestamp: g.timestamp.map_or(0, Into::into),
             parent_hash: g.parent_hash.map_or_else(H256::zero, Into::into).into(),
-            transactions_root: g.transactions_root.map_or_else(|| BLAKE_NULL_RLP, Into::into),
             state_root: g.state_root.map(Into::into),
+            transactions_root: g.transactions_root.map_or_else(|| BLAKE_NULL_RLP, Into::into),
             extra_data: g.extra_data.map_or_else(Vec::new, Into::into),
         }
     }

--- a/json/src/scheme/genesis.rs
+++ b/json/src/scheme/genesis.rs
@@ -34,10 +34,10 @@ pub struct Genesis {
     pub timestamp: Option<Uint>,
     /// Parent hash, defaults to 0.
     pub parent_hash: Option<H256>,
-    /// Transactions root.
-    pub transactions_root: Option<H256>,
     /// State root.
     pub state_root: Option<H256>,
+    /// Transactions root.
+    pub transactions_root: Option<H256>,
     /// Extra data.
     pub extra_data: Option<Bytes>,
 }
@@ -88,8 +88,8 @@ mod tests {
             author: Some(PlatformAddress::from_str("tccqyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhhn9p3").unwrap()),
             timestamp: Some(0x07.into()),
             parent_hash: Some(H256(Core256::from("0x9000000000000000000000000000000000000000000000000000000000000000"))),
-            transactions_root: None,
             state_root: Some(H256(Core256::from("0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544"))),
+            transactions_root: None,
             extra_data: Some(Bytes::from_str("0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa").unwrap()),
         });
     }

--- a/rpc/src/v1/types/block.rs
+++ b/rpc/src/v1/types/block.rs
@@ -30,8 +30,8 @@ pub struct Block {
 
     extra_data: Vec<u8>,
 
-    transactions_root: H256,
     state_root: H256,
+    transactions_root: H256,
 
     score: U256,
     seal: Vec<Vec<u8>>,
@@ -60,8 +60,8 @@ impl Block {
 
             extra_data: block.header.extra_data().clone(),
 
-            transactions_root: *block.header.transactions_root(),
             state_root: *block.header.state_root(),
+            transactions_root: *block.header.transactions_root(),
 
             score: *block.header.score(),
             seal: block.header.seal().to_vec(),

--- a/test/src/e2e.long/onChainBlockValid.test.ts
+++ b/test/src/e2e.long/onChainBlockValid.test.ts
@@ -100,8 +100,8 @@ describe("Test onChain block communication", async function() {
 
         VALID_PARENT = block1.parentHash;
         VALID_AUTHOR = block1.author.accountId;
-        VALID_TRANSACTIONS_ROOT = block1.transactionsRoot;
         VALID_STATEROOT = block1.stateRoot;
+        VALID_TRANSACTIONS_ROOT = block1.transactionsRoot;
 
         nodeA = new CodeChain();
         await nodeA.start();

--- a/test/src/helper/mock/cHeader.ts
+++ b/test/src/helper/mock/cHeader.ts
@@ -39,8 +39,8 @@ export class Header {
             number,
             author,
             extraData,
-            transactionsRoot,
             stateRoot,
+            transactionsRoot,
             score,
             []
         );
@@ -56,8 +56,8 @@ export class Header {
     private number: U256;
     private author: H160;
     private extraData: Buffer;
-    private transactionsRoot: H256;
     private stateRoot: H256;
+    private transactionsRoot: H256;
     private score: U256;
     private seal: number[][];
     private hash: null | H256;
@@ -81,8 +81,8 @@ export class Header {
         this.number = number;
         this.author = author;
         this.extraData = extraData;
-        this.transactionsRoot = transactionsRoot;
         this.stateRoot = stateRoot;
+        this.transactionsRoot = transactionsRoot;
         this.score = score;
         this.seal = seal;
         this.hash = hash == null ? this.hashing() : hash;
@@ -109,12 +109,12 @@ export class Header {
         this.extraData = extraData;
     }
 
-    public setTransactionsRoot(root: H256) {
-        this.transactionsRoot = root;
-    }
-
     public setStateRoot(root: H256) {
         this.stateRoot = root;
+    }
+
+    public setTransactionsRoot(root: H256) {
+        this.transactionsRoot = root;
     }
 
     public setScore(score: U256) {

--- a/types/src/header.rs
+++ b/types/src/header.rs
@@ -46,10 +46,10 @@ pub struct Header {
     /// Block extra data.
     extra_data: Bytes,
 
-    /// Transactions root.
-    transactions_root: H256,
     /// State root.
     state_root: H256,
+    /// Transactions root.
+    transactions_root: H256,
 
     /// Block score.
     score: U256,
@@ -72,8 +72,8 @@ impl Default for Header {
             author: Default::default(),
             extra_data: vec![],
 
-            transactions_root: BLAKE_NULL_RLP,
             state_root: BLAKE_NULL_RLP,
+            transactions_root: BLAKE_NULL_RLP,
 
             score: U256::default(),
             seal: vec![],


### PR DESCRIPTION
This refactoring reorders the order of two fields in 'code', which was inconsistent.
RLP encoding and other run-time properties have not been changed.