### PR TITLE
Return error when importing not allowed transactions

### DIFF
--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -212,6 +212,7 @@ impl Miner {
                 }
                 if !self.is_allowed_transaction(&tx.action) {
                     cdebug!(MINER, "Rejected transaction {:?}: {:?} is not allowed transaction", hash, tx.action);
+                    return Err(Error::Other("Not allowed transaction".to_string()))
                 }
                 let immune_users = self.immune_users.read();
                 let tx = tx


### PR DESCRIPTION
I don't know the purpose of https://github.com/CodeChain-io/foundry/commit/f9f3c463daa66c0eb74672d2a356e1bc6e5bccca, so I'm not quite sure if this is a bug or not. 
But I think it doesn't make sense to print "Rejected" message and accept the transaction.
Could you have a look at it?