### PR TITLE
Hot events for Informer API 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ version = "0.1.0"
 dependencies = [
  "cidr",
  "codechain-crypto",
+ "codechain-informer",
  "codechain-io",
  "codechain-key",
  "codechain-logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "codechain-informer"
+version = "0.1.0"
+dependencies = [
+ "cidr",
+ "codechain-logger",
+ "crossbeam-channel",
+ "jsonrpc-core",
+ "jsonrpc-derive",
+ "jsonrpc-http-server",
+ "jsonrpc-ipc-server",
+ "jsonrpc-pubsub",
+ "jsonrpc-ws-server",
+ "kvdb",
+ "lazy_static 1.2.0",
+ "log 0.4.6",
+ "parking_lot 0.6.4",
+ "primitives",
+ "rand 0.6.1",
+ "rlp",
+ "rustc-hex 1.0.0",
+ "rustc-serialize",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+]
+
+[[package]]
 name = "codechain-io"
 version = "1.9.0"
 dependencies = [
@@ -1001,6 +1029,7 @@ dependencies = [
  "clap",
  "codechain-core",
  "codechain-discovery",
+ "codechain-informer",
  "codechain-key",
  "codechain-keystore",
  "codechain-logger",
@@ -1009,6 +1038,7 @@ dependencies = [
  "codechain-sync",
  "codechain-timer",
  "codechain-types",
+ "crossbeam-channel",
  "ctrlc",
  "env_logger 0.5.10",
  "fdlimit",
@@ -1388,6 +1418,17 @@ dependencies = [
  "parity-tokio-ipc",
  "parking_lot 0.9.0",
  "tokio-service",
+]
+
+[[package]]
+name = "jsonrpc-pubsub"
+version = "14.0.3"
+source = "git+https://github.com/paritytech/jsonrpc.git?tag=v14.0.3#2135c25df57715238f1709365e3ea3bedc88e030"
+dependencies = [
+ "jsonrpc-core",
+ "log 0.4.6",
+ "parking_lot 0.9.0",
+ "serde",
 ]
 
 [[package]]
@@ -2514,9 +2555,9 @@ checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,12 @@ ckey = { package = "codechain-key", path = "key" }
 ctypes = { package = "codechain-types", path = "types" }
 ckeystore = { package = "codechain-keystore", path = "keystore" }
 cnetwork = { package = "codechain-network", path = "network" }
+cinformer = {package = "codechain-informer", path = "informer"}
 crpc = { package = "codechain-rpc", path = "rpc" }
 csync = { package = "codechain-sync", path = "sync" }
 ctimer = { package = "codechain-timer", path = "util/timer" }
 ctrlc = { git = "https://github.com/paritytech/rust-ctrlc.git" }
+crossbeam-channel = "0.3"
 fdlimit = "0.1"
 finally-block = "0.1"
 futures = "0.1"
@@ -67,6 +69,7 @@ members = [
     "keystore",
     "network",
     "rpc",
+    "informer",
     "sync",
     "types",
 ]

--- a/foundry/config/presets/config.dev.toml
+++ b/foundry/config/presets/config.dev.toml
@@ -40,6 +40,12 @@ port = 8080
 disable = false
 path = "/tmp/jsonrpc.ipc"
 
+[informer]
+disable = false
+interface = "127.0.0.1"
+port = 7070
+max_connections = 100
+
 [ws]
 disable = false
 interface = "127.0.0.1"

--- a/foundry/config/presets/config.prod.toml
+++ b/foundry/config/presets/config.prod.toml
@@ -40,6 +40,12 @@ port = 8080
 disable = false
 path = "/tmp/jsonrpc.ipc"
 
+[informer]
+disable = true
+interface = "127.0.0.1"
+port = 7070
+max_connections = 100
+
 [ws]
 disable = true
 interface = "127.0.0.1"

--- a/foundry/foundry.yml
+++ b/foundry/foundry.yml
@@ -105,6 +105,31 @@ args:
         value_name: PORT
         help: Listen for rpc connections on PORT.
         takes_value: true
+    - informer-interface:
+        long: informer-interface
+        value_name: INFORMER
+        help: Specify the interface address for the WebSockets JSON-RPC server.
+        takes_value: true
+        conflicts_with:
+          - no-informer
+    - informer-port:
+        long: informer-port
+        value_name: INF-PORT
+        help: Specify the port portion of the WebSockets JSON-RPC server.
+        takes_value: true
+        conflicts_with:
+          - no-informer
+    - informer-max-connections:
+        long: informer-max-connections
+        value_name: MCON
+        help: Maximum number of allowed concurrent WebSockets JSON-RPC connections.
+        takes_value: true
+        conflicts_with:
+          - no-informer
+    - no-informer:
+        long: no-informer
+        help: Do not run the WebSockets JSON-RPC server.
+        takes_value: false
     - no-ipc:
         long: no-ipc
         help: Do not run JSON-RPC over IPC service.

--- a/informer/Cargo.toml
+++ b/informer/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "codechain-informer"
+version = "0.1.0"
+authors = ["MSNTCS <najafi@codechain.io>"]
+edition = "2018"
+
+[lib]
+
+[dependencies]
+cidr = "0.0.4"
+codechain-logger = { path = "../util/logger" }
+kvdb = "0.1"
+lazy_static = "1.2"
+crossbeam-channel = "0.3"
+parking_lot = "0.6.0"
+primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
+rlp = { git = "https://github.com/CodeChain-io/rlp.git", version = "0.4" }
+serde = "1.0"
+log = "0.4.6"
+serde_json = "1.0"
+serde_derive = "1.0"
+rand = "0.6.1"
+rustc-hex = "1.0"
+rustc-serialize = "0.3"
+time = "0.1"
+jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc.git", tag = "v14.0.3" }
+jsonrpc-derive = { git = "https://github.com/paritytech/jsonrpc.git", tag = "v14.0.3" }
+jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc.git", tag = "v14.0.3" }
+jsonrpc-ipc-server = { git = "https://github.com/paritytech/jsonrpc.git", tag = "v14.0.3" }
+jsonrpc-ws-server = { git = "https://github.com/paritytech/jsonrpc.git", tag = "v14.0.3" }
+jsonrpc-pubsub = { git = "https://github.com/paritytech/jsonrpc.git", tag = "v14.0.3" }
+

--- a/informer/src/handler/connection.rs
+++ b/informer/src/handler/connection.rs
@@ -1,0 +1,66 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{EventTags, Events, Params, Sink};
+use futures::Future;
+use jsonrpc_core::futures;
+
+enum ConnectionState {
+    Connected,
+}
+
+pub struct Connection {
+    status: ConnectionState,
+    pub subscription_id: u64,
+    pub interested_events: Vec<EventTags>,
+    sink: Sink,
+}
+
+impl Connection {
+    pub fn new(sink: Sink, sub_id: u64) -> Self {
+        Self {
+            status: ConnectionState::Connected,
+            subscription_id: sub_id,
+            interested_events: Vec::new(),
+            sink,
+        }
+    }
+    pub fn add_events(&mut self, params: Vec<String>) {
+        match params[0].as_str() {
+            "PeerAdded" => {
+                let event = EventTags::PeerAdded;
+                cinfo!(INFORMER, "The event is successfully added to user's interested events");
+                self.interested_events.push(event);
+            }
+            _ => {
+                cinfo!(INFORMER, "invalid Event: the event is not supported");
+            }
+        }
+    }
+
+    pub fn notify_client(&self, event: &Events) {
+        let json_object = serde_json::to_value(event).expect("json format is not valid").as_object_mut().cloned();
+        let params = Params::Map(json_object.expect("Event is serialized as object"));
+        match self.status {
+            ConnectionState::Connected => match self.sink.notify(params).wait() {
+                Ok(_) => {}
+                Err(_) => {
+                    cinfo!(INFORMER, "Subscription has ended, finishing.");
+                }
+            },
+        }
+    }
+}

--- a/informer/src/handler/mod.rs
+++ b/informer/src/handler/mod.rs
@@ -1,0 +1,21 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+mod connection;
+mod rpc_ws_handler;
+
+pub use connection::Connection;
+pub use rpc_ws_handler::{Handler, InformerConfig};

--- a/informer/src/handler/rpc_ws_handler.rs
+++ b/informer/src/handler/rpc_ws_handler.rs
@@ -1,0 +1,103 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{
+    start_ws, Connection, Error, ErrorCode, Params, PubSubHandler, Rng, Session, Subscriber, SubscriptionId, Value,
+    WsError, WsServer,
+};
+use crossbeam::Sender;
+use crossbeam_channel as crossbeam;
+use jsonrpc_core::{futures, BoxFuture};
+use std::io;
+use std::sync::Arc;
+
+pub struct InformerConfig {
+    pub interface: String,
+    pub port: u16,
+    pub max_connections: usize,
+}
+
+pub struct Handler {
+    pub handler: PubSubHandler<Arc<Session>>,
+}
+
+impl Handler {
+    pub fn new(handler: PubSubHandler<Arc<Session>>) -> Self {
+        Self {
+            handler,
+        }
+    }
+    pub fn start_ws(self, config: InformerConfig) -> Result<WsServer, String> {
+        let url = format!("{}:{}", config.interface, config.port);
+        let addr = url.parse().map_err(|_| format!("Invalid WebSockets listen host/port given: {}", url))?;
+        let server = self.handler;
+        let start_result = start_ws(&addr, server, config.max_connections);
+        match start_result {
+            Err(WsError::Io(ref err)) if err.kind() == io::ErrorKind::AddrInUse => {
+                Err(format!("WebSockets address {} is already in use, make sure that another instance of a Codechain node is not using this", addr))
+            },
+            Err(e) => {
+                Err(format!("WebSockets error: {:?}", e))
+            },
+            Ok(server) => {
+                cinfo!(INFORMER, "WebSockets Listening on {}", addr);
+                Ok(server)
+            },
+        }
+    }
+    pub fn event_subscription(&mut self, sender: Sender<Connection>) {
+        self.handler.add_subscription(
+            "register",
+            ("register", move |params: Params, _, subscriber: Subscriber| {
+                if params == Params::None {
+                    subscriber
+                        .reject(Error {
+                            code: ErrorCode::ParseError,
+                            message: "Invalid parameters. Subscription rejected.".into(),
+                            data: None,
+                        })
+                        .expect("Connection is alive");
+                    return
+                }
+                let parsed_params: Result<Vec<String>, Error> = params.parse();
+                let all_params = match parsed_params {
+                    Ok(params) => params,
+                    Err(_err) => {
+                        subscriber
+                            .reject(Error {
+                                code: ErrorCode::ParseError,
+                                message: "Invalid parameters. Subscription rejected.".into(),
+                                data: None,
+                            })
+                            .expect("Connection is alive");
+                        return
+                    }
+                };
+                let mut rng = rand::thread_rng();
+                let sub_id = rng.gen();
+                let sink = subscriber.assign_id(SubscriptionId::Number(sub_id)).expect("Connection is alive");
+                let mut connection = Connection::new(sink, sub_id);
+                connection.add_events(all_params);
+                sender.send(connection).unwrap();
+            }),
+            // FIXME: We need another channel to remove connections form informer Service after Deregister
+            ("deregister", |_id: SubscriptionId, _meta| -> BoxFuture<Value> {
+                cinfo!(INFORMER, "Closing subscription");
+                Box::new(futures::future::ok(Value::Bool(true)))
+            }),
+        );
+    }
+}

--- a/informer/src/informer_service/informer_notify.rs
+++ b/informer/src/informer_service/informer_notify.rs
@@ -1,0 +1,57 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+use crate::Events;
+use crossbeam::{bounded, unbounded, Receiver, Sender};
+use crossbeam_channel as crossbeam;
+
+pub fn create() -> (InformerEventSender, Receiver<Events>) {
+    // FIXME: unbound would cause memory leak.
+    // FIXME: The full queue should be handled.
+    // This will be fixed soon.
+    let (tx, rx) = unbounded();
+    let event_sender = tx;
+    (
+        InformerEventSender {
+            event_sender,
+        },
+        rx,
+    )
+}
+
+#[derive(Clone)]
+pub struct InformerEventSender {
+    event_sender: Sender<Events>,
+}
+
+impl InformerEventSender {
+    pub fn notify(&self, event: Events) {
+        let guard = &self.event_sender;
+        if let Some(event_sender) = Some(guard) {
+            // TODO: Ignore the error. Receiver thread might be terminated or congested.
+            let _ = event_sender.try_send(event);
+        } else {
+            // TODO: ReceiverCanceller would dropped.
+        }
+    }
+    // FIXME: Handle error from try sender
+    pub fn null_notifier() -> Self {
+        let (sender, receiver) = bounded(0);
+        std::mem::drop(receiver);
+        Self {
+            event_sender: sender,
+        }
+    }
+}

--- a/informer/src/informer_service/informer_service_handler.rs
+++ b/informer/src/informer_service/informer_service_handler.rs
@@ -1,0 +1,100 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{informer_notify, Connection, InformerEventSender};
+use crossbeam::Receiver;
+use crossbeam_channel as crossbeam;
+use std::thread::spawn;
+
+#[derive(Clone)]
+pub enum EventTags {
+    PeerAdded,
+}
+
+#[derive(Serialize)]
+pub enum Events {
+    PeerAdded(String, String, usize),
+}
+
+pub struct InformerService {
+    connections: Vec<Connection>,
+    event_receiver: Receiver<Events>,
+    connection_receiver: Receiver<Connection>,
+}
+
+impl InformerService {
+    pub fn new(connection_receiver: Receiver<Connection>) -> (Self, InformerEventSender) {
+        let (sender, event_receiver) = informer_notify::create();
+        (
+            Self {
+                connections: Vec::new(),
+                event_receiver,
+                connection_receiver,
+            },
+            sender,
+        )
+    }
+
+    pub fn run_service(mut self) {
+        let event_rcv = self.event_receiver.clone();
+        let connection_rcv = self.connection_receiver.clone();
+        spawn(move || {
+            cinfo!(INFORMER, "Informer Service has started");
+            let mut select = crossbeam::Select::new();
+            let event_index = select.recv(&event_rcv);
+            let connection_index = select.recv(&connection_rcv);
+            loop {
+                match select.ready() {
+                    index if index == event_index => {
+                        if let Ok(event) = event_rcv.try_recv() {
+                            cinfo!(INFORMER, "Event is sent to all clients");
+                            self.notify_client(event);
+                        }
+                    }
+                    index if index == connection_index => {
+                        if let Ok(connection) = connection_rcv.recv() {
+                            cinfo!(INFORMER, "A new connection is added");
+                            self.add_new_connection(connection);
+                        }
+                    }
+                    _ => {
+                        cerror!(INFORMER, "is not an expected index of message queue");
+                    }
+                }
+            }
+        });
+    }
+
+    pub fn add_new_connection(&mut self, connection: Connection) {
+        self.connections.push(connection);
+    }
+
+    fn compare_event_types(tag: &EventTags, event: &Events) -> bool {
+        match (tag, event) {
+            (EventTags::PeerAdded, Events::PeerAdded(..)) => true,
+        }
+    }
+
+    pub fn notify_client(&self, popup_event: Events) {
+        for connection in &self.connections {
+            for interested_event in connection.interested_events.clone() {
+                if InformerService::compare_event_types(&interested_event, &popup_event) {
+                    connection.notify_client(&popup_event);
+                }
+            }
+        }
+    }
+}

--- a/informer/src/informer_service/mod.rs
+++ b/informer/src/informer_service/mod.rs
@@ -1,0 +1,21 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pub mod informer_notify;
+mod informer_service_handler;
+
+pub use informer_notify::InformerEventSender;
+pub use informer_service_handler::{EventTags, Events, InformerService};

--- a/informer/src/lib.rs
+++ b/informer/src/lib.rs
@@ -1,0 +1,37 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#[macro_use]
+extern crate codechain_logger as clogger;
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate serde_derive;
+
+extern crate rand;
+
+pub mod handler;
+mod informer_service;
+pub mod rpc_server;
+
+pub use handler::{Connection, InformerConfig};
+pub use informer_service::{informer_notify, EventTags, Events, InformerEventSender, InformerService};
+pub use jsonrpc_core;
+pub use jsonrpc_core::{Compatibility, Error, ErrorCode, MetaIoHandler, Metadata, Middleware, Params, Value};
+pub use jsonrpc_pubsub::{PubSubHandler, PubSubMetadata, Session, Sink, Subscriber, SubscriptionId};
+pub use jsonrpc_ws_server::{Error as WsError, RequestContext, Server as WsServer, ServerBuilder as WsServerBuilder};
+pub use rand::Rng;
+pub use rpc_server::start_ws;

--- a/informer/src/rpc_server.rs
+++ b/informer/src/rpc_server.rs
@@ -1,0 +1,29 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{PubSubHandler, RequestContext, Session, WsError, WsServer, WsServerBuilder};
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+pub fn start_ws(
+    addr: &SocketAddr,
+    handler: PubSubHandler<Arc<Session>>,
+    max_connections: usize,
+) -> Result<WsServer, WsError> {
+    WsServerBuilder::with_meta_extractor(handler, |context: &RequestContext| Arc::new(Session::new(context.sender())))
+        .max_connections(max_connections)
+        .start(addr)
+}

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -9,6 +9,7 @@ ccrypto = { package = "codechain-crypto", git = "https://github.com/CodeChain-io
 cio = { package = "codechain-io", path = "../util/io" }
 ckey = { package = "codechain-key", path = "../key" }
 codechain-logger = { path = "../util/logger" }
+cinformer = {package = "codechain-informer", path = "../informer"}
 ctimer = { package = "codechain-timer", path = "../util/timer" }
 crossbeam-channel = "0.3"
 finally-block = "0.1"

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -20,6 +20,7 @@ use crate::filters::{FilterEntry, FiltersControl};
 use crate::routing_table::RoutingTable;
 use crate::{p2p, Api, ManagingPeerdb, NetworkExtension, SocketAddr};
 use cidr::IpCidr;
+use cinformer::InformerEventSender;
 use cio::{IoError, IoService};
 use ckey::{NetworkId, X25519Public as Public};
 use crossbeam_channel::Sender;
@@ -47,6 +48,7 @@ impl Service {
         filters_control: Arc<dyn FiltersControl>,
         routing_table: Arc<RoutingTable>,
         peer_db: Box<dyn ManagingPeerdb>,
+        sender: InformerEventSender,
     ) -> Result<Arc<Self>, Error> {
         let p2p = IoService::start("P2P")?;
 
@@ -63,6 +65,7 @@ impl Service {
             min_peers,
             max_peers,
             peer_db,
+            sender,
         )?);
         p2p.register_handler(p2p_handler.clone())?;
 

--- a/test/src/config/mem-pool-min-fee1.toml
+++ b/test/src/config/mem-pool-min-fee1.toml
@@ -8,6 +8,8 @@ self_nomination_enable = false
 
 [rpc]
 
+[informer]
+
 [ipc]
 
 [ws]

--- a/test/src/config/mem-pool-min-fee2.toml
+++ b/test/src/config/mem-pool-min-fee2.toml
@@ -10,6 +10,8 @@ self_nomination_enable = false
 
 [ipc]
 
+[informer]
+
 [ws]
 
 [snapshot]

--- a/test/src/helper/spawn.ts
+++ b/test/src/helper/spawn.ts
@@ -240,6 +240,7 @@ export default class CodeChain {
                 `target/${useDebugBuild ? "debug" : "release"}/foundry`,
                 [
                     ...baseArgs,
+                    "--no-informer",
                     "--chain",
                     this.chain,
                     "--db-path",

--- a/test/tendermint.dynval/snapshot-config.yml
+++ b/test/tendermint.dynval/snapshot-config.yml
@@ -9,6 +9,8 @@ self_nomination_enable = false
 
 [ipc]
 
+[informer]
+
 [ws]
 
 [snapshot]

--- a/util/logger/src/macros.rs
+++ b/util/logger/src/macros.rs
@@ -97,6 +97,9 @@ macro_rules! log_target {
     (TX) => {
         "tx"
     };
+    (INFORMER) => {
+        "informer"
+    };
 }
 
 #[macro_export]


### PR DESCRIPTION
Informer API is supposed to send events as soon as they are triggered to all subscribed clients. In this PR, Hot events, those are not retrieved from the history of the event, are covered.  