### PR TITLE
[WIP] Implement.execute.block.call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,7 @@ dependencies = [
  "codechain-timer",
  "codechain-types",
  "codechain-vm",
+ "coordinator",
  "crossbeam-channel 0.3.8",
  "hyper 0.10.0-a.0",
  "kvdb",

--- a/coordinator/src/context.rs
+++ b/coordinator/src/context.rs
@@ -1,2 +1,7 @@
 /// A `Context` provides the interface against the system services such as
 pub trait Context {}
+
+#[derive(Default)]
+pub struct DummyContext {}
+
+impl Context for DummyContext {}

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -1,4 +1,3 @@
-use ctypes::header::Header;
 use std::unimplemented;
 use validator::*;
 

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -9,6 +9,8 @@ pub mod validator;
 ///
 /// It assembles modules and feeds them various events from the underlying
 /// consensus engine.
+
+#[derive(Default)]
 pub struct Coordinator<C: context::Context> {
     context: C,
 }

--- a/coordinator/src/validator.rs
+++ b/coordinator/src/validator.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 
 use ckey::Public;
-use ctypes::{header::Header, BlockHash};
+use ctypes::BlockHash;
 
 /// A `Validator` receives requests from the underlying consensus engine
 /// and performs validation of blocks and Txes.
@@ -47,6 +47,19 @@ pub struct ConsensusParams {
     /// allowed future time gap in milliseconds.
     pub allowed_future_timegap: Option<u64>,
 }
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Header {
+    /// Block timestamp.
+    timestamp: u64,
+    /// Block number.
+    number: u64,
+    /// Block author.
+    author: Public,
+    /// Block extra data.
+    extra_data: Bytes,
+}
+
 
 /// A decoded transaction.
 pub struct Transaction<'a> {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ cjson = { package = "codechain-json", path = "../json" }
 ckey = { package = "codechain-key", path = "../key" }
 ckeystore = { package = "codechain-keystore", path="../keystore" }
 codechain-logger = { path = "../util/logger" }
+coordinator = { path = "../coordinator" }
 cnetwork = { package = "codechain-network", path = "../network" }
 cstate = { package = "codechain-state", path = "../state" }
 ctimer = { package = "codechain-timer", path = "../util/timer" }

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -42,6 +42,7 @@ use crate::views::HeaderView;
 use crate::Client;
 use ckey::{Address, SchnorrSignature};
 use cnetwork::NetworkService;
+use coordinator::{context::DummyContext, Coordinator};
 use cstate::ActionHandler;
 use ctypes::errors::SyntaxError;
 use ctypes::transaction::Action;
@@ -119,6 +120,8 @@ pub trait ConsensusEngine: Sync + Send {
 
     /// Get access to the underlying state machine.
     fn machine(&self) -> &CodeChainMachine;
+
+    fn coordinator(&mut self) -> &mut Coordinator<DummyContext>;
 
     /// The number of additional header fields required for this engine.
     fn seal_fields(&self, _header: &Header) -> usize {

--- a/core/src/consensus/null_engine/mod.rs
+++ b/core/src/consensus/null_engine/mod.rs
@@ -23,6 +23,7 @@ use crate::codechain_machine::CodeChainMachine;
 use crate::consensus::{EngineError, EngineType};
 use crate::error::Error;
 use ckey::Address;
+use coordinator::{context::DummyContext, Coordinator};
 use ctypes::CommonParams;
 
 /// An engine which does not provide any consensus mechanism and does not seal blocks.
@@ -48,6 +49,10 @@ impl ConsensusEngine for NullEngine {
 
     fn machine(&self) -> &CodeChainMachine {
         &self.machine
+    }
+
+    fn coordinator(&mut self) -> &mut Coordinator<DummyContext> {
+        unimplemented!()
     }
 
     fn seals_internally(&self) -> bool {

--- a/core/src/consensus/solo/mod.rs
+++ b/core/src/consensus/solo/mod.rs
@@ -26,6 +26,7 @@ use crate::codechain_machine::CodeChainMachine;
 use crate::consensus::{EngineError, EngineType};
 use crate::error::Error;
 use ckey::Address;
+use coordinator::{context::DummyContext, Coordinator};
 use cstate::{ActionHandler, HitHandler, TopStateView};
 use ctypes::{BlockHash, CommonParams, Header};
 use parking_lot::RwLock;
@@ -70,6 +71,10 @@ impl ConsensusEngine for Solo {
 
     fn machine(&self) -> &CodeChainMachine {
         &self.machine
+    }
+
+    fn coordinator(&mut self) -> &mut Coordinator<DummyContext> {
+        unimplemented!()
     }
 
     fn seals_internally(&self) -> bool {

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -34,6 +34,7 @@ use crate::views::HeaderView;
 use crate::BlockId;
 use ckey::{public_to_address, Address};
 use cnetwork::NetworkService;
+use coordinator::{context::DummyContext, Coordinator};
 use crossbeam_channel as crossbeam;
 use cstate::{ActionHandler, TopState, TopStateView};
 use ctypes::{BlockHash, CommonParams, Header};
@@ -60,6 +61,10 @@ impl ConsensusEngine for Tendermint {
 
     fn machine(&self) -> &CodeChainMachine {
         &self.machine.as_ref()
+    }
+
+    fn coordinator(&mut self) -> &mut Coordinator<DummyContext> {
+        &mut self.coordinator
     }
 
     /// (consensus view, proposal signature, authority signatures)

--- a/core/src/consensus/tendermint/mod.rs
+++ b/core/src/consensus/tendermint/mod.rs
@@ -34,6 +34,7 @@ use crate::client::ConsensusClient;
 use crate::codechain_machine::CodeChainMachine;
 use crate::snapshot_notify::NotifySender as SnapshotNotifySender;
 use crate::ChainNotify;
+use coordinator::{context::DummyContext, Coordinator};
 use crossbeam_channel as crossbeam;
 use cstate::ActionHandler;
 use ctimer::TimerToken;
@@ -54,6 +55,7 @@ const ENGINE_TIMEOUT_BROADCAT_STEP_STATE_INTERVAL: u64 = 1;
 
 /// ConsensusEngine using `Tendermint` consensus algorithm
 pub struct Tendermint {
+    coordinator: Coordinator<DummyContext>,
     client: RwLock<Option<Weak<dyn ConsensusClient>>>,
     external_params_initializer: crossbeam::Sender<TimeGapParams>,
     extension_initializer: crossbeam::Sender<(crossbeam::Sender<network::Event>, Weak<dyn ConsensusClient>)>,
@@ -105,6 +107,7 @@ impl Tendermint {
         let chain_notify = Arc::new(TendermintChainNotify::new(inner.clone()));
 
         Arc::new(Tendermint {
+            coordinator: Coordinator::default(),
             client: Default::default(),
             external_params_initializer,
             extension_initializer,


### PR DESCRIPTION
I tried to simplify the work as far as I could.

TODO:
- [x] Use `execute_block` interface in importer
- [ ] Implement and use `commit` and `revert` interface
- [ ] Decouple double vote reporting logic from host
    - [ ] Create double vote type in coordinator crate (cannot import from the core because of cyclic dependency)
- [ ] Change transaction encoding
    - [ ] Do less decoding in `VerificationQueue`
- [ ] Inject coordinator reference to engine
- [ ] Implement `execute_block`
    - transaction verification should be done here
Remaining issues:
- Handling `evidence` when calling `execute_block`
- where should we call `mempool.remove_old`?

