### PR TITLE
Modify getPendingTransactions and countPendingTransaction to include future transactions

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -648,6 +648,10 @@ impl BlockChainClient for Client {
         self.importer.miner.count_pending_transactions(range)
     }
 
+    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
+        self.importer.miner.future_pending_transactions(range)
+    }
+
     fn is_pending_queue_empty(&self) -> bool {
         self.importer.miner.status().transactions_in_pending_queue == 0
     }

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -652,6 +652,10 @@ impl BlockChainClient for Client {
         self.importer.miner.future_pending_transactions(range)
     }
 
+    fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize {
+        self.importer.miner.future_included_count_pending_transactions(range)
+    }
+
     fn is_pending_queue_empty(&self) -> bool {
         self.importer.miner.status().transactions_in_pending_queue == 0
     }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -219,6 +219,9 @@ pub trait BlockChainClient: Sync + Send + AccountData + BlockChainTrait + Import
     /// List all transactions that are allowed into the next block.
     fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
 
+    /// List all transactions in future block.
+    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
+
     /// Get the count of all pending transactions currently in the mem_pool.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;
 

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -225,6 +225,9 @@ pub trait BlockChainClient: Sync + Send + AccountData + BlockChainTrait + Import
     /// Get the count of all pending transactions currently in the mem_pool.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;
 
+    /// Get the count of all pending transactions included future transaction in the mem_pool.
+    fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize;
+
     /// Check there are transactions which are allowed into the next block.
     fn is_pending_queue_empty(&self) -> bool;
 

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -536,6 +536,10 @@ impl BlockChainClient for TestBlockChainClient {
         self.miner.count_pending_transactions(range)
     }
 
+    fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize {
+        self.miner.future_included_count_pending_transactions(range)
+    }
+
     fn is_pending_queue_empty(&self) -> bool {
         self.miner.status().transactions_in_pending_queue == 0
     }

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -528,6 +528,10 @@ impl BlockChainClient for TestBlockChainClient {
         self.miner.ready_transactions(range)
     }
 
+    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
+        self.miner.future_pending_transactions(range)
+    }
+
     fn count_pending_transactions(&self, range: Range<u64>) -> usize {
         self.miner.count_pending_transactions(range)
     }

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -864,7 +864,78 @@ impl MemPool {
             .count()
     }
 
-    /// Return all future transactions.
+    /// Return all future transactions along with current transactions.
+    pub fn get_future_pending_transactions(
+        &self,
+        size_limit: usize,
+        current_timestamp: Option<u64>,
+        range: Range<u64>,
+    ) -> PendingSignedTransactions {
+        let mut current_size: usize = 0;
+        let pending_items: Vec<_> = self
+            .current
+            .queue
+            .iter()
+            .map(|t| {
+                self.by_hash
+                    .get(&t.hash)
+                    .expect("All transactions in `current` and `future` are always included in `by_hash`")
+            })
+            .filter(|t| {
+                if let Some(expiration) = t.expiration() {
+                    if let Some(timestamp) = current_timestamp {
+                        return expiration >= timestamp
+                    }
+                }
+                true
+            })
+            .filter(|t| range.contains(&t.inserted_timestamp))
+            .take_while(|t| {
+                let encoded_byte_array = rlp::encode(&t.tx);
+                let size_in_byte = encoded_byte_array.len();
+                current_size += size_in_byte;
+                current_size < size_limit
+            })
+            .collect();
+        let future_pending_items: Vec<_> = self
+            .future
+            .queue
+            .iter()
+            .map(|t| {
+                self.by_hash
+                    .get(&t.hash)
+                    .expect("All transactions in `current` and `future` are always included in `by_hash`")
+            })
+            .filter(|t| {
+                if let Some(expiration) = t.expiration() {
+                    if let Some(timestamp) = current_timestamp {
+                        return expiration >= timestamp
+                    }
+                }
+                true
+            })
+            .filter(|t| range.contains(&t.inserted_timestamp))
+            .take_while(|t| {
+                let encoded_byte_array = rlp::encode(&t.tx);
+                let size_in_byte = encoded_byte_array.len();
+                current_size += size_in_byte;
+                current_size < size_limit
+            })
+            .collect();
+        let mut current_signed_tx: Vec<SignedTransaction> = pending_items.iter().map(|t| t.tx.clone()).collect();
+        let mut future_signed_tx: Vec<SignedTransaction> = future_pending_items.iter().map(|t| t.tx.clone()).collect();
+        for tx in &mut future_signed_tx {
+            current_signed_tx.push(tx.clone());
+        }
+        let transactions: Vec<SignedTransaction> = current_signed_tx;
+        let last_timestamp = future_pending_items.into_iter().map(|t| t.inserted_timestamp).max();
+
+        PendingSignedTransactions {
+            transactions,
+            last_timestamp,
+        }
+    }
+
     pub fn future_transactions(&self) -> Vec<SignedTransaction> {
         self.future
             .queue

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -28,6 +28,7 @@ use ckey::{public_to_address, Public};
 use ctypes::errors::{HistoryError, RuntimeError, SyntaxError};
 use ctypes::{BlockNumber, TxHash};
 use kvdb::{DBTransaction, KeyValueDB};
+use std::cmp::max;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ops::Range;
 use std::sync::Arc;
@@ -864,6 +865,30 @@ impl MemPool {
             .count()
     }
 
+    pub fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize {
+        self.future
+            .queue
+            .iter()
+            .map(|t| {
+                self.by_hash
+                    .get(&t.hash)
+                    .expect("All transactions in `current` and `future` are always included in `by_hash`")
+            })
+            .filter(|t| range.contains(&t.inserted_timestamp))
+            .count()
+            + self
+                .current
+                .queue
+                .iter()
+                .map(|t| {
+                    self.by_hash
+                        .get(&t.hash)
+                        .expect("All transactions in `current` and `future` are always included in `by_hash`")
+                })
+                .filter(|t| range.contains(&t.inserted_timestamp))
+                .count()
+    }
+
     /// Return all future transactions along with current transactions.
     pub fn get_future_pending_transactions(
         &self,
@@ -923,13 +948,12 @@ impl MemPool {
             })
             .collect();
         let mut current_signed_tx: Vec<SignedTransaction> = pending_items.iter().map(|t| t.tx.clone()).collect();
+        let current_last_timestamp = pending_items.into_iter().map(|t| t.inserted_timestamp).max();
         let mut future_signed_tx: Vec<SignedTransaction> = future_pending_items.iter().map(|t| t.tx.clone()).collect();
-        for tx in &mut future_signed_tx {
-            current_signed_tx.push(tx.clone());
-        }
+        current_signed_tx.append(&mut future_signed_tx);
         let transactions: Vec<SignedTransaction> = current_signed_tx;
-        let last_timestamp = future_pending_items.into_iter().map(|t| t.inserted_timestamp).max();
-
+        let future_last_timestamp = future_pending_items.into_iter().map(|t| t.inserted_timestamp).max();
+        let last_timestamp = max(current_last_timestamp, future_last_timestamp);
         PendingSignedTransactions {
             transactions,
             last_timestamp,

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -674,6 +674,10 @@ impl MinerService for Miner {
         self.mem_pool.read().count_pending_transactions(range)
     }
 
+    fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize {
+        self.mem_pool.read().future_included_count_pending_transactions(range)
+    }
+
     fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
         self.mem_pool.read().get_future_pending_transactions(usize::max_value(), None, range)
     }

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -674,6 +674,10 @@ impl MinerService for Miner {
         self.mem_pool.read().count_pending_transactions(range)
     }
 
+    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
+        self.mem_pool.read().get_future_pending_transactions(usize::max_value(), None, range)
+    }
+
     /// Get a list of all future transactions.
     fn future_transactions(&self) -> Vec<SignedTransaction> {
         self.mem_pool.read().future_transactions()

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -114,6 +114,9 @@ pub trait MinerService: Send + Sync {
     /// Get a list of all pending transactions in the mem pool.
     fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
 
+    /// Get list of all future transaction in the mem pool.
+    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
+
     /// Get a count of all pending transactions in the mem pool.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;
 

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -120,6 +120,9 @@ pub trait MinerService: Send + Sync {
     /// Get a count of all pending transactions in the mem pool.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;
 
+    /// a count of all pending transaction including both current and future transactions.
+    fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize;
+
     /// Get a list of all future transactions.
     fn future_transactions(&self) -> Vec<SignedTransaction>;
 

--- a/rpc/src/v1/impls/mempool.rs
+++ b/rpc/src/v1/impls/mempool.rs
@@ -78,17 +78,26 @@ where
         &self,
         from: Option<u64>,
         to: Option<u64>,
-        future_included: bool,
+        future_included: Option<bool>,
     ) -> Result<PendingTransactions> {
-        if future_included {
+        if future_included.unwrap_or(false) {
             Ok(self.client.future_pending_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)).into())
         } else {
             Ok(self.client.ready_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)).into())
         }
     }
 
-    fn get_pending_transactions_count(&self, from: Option<u64>, to: Option<u64>) -> Result<usize> {
-        Ok(self.client.count_pending_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)))
+    fn get_pending_transactions_count(
+        &self,
+        from: Option<u64>,
+        to: Option<u64>,
+        future_included: Option<bool>,
+    ) -> Result<usize> {
+        if future_included.unwrap_or(false) {
+            Ok(self.client.future_included_count_pending_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)))
+        } else {
+            Ok(self.client.count_pending_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)))
+        }
     }
 
     fn get_banned_accounts(&self) -> Result<Vec<PlatformAddress>> {

--- a/rpc/src/v1/impls/mempool.rs
+++ b/rpc/src/v1/impls/mempool.rs
@@ -74,8 +74,17 @@ where
         Ok(())
     }
 
-    fn get_pending_transactions(&self, from: Option<u64>, to: Option<u64>) -> Result<PendingTransactions> {
-        Ok(self.client.ready_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)).into())
+    fn get_pending_transactions(
+        &self,
+        from: Option<u64>,
+        to: Option<u64>,
+        future_included: bool,
+    ) -> Result<PendingTransactions> {
+        if future_included {
+            Ok(self.client.future_pending_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)).into())
+        } else {
+            Ok(self.client.ready_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)).into())
+        }
     }
 
     fn get_pending_transactions_count(&self, from: Option<u64>, to: Option<u64>) -> Result<usize> {

--- a/rpc/src/v1/traits/mempool.rs
+++ b/rpc/src/v1/traits/mempool.rs
@@ -44,12 +44,17 @@ pub trait Mempool {
         &self,
         from: Option<u64>,
         to: Option<u64>,
-        future_included: bool,
+        future_included: Option<bool>,
     ) -> Result<PendingTransactions>;
 
     /// Gets the count of transactions in the current mem pool.
     #[rpc(name = "mempool_getPendingTransactionsCount")]
-    fn get_pending_transactions_count(&self, from: Option<u64>, to: Option<u64>) -> Result<usize>;
+    fn get_pending_transactions_count(
+        &self,
+        from: Option<u64>,
+        to: Option<u64>,
+        future_included: Option<bool>,
+    ) -> Result<usize>;
 
     #[rpc(name = "mempool_getBannedAccounts")]
     fn get_banned_accounts(&self) -> Result<Vec<PlatformAddress>>;

--- a/rpc/src/v1/traits/mempool.rs
+++ b/rpc/src/v1/traits/mempool.rs
@@ -38,9 +38,14 @@ pub trait Mempool {
     #[rpc(name = "mempool_deleteAllPendingTransactions")]
     fn delete_all_pending_transactions(&self) -> Result<()>;
 
-    /// Gets transactions in the current mem pool.
+    /// Gets transactions in the current mem pool. future_included is set to check whether append future queue or not.
     #[rpc(name = "mempool_getPendingTransactions")]
-    fn get_pending_transactions(&self, from: Option<u64>, to: Option<u64>) -> Result<PendingTransactions>;
+    fn get_pending_transactions(
+        &self,
+        from: Option<u64>,
+        to: Option<u64>,
+        future_included: bool,
+    ) -> Result<PendingTransactions>;
 
     /// Gets the count of transactions in the current mem pool.
     #[rpc(name = "mempool_getPendingTransactionsCount")]

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -1631,7 +1631,7 @@ Gets transactions that have insertion_timestamps within the given range from the
 ### Params
  1. from: `number | null` - The lower bound of collected pending transactions. If null, there is no lower bound.
  2. to: `number | null` - The upper bound of collected pending transactions. If null, there is no upper bound.
-
+ 3. future_included: `boolean` -  The parameter to include future transactions. If true, future transactions are included.
 ### Returns
 `{ transactions: Transaction[], lastTimestamp: number }`
 
@@ -1639,7 +1639,7 @@ Gets transactions that have insertion_timestamps within the given range from the
 ```
   curl \
     -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "mempool_getPendingTransactions", "params": [null, null], "id": null}' \
+    -d '{"jsonrpc": "2.0", "method": "mempool_getPendingTransactions", "params": [null, null,true], "id": null}' \
     localhost:8080
 ```
 
@@ -1683,7 +1683,8 @@ Returns a count of the transactions that have insertion_timestamps within the gi
 ### Params
  1. from: `number | null` - The lower bound of collected pending transactions. If null, there is no lower bound.
  2. to: `number | null` - The upper bound of collected pending transactions. If null, there is no upper bound.
-
+ 3. future_included: `boolean` -  The parameter to count future transactions. If true, future transactions are also counted.
+ 
 ### Returns
 `number`
 
@@ -1691,7 +1692,7 @@ Returns a count of the transactions that have insertion_timestamps within the gi
 ```
   curl \
     -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "mempool_getPendingTransactionsCount", "params": [null, null], "id": null}' \
+    -d '{"jsonrpc": "2.0", "method": "mempool_getPendingTransactionsCount", "params": [null, null,true], "id": null}' \
     localhost:8080
 ```
 

--- a/test/package.json
+++ b/test/package.json
@@ -59,7 +59,7 @@
     "codechain-primitives": "^1.0.4",
     "codechain-stakeholder-sdk": "https://github.com/junha1/codechain-stakeholder-sdk-js#master",
     "elliptic": "^6.4.1",
-    "foundry-rpc": "git://github.com/CodeChain-io/foundry-rpc-js.git#alpha-1",
+    "foundry-rpc": "git://github.com/CodeChain-io/foundry-rpc-js.git#alpha-2",
     "jayson": "^3.2.0",
     "lodash": "^4.17.11",
     "mkdirp": "^0.5.1",

--- a/test/src/e2e/mempool.test.ts
+++ b/test/src/e2e/mempool.test.ts
@@ -126,6 +126,36 @@ describe("Get Pending Transaction", function() {
     });
 });
 
+describe("Count pending transactions", function() {
+    let node: CodeChain;
+
+    beforeEach(async function() {
+        node = new CodeChain();
+        await node.start();
+    });
+
+    it("Counting transactions included future transactions", async function() {
+        await node.rpc.devel!.stopSealing();
+
+        const sq = (await node.rpc.chain.getSeq({
+            address: faucetAddress.toString()
+        }))!;
+        const tx = await node.sendPayTx({ seq: sq + 3 });
+        const count = await node.rpc.mempool.countPendingTransactions({
+            futureIncluded: true
+        });
+
+        expect(count).to.equal(1);
+    });
+
+    afterEach(async function() {
+        if (this.currentTest!.state === "failed") {
+            node.keepLogs();
+        }
+        await node.clean();
+    });
+});
+
 describe("Delete All Pending Transactions", function() {
     let node: CodeChain;
 

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -1711,9 +1711,9 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-"foundry-rpc@git://github.com/CodeChain-io/foundry-rpc-js.git#alpha-1":
+"foundry-rpc@git://github.com/CodeChain-io/foundry-rpc-js.git#alpha-2":
   version "2.0.0"
-  resolved "git://github.com/CodeChain-io/foundry-rpc-js.git#e8ac3979f460f837c5dcb9383d7ed22aaa15091d"
+  resolved "git://github.com/CodeChain-io/foundry-rpc-js.git#e87fba595a37932a795300e788c01609df5c681e"
   dependencies:
     "@types/node-fetch" "^2.3.4"
     node-fetch "^2.6.0"


### PR DESCRIPTION
The change is supposed to include the future queue in pending transactions as well. Previously, we only had the current queue. Now, `mempool_getPendingTransactions` can return either the `current queue` or both the `current` and `future queues`. In order to have `future queue`, the boolean `future_included` parameter is considered. It fixes #150 