### PR TITLE
[WIP] Implement check_transaction call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,7 @@ dependencies = [
  "codechain-timer",
  "codechain-types",
  "codechain-vm",
+ "coordinator",
  "crossbeam-channel 0.3.8",
  "hyper 0.10.0-a.0",
  "kvdb",

--- a/coordinator/src/context.rs
+++ b/coordinator/src/context.rs
@@ -1,2 +1,7 @@
 /// A `Context` provides the interface against the system services such as
 pub trait Context {}
+
+#[derive(Default)]
+pub struct DummyContext {}
+
+impl Context for DummyContext {}

--- a/coordinator/src/validator.rs
+++ b/coordinator/src/validator.rs
@@ -60,6 +60,7 @@ pub struct Header {
 }
 
 /// A decoded transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Transaction {
     tx_type: String,
     body: Bytes,
@@ -92,6 +93,7 @@ pub enum TxOrigin {
     External,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransactionWithMetadata {
     pub tx: Transaction,
     pub origin: TxOrigin,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["CodeChain Team <hi@codechain.io>"]
 edition = "2018"
 
 [dependencies]
+coordinator = { path = "../coordinator" }
 ccrypto = { package = "codechain-crypto", git = "https://github.com/CodeChain-io/rust-codechain-crypto.git", version = "0.2" }
 cdb = { package = "codechain-db", git = "https://github.com/CodeChain-io/rust-codechain-db.git", version = "0.2" }
 cio = { package = "codechain-io", path = "../util/io" }

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -648,14 +648,6 @@ impl BlockChainClient for Client {
         self.importer.miner.count_pending_transactions(range)
     }
 
-    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
-        self.importer.miner.future_pending_transactions(range)
-    }
-
-    fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize {
-        self.importer.miner.future_included_count_pending_transactions(range)
-    }
-
     fn is_pending_queue_empty(&self) -> bool {
         self.importer.miner.status().transactions_in_pending_queue == 0
     }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -219,14 +219,8 @@ pub trait BlockChainClient: Sync + Send + AccountData + BlockChainTrait + Import
     /// List all transactions that are allowed into the next block.
     fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
 
-    /// List all transactions in future block.
-    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
-
     /// Get the count of all pending transactions currently in the mem_pool.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;
-
-    /// Get the count of all pending transactions included future transaction in the mem_pool.
-    fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize;
 
     /// Check there are transactions which are allowed into the next block.
     fn is_pending_queue_empty(&self) -> bool;

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -41,7 +41,7 @@ use crate::consensus::EngineError;
 use crate::db::{COL_STATE, NUM_COLUMNS};
 use crate::encoded;
 use crate::error::{BlockImportError, Error as GenericError};
-use crate::miner::{MemPoolMinFees, Miner, MinerService, TransactionImportResult};
+use crate::miner::{MemPoolMinFees, Miner, MinerService};
 use crate::scheme::Scheme;
 use crate::transaction::{LocalizedTransaction, PendingSignedTransactions, SignedTransaction};
 use crate::types::{BlockId, TransactionId, VerificationQueueInfo as QueueInfo};
@@ -292,7 +292,6 @@ impl TestBlockChainClient {
         let hash = signed.hash();
         let res = self.miner.import_external_transactions(self, vec![signed.into()]);
         let res = res.into_iter().next().unwrap().expect("Successful import");
-        assert_eq!(res, TransactionImportResult::Current);
         hash
     }
 
@@ -528,16 +527,8 @@ impl BlockChainClient for TestBlockChainClient {
         self.miner.ready_transactions(range)
     }
 
-    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
-        self.miner.future_pending_transactions(range)
-    }
-
     fn count_pending_transactions(&self, range: Range<u64>) -> usize {
         self.miner.count_pending_transactions(range)
-    }
-
-    fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize {
-        self.miner.future_included_count_pending_transactions(range)
     }
 
     fn is_pending_queue_empty(&self) -> bool {

--- a/core/src/miner/backup.rs
+++ b/core/src/miner/backup.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::mem_pool_types::MemPoolItem;
 use crate::db as dblib;
+use coordinator::validator::TransactionWithMetadata;
 use kvdb::{DBTransaction, KeyValueDB};
 use primitives::H256;
 use rlp::Encodable;
@@ -28,7 +28,7 @@ pub fn backup_batch_with_capacity(length: usize) -> DBTransaction {
     DBTransaction::with_capacity(length)
 }
 
-pub fn backup_item(batch: &mut DBTransaction, key: H256, item: &MemPoolItem) {
+pub fn backup_item(batch: &mut DBTransaction, key: H256, item: &TransactionWithMetadata) {
     let mut db_key = PREFIX_ITEM.to_vec();
     db_key.extend_from_slice(key.as_ref());
     batch.put(dblib::COL_MEMPOOL, db_key.as_ref(), item.rlp_bytes().as_ref());
@@ -40,7 +40,7 @@ pub fn remove_item(batch: &mut DBTransaction, key: &H256) {
     batch.delete(dblib::COL_MEMPOOL, db_key.as_ref());
 }
 
-pub fn recover_to_data(db: &dyn KeyValueDB) -> HashMap<H256, MemPoolItem> {
+pub fn recover_to_data(db: &dyn KeyValueDB) -> HashMap<H256, TransactionWithMetadata> {
     let mut by_hash = HashMap::new();
 
     for (key, value) in db.iter(dblib::COL_MEMPOOL) {

--- a/core/src/miner/mem_pool_types.rs
+++ b/core/src/miner/mem_pool_types.rs
@@ -14,387 +14,63 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::transaction::SignedTransaction;
-use ckey::Public;
+use coordinator::validator::TransactionWithMetadata;
 use ctypes::transaction::Action;
 use ctypes::{BlockNumber, TxHash};
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
-use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::HashMap;
 
-/// Point in time when transaction was inserted.
 pub type PoolingInstant = BlockNumber;
 
-/// Transaction origin
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum TxOrigin {
-    /// Transaction coming from local RPC
-    Local,
-    /// External transaction received from network
-    External,
-}
-
-type TxOriginType = u8;
-const LOCAL: TxOriginType = 0x01;
-const EXTERNAL: TxOriginType = 0x02;
-
-impl Encodable for TxOrigin {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        match self {
-            TxOrigin::Local => LOCAL.rlp_append(s),
-            TxOrigin::External => EXTERNAL.rlp_append(s),
-        };
-    }
-}
-
-impl Decodable for TxOrigin {
-    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
-        match d.as_val().expect("rlp decode Error") {
-            LOCAL => Ok(TxOrigin::Local),
-            EXTERNAL => Ok(TxOrigin::External),
-            _ => Err(DecoderError::Custom("Unexpected Txorigin type")),
-        }
-    }
-}
-
-impl PartialOrd for TxOrigin {
-    fn partial_cmp(&self, other: &TxOrigin) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for TxOrigin {
-    fn cmp(&self, other: &TxOrigin) -> Ordering {
-        if *other == *self {
-            return Ordering::Equal
-        }
-
-        match (*self, *other) {
-            (TxOrigin::Local, _) => Ordering::Less,
-            _ => Ordering::Greater,
-        }
-    }
-}
-
-impl TxOrigin {
-    pub fn is_local(self) -> bool {
-        self == TxOrigin::Local
-    }
-
-    pub fn is_external(self) -> bool {
-        self == TxOrigin::External
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-/// Light structure used to identify transaction and its order
-pub struct TransactionOrder {
-    /// Primary ordering factory. Difference between transaction seq and expected seq in state
-    /// (e.g. Transaction(seq:5), State(seq:0) -> height: 5)
-    /// High seq_height = Low priority (processed later)
-    pub seq_height: u64,
-    /// Fee of the transaction.
-    pub fee: u64,
-    /// Fee per bytes(rlp serialized) of the transaction
-    pub fee_per_byte: u64,
-    /// Memory usage of this transaction.
-    /// Currently using the RLP byte length of the transaction as the mem usage.
-    pub mem_usage: usize,
-    /// Hash to identify associated transaction
-    pub hash: TxHash,
-    /// Incremental id assigned when transaction is inserted to the pool.
-    pub insertion_id: u64,
-    /// Origin of the transaction
-    pub origin: TxOrigin,
-}
-
-impl TransactionOrder {
-    pub fn for_transaction(item: &MemPoolItem, seq_seq: u64) -> Self {
-        let rlp_bytes_len = rlp::encode(&item.tx).len();
-        let fee = item.tx.fee;
-        ctrace!(MEM_POOL, "New tx with size {}", rlp_bytes_len);
-        Self {
-            seq_height: item.seq() - seq_seq,
-            fee,
-            mem_usage: rlp_bytes_len,
-            fee_per_byte: fee / rlp_bytes_len as u64,
-            hash: item.hash(),
-            insertion_id: item.insertion_id,
-            origin: item.origin,
-        }
-    }
-
-    pub fn update_height(mut self, seq: u64, base_seq: u64) -> Self {
-        self.seq_height = seq - base_seq;
-        self
-    }
-
-    pub fn change_origin(mut self, origin: TxOrigin) -> Self {
-        self.origin = origin;
-        self
-    }
-}
-
-impl Eq for TransactionOrder {}
-impl PartialEq for TransactionOrder {
-    fn eq(&self, other: &TransactionOrder) -> bool {
-        self.cmp(other) == Ordering::Equal
-    }
-}
-impl PartialOrd for TransactionOrder {
-    fn partial_cmp(&self, other: &TransactionOrder) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for TransactionOrder {
-    fn cmp(&self, b: &TransactionOrder) -> Ordering {
-        // Local transactions should always have priority
-        if self.origin != b.origin {
-            return self.origin.cmp(&b.origin)
-        }
-
-        // Check seq_height
-        if self.seq_height != b.seq_height {
-            return self.seq_height.cmp(&b.seq_height)
-        }
-
-        if self.fee_per_byte != b.fee_per_byte {
-            return self.fee_per_byte.cmp(&b.fee_per_byte)
-        }
-
-        // Then compare fee
-        if self.fee != b.fee {
-            return b.fee.cmp(&self.fee)
-        }
-
-        // Lastly compare insertion_id
-        self.insertion_id.cmp(&b.insertion_id)
-    }
-}
-
-/// Transaction item in the mem pool.
-#[derive(Clone, Eq, PartialEq, Debug, RlpEncodable, RlpDecodable)]
-pub struct MemPoolItem {
-    /// Transaction.
-    pub tx: SignedTransaction,
-    /// Transaction origin.
-    pub origin: TxOrigin,
-    /// Insertion time
-    pub inserted_block_number: PoolingInstant,
-    /// Insertion timstamp
-    pub inserted_timestamp: u64,
-    /// ID assigned upon insertion, should be unique.
-    pub insertion_id: u64,
-}
-
-impl MemPoolItem {
-    pub fn new(
-        tx: SignedTransaction,
-        origin: TxOrigin,
-        inserted_block_number: PoolingInstant,
-        inserted_timestamp: u64,
-        insertion_id: u64,
-    ) -> Self {
-        MemPoolItem {
-            tx,
-            origin,
-            inserted_block_number,
-            inserted_timestamp,
-            insertion_id,
-        }
-    }
-
-    pub fn hash(&self) -> TxHash {
-        self.tx.hash()
-    }
-
-    pub fn seq(&self) -> u64 {
-        self.tx.seq
-    }
-
-    pub fn signer_public(&self) -> Public {
-        self.tx.signer_public()
-    }
-
-    pub fn cost(&self) -> u64 {
-        match &self.tx.action {
-            Action::Pay {
-                quantity,
-                ..
-            } => self.tx.fee + *quantity,
-            _ => self.tx.fee,
-        }
-    }
-
-    pub fn expiration(&self) -> Option<u64> {
-        // FIXME: please remove the expiration function
-        None
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum QueueTag {
-    Current,
-    Future,
-    New,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct TransactionOrderWithTag {
-    pub order: TransactionOrder,
-    pub tag: QueueTag,
-}
-
-impl TransactionOrderWithTag {
-    pub fn new(order: TransactionOrder, tag: QueueTag) -> Self {
-        Self {
-            order,
-            tag,
-        }
-    }
-}
-
 #[derive(Debug, PartialEq)]
-pub struct CurrentQueue {
+pub struct TransactionPool {
     /// Priority queue for transactions
-    pub queue: BTreeSet<TransactionOrder>,
-    /// Counter on fees of transactions in the current queue
-    pub fee_counter: BTreeMap<u64, usize>,
-    /// Memory usage of the external transactions in the queue
+    pub pool: HashMap<TxHash, TransactionWithMetadata>,
+    /// Memory usage of the transactions in the queue
     pub mem_usage: usize,
     /// Count of the external transactions in the queue
     pub count: usize,
 }
 
-impl CurrentQueue {
+impl<'a> TransactionPool {
     pub fn new() -> Self {
         Self {
-            queue: BTreeSet::new(),
-            fee_counter: BTreeMap::new(),
+            pool: HashMap::new(),
             mem_usage: 0,
             count: 0,
         }
     }
 
     pub fn clear(&mut self) {
-        self.queue.clear();
-        self.fee_counter.clear();
+        self.pool.clear();
         self.mem_usage = 0;
         self.count = 0;
     }
 
     pub fn len(&self) -> usize {
-        self.queue.len()
+        self.pool.len()
     }
 
-    pub fn insert(&mut self, order: TransactionOrder) {
-        self.queue.insert(order);
-        if !order.origin.is_local() {
-            self.mem_usage += order.mem_usage;
-            self.count += 1;
-        }
-        *self.fee_counter.entry(order.fee).or_default() += 1;
+    pub fn contains(&self, hash: &TxHash) -> bool {
+        self.pool.contains_key(hash)
     }
 
-    pub fn remove(&mut self, order: &TransactionOrder) {
-        assert!(self.queue.remove(order));
-        if !order.origin.is_local() {
-            self.mem_usage -= order.mem_usage;
-            self.count -= 1;
-        }
-        {
-            let counter = self.fee_counter.get_mut(&order.fee).unwrap();
-            *counter -= 1;
-            if *counter != 0 {
-                return
-            }
-        }
-        self.fee_counter.remove(&order.fee);
+    pub fn insert(&mut self, tx: TransactionWithMetadata) {
+        self.pool.insert(tx.hash(), tx);
+        self.mem_usage += tx.size();
+        self.count += 1;
     }
 
-    pub fn minimum_fee(&self) -> u64 {
-        self.fee_counter.keys().next().map_or(0, |k| k + 1)
+    pub fn remove(&mut self, hash: &TxHash) {
+        assert!(self.contains(hash));
+        self.pool.remove(hash);
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct FutureQueue {
-    /// Priority queue for transactions
-    pub queue: BTreeSet<TransactionOrder>,
-    /// Memory usage of the external transactions in the queue
-    pub mem_usage: usize,
-    /// Count of the external transactions in the queue
-    pub count: usize,
-}
-
-impl FutureQueue {
-    pub fn new() -> Self {
-        Self {
-            queue: BTreeSet::new(),
-            mem_usage: 0,
-            count: 0,
-        }
-    }
-
-    pub fn clear(&mut self) {
-        self.queue.clear();
-        self.mem_usage = 0;
-        self.count = 0;
-    }
-
-    pub fn len(&self) -> usize {
-        self.queue.len()
-    }
-
-    pub fn insert(&mut self, order: TransactionOrder) {
-        self.queue.insert(order);
-        if !order.origin.is_local() {
-            self.mem_usage += order.mem_usage;
-            self.count += 1;
-        }
-    }
-
-    pub fn remove(&mut self, order: &TransactionOrder) {
-        assert!(self.queue.remove(order));
-        if !order.origin.is_local() {
-            self.mem_usage -= order.mem_usage;
-            self.count -= 1;
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct MemPoolInput {
-    pub transaction: SignedTransaction,
-    pub origin: TxOrigin,
-}
-
-impl MemPoolInput {
-    pub fn new(transaction: SignedTransaction, origin: TxOrigin) -> Self {
-        Self {
-            transaction,
-            origin,
-        }
-    }
-}
-
-#[derive(Debug)]
 /// Current status of the pool
+#[derive(Debug)]
 pub struct MemPoolStatus {
     /// Number of pending transactions (ready to go to block)
     pub pending: usize,
-    /// Number of future transactions (waiting for transactions with lower seqs first)
-    pub future: usize,
-}
-
-#[derive(Debug)]
-/// Details of account
-pub struct AccountDetails {
-    /// Most recent account seq
-    pub seq: u64,
-    /// Current account balance
-    pub balance: u64,
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq)]

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -576,19 +576,6 @@ impl MinerService for Miner {
         self.mem_pool.read().count_pending_transactions(range)
     }
 
-    fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize {
-        self.mem_pool.read().future_included_count_pending_transactions(range)
-    }
-
-    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
-        self.mem_pool.read().get_future_pending_transactions(usize::max_value(), None, range)
-    }
-
-    /// Get a list of all future transactions.
-    fn future_transactions(&self) -> Vec<SignedTransaction> {
-        self.mem_pool.read().future_transactions()
-    }
-
     fn start_sealing<C: MiningBlockChainClient + EngineInfo + TermInfo>(&self, client: &C) {
         cdebug!(MINER, "Start sealing");
         self.sealing_enabled.store(true, Ordering::Relaxed);

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -114,17 +114,8 @@ pub trait MinerService: Send + Sync {
     /// Get a list of all pending transactions in the mem pool.
     fn ready_transactions(&self, range: Range<u64>) -> Vec<Transaction>;
 
-    /// Get list of all future transaction in the mem pool.
-    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
-
     /// Get a count of all pending transactions in the mem pool.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;
-
-    /// a count of all pending transaction including both current and future transactions.
-    fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize;
-
-    /// Get a list of all future transactions.
-    fn future_transactions(&self) -> Vec<SignedTransaction>;
 
     /// Start sealing.
     fn start_sealing<C: MiningBlockChainClient + EngineInfo + TermInfo>(&self, client: &C);
@@ -153,28 +144,4 @@ pub trait MinerService: Send + Sync {
 pub struct MinerStatus {
     /// Number of transactions in queue with state `pending` (ready to be included in block)
     pub transactions_in_pending_queue: usize,
-    /// Number of transactions in queue with state `future` (not yet ready to be included in block)
-    pub transactions_in_future_queue: usize,
-}
-
-/// Represents the result of importing tranasction.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum TransactionImportResult {
-    /// Tranasction was imported to current queue.
-    Current,
-    /// Transaction was imported to future queue.
-    Future,
-}
-
-#[cfg(all(feature = "nightly", test))]
-mod mem_pool_benches;
-
-fn fetch_account_creator<'c>(client: &'c dyn AccountData) -> impl Fn(&Public) -> AccountDetails + 'c {
-    move |public: &Public| {
-        let address = public_to_address(public);
-        AccountDetails {
-            seq: client.latest_seq(&address),
-            balance: client.latest_balance(&address),
-        }
-    }
 }

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -28,7 +28,6 @@ use cvm::ChainTimeInfo;
 use primitives::Bytes;
 use std::ops::Range;
 
-use self::mem_pool_types::AccountDetails;
 pub use self::mem_pool_types::MemPoolMinFees;
 pub use self::miner::{AuthoringParams, Miner, MinerOptions};
 use crate::account_provider::{AccountProvider, Error as AccountProviderError};
@@ -39,6 +38,7 @@ use crate::consensus::EngineType;
 use crate::error::Error;
 use crate::transaction::{PendingSignedTransactions, SignedTransaction, UnverifiedTransaction};
 use crate::BlockId;
+use coordinator::validator::Transaction;
 
 /// Miner client API
 pub trait MinerService: Send + Sync {
@@ -90,15 +90,15 @@ pub trait MinerService: Send + Sync {
     fn import_external_transactions<C: MiningBlockChainClient + EngineInfo + TermInfo>(
         &self,
         client: &C,
-        transactions: Vec<UnverifiedTransaction>,
-    ) -> Vec<Result<TransactionImportResult, Error>>;
+        transactions: Vec<Transaction>,
+    ) -> Vec<bool>;
 
     /// Imports own (node owner) transaction to mem pool.
     fn import_own_transaction<C: MiningBlockChainClient + EngineInfo + TermInfo>(
         &self,
         chain: &C,
-        tx: SignedTransaction,
-    ) -> Result<TransactionImportResult, Error>;
+        tx: Transaction,
+    ) -> bool;
 
     /// Imports incomplete (node owner) transaction to mem pool.
     fn import_incomplete_transaction<C: MiningBlockChainClient + AccountData + EngineInfo + TermInfo>(
@@ -112,7 +112,7 @@ pub trait MinerService: Send + Sync {
     ) -> Result<(TxHash, u64), Error>;
 
     /// Get a list of all pending transactions in the mem pool.
-    fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
+    fn ready_transactions(&self, range: Range<u64>) -> Vec<Transaction>;
 
     /// Get list of all future transaction in the mem pool.
     fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;


### PR DESCRIPTION
We decide to remove `FutureQueue` from mempool, so TODO has been changed.
TODO:
- [x] Remove `FutureQueue` from mempool
- [x] Implement `mem_pool.add` using `check_transaction`
~~Implement future queue update method~~
- [x] Replace `TransactionOrder` type with `Priority`
- [x] Change callers of the mempool methods
- ~~[ ] Design and use `create_block` interface~~
 - ~~This should filter away old Txes from mempool and return a list of ordered Txes to be included in a block (ordering should be valid)~~
- ~~[ ] Design and use an interface to support removing invalid transactions (`remove_old`)~~
- ~~This should be similar to the `create_block` method. It should filter away old Txes from mempool, after accepting each block.~~
- [x] Design and use `fetch_transactions_for_block` interface
- This will return a list of ordered transactions that can be included in a block
- This will not filter away old Txes
- Miner does not have to include all returned transactions into a block. It will be the miner's responsibility to enforce the gas/size limit of blocks.
- [x] Design and use 'remove_old_transactions` interface
- This should be called after accepting each block.
- [ ] Change transaction encoding scheme
