### PR TITLE
Adapt tendermint test to handle Engine error

### DIFF
--- a/test/src/e2e.long/tendermint.test.ts
+++ b/test/src/e2e.long/tendermint.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../helper/constants";
 import { PromiseExpect } from "../helper/promise";
 import CodeChain from "../helper/spawn";
+import { ERROR } from "../helper/error";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -107,26 +108,38 @@ describe("Tendermint ", function() {
 
         it("larger than the current block", async function() {
             const currentBlock = await nodes[0].getBestBlockNumber();
-            expect(
-                nodes[0].rpc.chain.getPossibleAuthors({
+            try {
+                await nodes[0].rpc.chain.getPossibleAuthors({
                     blockNumber: currentBlock + 10
-                })
-            ).be.rejectedWith("Engine");
-            expect(
-                nodes[1].rpc.chain.getPossibleAuthors({
+                });
+                expect.fail();
+            } catch (e) {
+                expect(e.toString()).is.include(ERROR.ENGIN_ERROR);
+            }
+            try {
+                await nodes[1].rpc.chain.getPossibleAuthors({
                     blockNumber: currentBlock + 100
-                })
-            ).be.rejectedWith("Engine");
-            expect(
-                nodes[2].rpc.chain.getPossibleAuthors({
+                });
+                expect.fail();
+            } catch (e) {
+                expect(e.toString()).is.include(ERROR.ENGIN_ERROR);
+            }
+            try {
+                await nodes[2].rpc.chain.getPossibleAuthors({
                     blockNumber: currentBlock + 1000
-                })
-            ).be.rejectedWith("Engine");
-            expect(
-                nodes[3].rpc.chain.getPossibleAuthors({
+                });
+                expect.fail();
+            } catch (e) {
+                expect(e.toString()).is.include(ERROR.ENGIN_ERROR);
+            }
+            try {
+                await nodes[3].rpc.chain.getPossibleAuthors({
                     blockNumber: currentBlock + 10000
-                })
-            ).be.rejectedWith("Engine");
+                });
+                expect.fail();
+            } catch (e) {
+                expect(e.toString()).is.include(ERROR.ENGIN_ERROR);
+            }
         });
     });
 

--- a/test/src/helper/error.ts
+++ b/test/src/helper/error.ts
@@ -20,6 +20,11 @@ import { $anything, $containsWord, similar } from "./chai-similar";
 chai.use(similar);
 
 export const ERROR: any = {
+    ENGIN_ERROR: {
+        code: -32010,
+        data: $anything,
+        message: $anything
+    },
     NOT_ENOUGH_BALANCE: {
         code: -32032,
         data: $anything,


### PR DESCRIPTION
Previously, when there was codechain dependency tenderminet could handle Engine
error. Foundry rpc can not handle Engine error. In this patch, the Engin error
is handled.