### PR TITLE
Add get_current_height function to the IBC Context

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -867,7 +867,8 @@ impl IBCTransactionExecutor for Client {
         state: &mut TopLevelState,
         fee_payer: &Address,
         sender_pubkey: &Public,
+        current_block_number: BlockNumber,
     ) -> StateResult<()> {
-        ibc::execute_transaction(bytes, state, fee_payer, sender_pubkey)
+        ibc::execute_transaction(bytes, state, fee_payer, sender_pubkey, current_block_number)
     }
 }

--- a/core/src/ibc/context.rs
+++ b/core/src/ibc/context.rs
@@ -22,18 +22,21 @@ use rlp::RlpStream;
 
 pub trait Context {
     fn get_kv_store(&mut self) -> &mut dyn kv_store::KVStore;
+    fn get_current_height(&self) -> u64;
 }
 
 pub struct TopLevelContext<'a> {
     kv_store: TopLevelKVStore<'a>,
+    current_height: u64,
 }
 
 impl<'a> TopLevelContext<'a> {
-    pub fn new(state: &'a mut TopLevelState) -> Self {
+    pub fn new(state: &'a mut TopLevelState, current_height: u64) -> Self {
         TopLevelContext {
             kv_store: TopLevelKVStore {
                 state,
             },
+            current_height,
         }
     }
 }
@@ -41,6 +44,10 @@ impl<'a> TopLevelContext<'a> {
 impl<'a> Context for TopLevelContext<'a> {
     fn get_kv_store(&mut self) -> &mut dyn KVStore {
         &mut self.kv_store
+    }
+
+    fn get_current_height(&self) -> u64 {
+        self.current_height
     }
 }
 

--- a/rpc/src/v1/impls/ibc.rs
+++ b/rpc/src/v1/impls/ibc.rs
@@ -56,7 +56,7 @@ where
             Some(block_number) => block_number,
         };
 
-        let mut context = ibc::context::TopLevelContext::new(&mut state);
+        let mut context = ibc::context::TopLevelContext::new(&mut state, block_number);
         let client_manager = ibc::client::Manager::new();
         let client_state =
             client_manager.query(&mut context, &client_id).map_err(|_| errors::ibc_client_not_exist())?;
@@ -96,7 +96,7 @@ where
             Some(block_number) => block_number,
         };
 
-        let mut context = ibc::context::TopLevelContext::new(&mut state);
+        let mut context = ibc::context::TopLevelContext::new(&mut state, block_number);
         let client_manager = ibc::client::Manager::new();
         let client_state =
             client_manager.query(&mut context, &client_id).map_err(|_| errors::ibc_client_not_exist())?;

--- a/state/src/ibc.rs
+++ b/state/src/ibc.rs
@@ -16,6 +16,7 @@
 
 use crate::{StateResult, TopLevelState};
 use ckey::{Address, Public};
+use ctypes::BlockNumber;
 
 pub trait IBCTransactionExecutor {
     fn execute(
@@ -24,6 +25,7 @@ pub trait IBCTransactionExecutor {
         _state: &mut TopLevelState,
         _fee_payer: &Address,
         _sender_pubkey: &Public,
+        _current_block_number: BlockNumber,
     ) -> StateResult<()> {
         Ok(())
     }

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -408,7 +408,14 @@ impl TopLevelState {
             Action::IBC {
                 bytes,
             } => {
-                IBCTransactionExecutor::execute(client, bytes, self, fee_payer, signer_public)?;
+                IBCTransactionExecutor::execute(
+                    client,
+                    bytes,
+                    self,
+                    fee_payer,
+                    signer_public,
+                    parent_block_number + 1,
+                )?;
                 return Ok(())
             }
         };


### PR DESCRIPTION
The connection spec's OpenTry datagram handler need to know the host's current height.
https://github.com/cosmos/ics/tree/master/spec/ics-003-connection-semantics