### PR TITLE
Implement module db for coordinator Context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "codechain-key",
  "codechain-logger",
  "codechain-types",
+ "coordinator",
  "kvdb",
  "kvdb-memorydb",
  "log 0.4.6",

--- a/coordinator/src/context.rs
+++ b/coordinator/src/context.rs
@@ -1,2 +1,20 @@
-/// A `Context` provides the interface against the system services such as
-pub trait Context {}
+pub use ctypes::StorageId;
+
+/// A `Context` provides the interface against the system services such as DB access,
+pub trait Context: SubStorageAccess {}
+
+pub type Key = dyn AsRef<[u8]>;
+pub type Value = Vec<u8>;
+pub trait SubStorageAccess {
+    fn get(&self, storage_id: StorageId, key: &Key) -> Option<Value>;
+    fn set(&mut self, storage_id: StorageId, key: &Key, value: Value);
+    fn has(&self, storage_id: StorageId, key: &Key) -> bool;
+    fn remove(&mut self, storage_id: StorageId, key: &Key);
+
+    /// Create a recoverable checkpoint of this state
+    fn create_checkpoint(&mut self);
+    /// Revert to the last checkpoint and discard it
+    fn revert_to_the_checkpoint(&mut self);
+    /// Merge last checkpoint with the previous
+    fn discard_checkpoint(&mut self);
+}

--- a/coordinator/src/validator.rs
+++ b/coordinator/src/validator.rs
@@ -148,7 +148,7 @@ pub enum Evidence {
     DoubleVote {
         author: Public,
         block_hash: BlockHash,
-    }, 
+    },
 }
 
 pub struct TransactionExecutionOutcome {

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -10,6 +10,7 @@ codechain-db = { git = "https://github.com/CodeChain-io/rust-codechain-db.git", 
 codechain-logger = { path = "../util/logger" }
 codechain-key = { path = "../key" }
 codechain-types = { path = "../types" }
+coordinator = { path = "../coordinator" }
 kvdb = "0.1"
 kvdb-memorydb = "0.1"
 log = "0.4.6"

--- a/state/src/cache/global_cache.rs
+++ b/state/src/cache/global_cache.rs
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use super::lru_cache::LruCache;
-use super::{ShardCache, TopCache};
+use super::{ModuleCache, ShardCache, TopCache};
 use crate::CacheableItem;
-use crate::{Account, ActionData, Metadata, Shard, ShardText};
-use ctypes::ShardId;
+use crate::{Account, ActionData, Metadata, Module, ModuleDatum, Shard, ShardText};
+use ctypes::{ShardId, StorageId};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Clone)]
@@ -26,29 +26,41 @@ pub struct GlobalCache {
     account: LruCache<Account>,
     metadata: LruCache<Metadata>,
     shard: LruCache<Shard>,
+    module: LruCache<Module>,
     action_data: LruCache<ActionData>,
 
+    module_data: LruCache<ModuleDatum>,
     shard_text: LruCache<ShardText>,
 }
 
 impl GlobalCache {
-    pub fn new(account: usize, shard: usize, action_data: usize, shard_text: usize) -> Self {
+    pub fn new(
+        account: usize,
+        shard: usize,
+        module: usize,
+        action_data: usize,
+        shard_text: usize,
+        module_data: usize,
+    ) -> Self {
         Self {
             account: LruCache::new(account),
             metadata: LruCache::new(1),
             shard: LruCache::new(shard),
+            module: LruCache::new(module),
             action_data: LruCache::new(action_data),
 
+            module_data: LruCache::new(module_data),
             shard_text: LruCache::new(shard_text),
         }
     }
 
     pub fn top_cache(&self) -> TopCache {
         TopCache::new(
-            self.account.iter().map(|(addr, item)| (*addr, item.clone())),
-            self.metadata.iter().map(|(addr, item)| (*addr, item.clone())),
-            self.shard.iter().map(|(addr, item)| (*addr, item.clone())),
-            self.action_data.iter().map(|(addr, item)| (*addr, item.clone())),
+            self.account.cloned_iter(),
+            self.metadata.cloned_iter(),
+            self.shard.cloned_iter(),
+            self.module.cloned_iter(),
+            self.action_data.cloned_iter(),
         )
     }
 
@@ -65,8 +77,25 @@ impl GlobalCache {
         self.shard_text.iter().map(|(addr, _)| addr.shard_id()).collect()
     }
 
+    fn module_cache(&self, storage_id: StorageId) -> ModuleCache {
+        ModuleCache::new(
+            self.module_data
+                .iter()
+                .filter(|(addr, _)| addr.storage_id() == storage_id)
+                .map(|(addr, item)| (*addr, item.clone())),
+        )
+    }
+
+    fn storage_ids(&self) -> HashSet<StorageId> {
+        self.module_data.iter().map(|(addr, _)| addr.storage_id()).collect()
+    }
+
     pub fn shard_caches(&self) -> HashMap<ShardId, ShardCache> {
         self.shard_ids().into_iter().map(|shard_id| (shard_id, self.shard_cache(shard_id))).collect()
+    }
+
+    pub fn module_caches(&self) -> HashMap<StorageId, ModuleCache> {
+        self.storage_ids().into_iter().map(|storage_id| (storage_id, self.module_cache(storage_id))).collect()
     }
 
     fn drain_cacheable_into_lru_cache<T: CacheableItem>(from: Vec<(T::Address, Option<T>)>, to: &mut LruCache<T>) {
@@ -78,7 +107,12 @@ impl GlobalCache {
         })
     }
 
-    pub fn override_cache(&mut self, top_cache: &TopCache, shard_caches: &HashMap<ShardId, ShardCache>) {
+    pub fn override_cache(
+        &mut self,
+        top_cache: &TopCache,
+        shard_caches: &HashMap<ShardId, ShardCache>,
+        module_caches: &HashMap<StorageId, ModuleCache>,
+    ) {
         self.clear();
 
         Self::drain_cacheable_into_lru_cache(top_cache.cached_accounts(), &mut self.account);
@@ -91,14 +125,22 @@ impl GlobalCache {
         cached_shard_texts.sort_unstable_by_key(|item| item.0);
         let cached_shard_texts: Vec<_> = cached_shard_texts.into_iter().map(|(_, addr, item)| (addr, item)).collect();
         Self::drain_cacheable_into_lru_cache(cached_shard_texts, &mut self.shard_text);
+
+        let mut cached_module_data: Vec<_> =
+            module_caches.iter().flat_map(|(_, module_cache)| module_cache.cached_module_datum().into_iter()).collect();
+        cached_module_data.sort_unstable_by_key(|item| item.0);
+        let cached_module_data: Vec<_> = cached_module_data.into_iter().map(|(_, addr, item)| (addr, item)).collect();
+        Self::drain_cacheable_into_lru_cache(cached_module_data, &mut self.module_data);
     }
 
     pub fn clear(&mut self) {
         self.account.clear();
         self.metadata.clear();
         self.shard.clear();
+        self.module.clear();
         self.action_data.clear();
         self.shard_text.clear();
+        self.module_data.clear();
     }
 }
 
@@ -107,8 +149,10 @@ impl Default for GlobalCache {
         // FIXME: Set the right number
         const N_ACCOUNT: usize = 100;
         const N_SHARD: usize = 100;
+        const N_MODULE: usize = 10;
         const N_ACTION_DATA: usize = 10;
         const N_SHARD_TEXT: usize = 1000;
-        Self::new(N_ACCOUNT, N_SHARD, N_ACTION_DATA, N_SHARD_TEXT)
+        const N_MODULE_DATA: usize = 1000;
+        Self::new(N_ACCOUNT, N_SHARD, N_MODULE, N_ACTION_DATA, N_SHARD_TEXT, N_MODULE_DATA)
     }
 }

--- a/state/src/cache/lru_cache.rs
+++ b/state/src/cache/lru_cache.rs
@@ -38,6 +38,10 @@ impl<Item: CacheableItem> LruCache<Item> {
         self.cache.iter()
     }
 
+    pub fn cloned_iter<'a>(&'a self) -> impl Iterator<Item = (Item::Address, Item)> + 'a {
+        self.cache.iter().map(|(addr, value)| (*addr, value.clone()))
+    }
+
     pub fn insert(&mut self, k: Item::Address, v: Item) -> Option<Item> {
         self.cache.insert(k, v)
     }

--- a/state/src/cache/mod.rs
+++ b/state/src/cache/mod.rs
@@ -20,11 +20,13 @@ use std::hash::Hash;
 
 mod global_cache;
 mod lru_cache;
+mod module_cache;
 mod shard_cache;
 mod top_cache;
 mod write_back;
 
 pub use self::global_cache::GlobalCache;
+pub use self::module_cache::ModuleCache;
 pub use self::shard_cache::ShardCache;
 pub use self::top_cache::TopCache;
 pub use self::write_back::WriteBack;

--- a/state/src/cache/module_cache.rs
+++ b/state/src/cache/module_cache.rs
@@ -1,0 +1,82 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::WriteBack;
+use crate::{ModuleDatum, ModuleDatumAddress};
+use merkle_trie::{Result as TrieResult, Trie, TrieMut};
+use std::cell::RefMut;
+
+#[derive(Clone)]
+pub struct ModuleCache {
+    data: WriteBack<ModuleDatum>,
+}
+
+impl ModuleCache {
+    pub fn new(module_data: impl Iterator<Item = (ModuleDatumAddress, ModuleDatum)>) -> Self {
+        Self {
+            data: WriteBack::new_with_iter(module_data),
+        }
+    }
+
+    pub fn checkpoint(&mut self) {
+        self.data.checkpoint();
+    }
+
+    pub fn discard_checkpoint(&mut self) {
+        self.data.discard_checkpoint();
+    }
+
+    pub fn revert_to_checkpoint(&mut self) {
+        self.data.revert_to_checkpoint();
+    }
+
+    pub fn commit(&mut self, trie: &mut dyn TrieMut) -> TrieResult<()> {
+        self.data.commit(trie)?;
+        Ok(())
+    }
+
+    pub fn create_module_datum<F>(&self, a: &ModuleDatumAddress, f: F) -> TrieResult<ModuleDatum>
+    where
+        F: FnOnce() -> ModuleDatum, {
+        self.data.create(a, f)
+    }
+
+    pub fn has(&self, a: &ModuleDatumAddress, db: &dyn Trie) -> TrieResult<bool> {
+        self.data.has(a, db)
+    }
+
+    pub fn module_datum(&self, a: &ModuleDatumAddress, db: &dyn Trie) -> TrieResult<Option<ModuleDatum>> {
+        self.data.get(a, db)
+    }
+
+    pub fn module_datum_mut(&self, a: &ModuleDatumAddress, db: &dyn Trie) -> TrieResult<RefMut<'_, ModuleDatum>> {
+        self.data.get_mut(a, db)
+    }
+
+    pub fn remove_module_datum(&self, a: &ModuleDatumAddress) {
+        self.data.remove(a);
+    }
+
+    pub fn cached_module_datum(&self) -> Vec<(usize, ModuleDatumAddress, Option<ModuleDatum>)> {
+        self.data.items()
+    }
+}
+
+impl Default for ModuleCache {
+    fn default() -> Self {
+        Self::new(::std::iter::empty())
+    }
+}

--- a/state/src/cache/top_cache.rs
+++ b/state/src/cache/top_cache.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use super::WriteBack;
-use crate::{Account, ActionData, Metadata, MetadataAddress, Shard, ShardAddress};
+use crate::{Account, ActionData, Metadata, MetadataAddress, Module, ModuleAddress, Shard, ShardAddress};
 use ckey::Address;
 use merkle_trie::{Result as TrieResult, Trie, TrieMut};
 use primitives::H256;
@@ -26,6 +26,7 @@ pub struct TopCache {
     account: WriteBack<Account>,
     metadata: WriteBack<Metadata>,
     shard: WriteBack<Shard>,
+    module: WriteBack<Module>,
     action_data: WriteBack<ActionData>,
 }
 
@@ -34,12 +35,14 @@ impl TopCache {
         accounts: impl Iterator<Item = (Address, Account)>,
         metadata: impl Iterator<Item = (MetadataAddress, Metadata)>,
         shards: impl Iterator<Item = (ShardAddress, Shard)>,
+        modules: impl Iterator<Item = (ModuleAddress, Module)>,
         action_data: impl Iterator<Item = (H256, ActionData)>,
     ) -> Self {
         Self {
             account: WriteBack::new_with_iter(accounts),
             metadata: WriteBack::new_with_iter(metadata),
             shard: WriteBack::new_with_iter(shards),
+            module: WriteBack::new_with_iter(modules),
             action_data: WriteBack::new_with_iter(action_data),
         }
     }
@@ -132,5 +135,9 @@ impl TopCache {
 
     pub fn cached_action_data(&self) -> Vec<(H256, Option<ActionData>)> {
         self.action_data.items_sorted_by_touched()
+    }
+
+    pub fn cached_modules(&self) -> Vec<(ModuleAddress, Option<Module>)> {
+        self.module.items_sorted_by_touched()
     }
 }

--- a/state/src/cache/top_cache.rs
+++ b/state/src/cache/top_cache.rs
@@ -104,6 +104,14 @@ impl TopCache {
         self.shard.get_mut(a, db)
     }
 
+    pub fn module(&self, a: &ModuleAddress, db: &dyn Trie) -> TrieResult<Option<Module>> {
+        self.module.get(a, db)
+    }
+
+    pub fn module_mut(&self, a: &ModuleAddress, db: &dyn Trie) -> TrieResult<RefMut<'_, Module>> {
+        self.module.get_mut(a, db)
+    }
+
     #[allow(dead_code)]
     pub fn remove_shard(&self, address: &ShardAddress) {
         self.shard.remove(address)

--- a/state/src/db/state_db.rs
+++ b/state/src/db/state_db.rs
@@ -30,10 +30,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::cache::{GlobalCache, ShardCache, TopCache};
+use crate::cache::{GlobalCache, ModuleCache, ShardCache, TopCache};
 use crate::impls::TopLevelState;
 use cdb::{new_journaldb, Algorithm, AsHashDB, DatabaseError, HashDB, JournalDB};
-use ctypes::ShardId;
+use ctypes::{ShardId, StorageId};
 use kvdb::DBTransaction;
 use primitives::H256;
 use std::collections::HashMap;
@@ -83,8 +83,12 @@ impl StateDB {
         self.cache.shard_caches()
     }
 
+    pub fn module_caches(&self) -> HashMap<StorageId, ModuleCache> {
+        self.cache.module_caches()
+    }
+
     pub fn override_state(&mut self, state: &TopLevelState) {
-        self.cache.override_cache(state.top_cache(), state.shard_caches());
+        self.cache.override_cache(state.top_cache(), state.shard_caches(), state.module_caches());
         self.current_hash = Some(state.root());
     }
 

--- a/state/src/impls/mod.rs
+++ b/state/src/impls/mod.rs
@@ -17,8 +17,10 @@
 #[cfg(test)]
 mod test_helper; // It must be placed above other modules
 
+mod module_level;
 mod shard_level;
 mod top_level;
 
+pub use self::module_level::ModuleLevelState;
 pub use self::shard_level::ShardLevelState;
 pub use self::top_level::TopLevelState;

--- a/state/src/impls/module_level.rs
+++ b/state/src/impls/module_level.rs
@@ -1,0 +1,319 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::cache::ModuleCache;
+use crate::checkpoint::{CheckpointId, StateWithCheckpoint};
+use crate::traits::ModuleStateView;
+use crate::{ModuleDatum, ModuleDatumAddress, StateDB, StateResult};
+use ccrypto::BLAKE_NULL_RLP;
+use cdb::AsHashDB;
+use ctypes::StorageId;
+use merkle_trie::{Result as TrieResult, TrieError, TrieFactory};
+use primitives::H256;
+use std::cell::RefCell;
+
+pub struct ModuleLevelState<'db> {
+    db: &'db mut RefCell<StateDB>,
+    root: H256,
+    cache: &'db mut ModuleCache,
+    id_of_checkpoints: Vec<CheckpointId>,
+    storage_id: StorageId,
+}
+
+impl<'db> ModuleLevelState<'db> {
+    /// Creates new state with empty state root
+    pub fn try_new(
+        storage_id: StorageId,
+        db: &'db mut RefCell<StateDB>,
+        cache: &'db mut ModuleCache,
+    ) -> StateResult<Self> {
+        let root = BLAKE_NULL_RLP;
+        Ok(Self {
+            db,
+            root,
+            cache,
+            id_of_checkpoints: Default::default(),
+            storage_id,
+        })
+    }
+
+    /// Creates new state with existing state root
+    pub fn from_existing(
+        storage_id: StorageId,
+        db: &'db mut RefCell<StateDB>,
+        root: H256,
+        cache: &'db mut ModuleCache,
+    ) -> TrieResult<Self> {
+        if !db.borrow().as_hashdb().contains(&root) {
+            return Err(TrieError::InvalidStateRoot(root))
+        }
+
+        Ok(Self {
+            db,
+            root,
+            cache,
+            id_of_checkpoints: Default::default(),
+            storage_id,
+        })
+    }
+
+    /// Creates immutable module state
+    pub fn read_only(
+        storage_id: StorageId,
+        db: &RefCell<StateDB>,
+        root: H256,
+        cache: ModuleCache,
+    ) -> TrieResult<ReadOnlyModuleLevelState<'_>> {
+        if !db.borrow().as_hashdb().contains(&root) {
+            return Err(TrieError::InvalidStateRoot(root))
+        }
+
+        Ok(ReadOnlyModuleLevelState {
+            db,
+            root,
+            cache,
+            storage_id,
+        })
+    }
+
+    pub fn set_datum(&self, key: &dyn AsRef<[u8]>, datum: Vec<u8>) -> StateResult<()> {
+        let db = self.db.borrow();
+        let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
+        let mut datum_mut = self.cache.module_datum_mut(&ModuleDatumAddress::new(key, self.storage_id), &trie)?;
+        *datum_mut = ModuleDatum::new(datum);
+        Ok(())
+    }
+
+    pub fn remove_key(&self, key: &dyn AsRef<[u8]>) {
+        self.cache.remove_module_datum(&ModuleDatumAddress::new(key, self.storage_id))
+    }
+}
+
+impl<'db> ModuleStateView for ModuleLevelState<'db> {
+    fn get_datum(&self, key: &dyn AsRef<[u8]>) -> Result<Option<ModuleDatum>, TrieError> {
+        let db = self.db.borrow();
+        let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
+        self.cache.module_datum(&ModuleDatumAddress::new(key, self.storage_id), &trie)
+    }
+
+    fn has_key(&self, key: &dyn AsRef<[u8]>) -> TrieResult<bool> {
+        let db = self.db.borrow();
+        let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
+        self.cache.has(&ModuleDatumAddress::new(key, self.storage_id), &trie)
+    }
+}
+
+impl<'db> StateWithCheckpoint for ModuleLevelState<'db> {
+    fn create_checkpoint(&mut self, id: CheckpointId) {
+        ctrace!(STATE, "Checkpoint({}) for module({}) is created", id, self.storage_id);
+        self.id_of_checkpoints.push(id);
+        self.cache.checkpoint();
+    }
+
+    fn discard_checkpoint(&mut self, id: CheckpointId) {
+        let expected = self.id_of_checkpoints.pop().expect("The checkpoint must exist");
+        assert_eq!(expected, id);
+
+        ctrace!(STATE, "Checkpoint({}) for module({}) is discarded", id, self.storage_id);
+        self.cache.discard_checkpoint();
+    }
+
+    fn revert_to_checkpoint(&mut self, id: CheckpointId) {
+        let expected = self.id_of_checkpoints.pop().expect("The checkpoint must exist");
+        assert_eq!(expected, id);
+
+        ctrace!(STATE, "Checkpoint({}) for module({}) is reverted", id, self.storage_id);
+        self.cache.revert_to_checkpoint();
+    }
+}
+
+pub struct ReadOnlyModuleLevelState<'db> {
+    db: &'db RefCell<StateDB>,
+    root: H256,
+    cache: ModuleCache,
+    storage_id: StorageId,
+}
+
+impl<'db> ModuleStateView for ReadOnlyModuleLevelState<'db> {
+    fn get_datum(&self, key: &dyn AsRef<[u8]>) -> Result<Option<ModuleDatum>, TrieError> {
+        let db = self.db.borrow();
+        let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
+        self.cache.module_datum(&ModuleDatumAddress::new(key, self.storage_id), &trie)
+    }
+
+    fn has_key(&self, key: &dyn AsRef<[u8]>) -> TrieResult<bool> {
+        let db = self.db.borrow();
+        let trie = TrieFactory::readonly(db.as_hashdb(), &self.root)?;
+        self.cache.has(&ModuleDatumAddress::new(key, self.storage_id), &trie)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::helpers::get_temp_state_db;
+    use crate::ModuleDatum;
+
+    const STORAGE_ID: StorageId = 4;
+    const CHECKPOINT_ID: usize = 777;
+
+    fn get_temp_module_state<'d>(
+        state_db: &'d mut RefCell<StateDB>,
+        storage_id: StorageId,
+        cache: &'d mut ModuleCache,
+    ) -> ModuleLevelState<'d> {
+        ModuleLevelState::try_new(storage_id, state_db, cache).unwrap()
+    }
+
+    fn set_str_datum(state: &ModuleLevelState, key: &dyn AsRef<[u8]>, datum: &str) {
+        let datum = String::from(datum).into_bytes();
+        state.set_datum(key, datum).unwrap();
+    }
+
+    fn module_datum_from_str(datum: &str) -> ModuleDatum {
+        let datum = String::from(datum).into_bytes();
+        ModuleDatum::new(datum)
+    }
+
+    fn assert_key_str_datum(state: &ModuleLevelState, key: &dyn AsRef<[u8]>, datum: Option<&str>) {
+        match datum {
+            Some(datum) => assert_eq!(state.get_datum(key).unwrap(), Some(module_datum_from_str(datum))),
+            None => assert_eq!(state.get_datum(key).unwrap(), None),
+        }
+    }
+
+    #[test]
+    fn set_module_datum() {
+        let mut state_db = RefCell::new(get_temp_state_db());
+        let mut module_cache = ModuleCache::default();
+        let state = get_temp_module_state(&mut state_db, STORAGE_ID, &mut module_cache);
+
+        let key = "datum key";
+        let datum = "module_datum";
+
+        set_str_datum(&state, &key, datum);
+        assert_eq!(state.get_datum(&key).unwrap().unwrap(), module_datum_from_str(datum));
+    }
+
+    #[test]
+    fn checkpoint_and_revert() {
+        let mut state_db = RefCell::new(get_temp_state_db());
+        let mut module_cache = ModuleCache::default();
+        let mut state = get_temp_module_state(&mut state_db, STORAGE_ID, &mut module_cache);
+
+        // state 1
+        let key1 = "datum key 1";
+        let datum = "module datum";
+        set_str_datum(&state, &key1, datum);
+        assert_eq!(state.get_datum(&key1).unwrap().unwrap(), module_datum_from_str(datum));
+        state.create_checkpoint(CHECKPOINT_ID);
+
+        // state 2
+        let modified_datum = "A modified module datum";
+        set_str_datum(&state, &key1, modified_datum);
+        let key2 = "datum key 2";
+        let new_datum = "A new module datum";
+        set_str_datum(&state, &key2, new_datum);
+
+        // state 2
+        assert_key_str_datum(&state, &key1, Some(modified_datum));
+        assert_key_str_datum(&state, &key2, Some(new_datum));
+
+        // state 1
+        state.revert_to_checkpoint(CHECKPOINT_ID);
+        assert_key_str_datum(&state, &key1, Some(datum));
+        assert_key_str_datum(&state, &key2, None);
+        assert!(!state.has_key(&key2).unwrap());
+    }
+
+    #[test]
+    fn checkpoint_discard_and_revert() {
+        let mut state_db = RefCell::new(get_temp_state_db());
+        let mut module_cache = ModuleCache::default();
+        let mut state = get_temp_module_state(&mut state_db, STORAGE_ID, &mut module_cache);
+
+        // state 1
+        let key = "datum key";
+        let datum = "module datum";
+        set_str_datum(&state, &key, datum);
+        assert_key_str_datum(&state, &key, Some(datum));
+        state.create_checkpoint(CHECKPOINT_ID);
+
+        // state 2
+        let another_key = "another datum key";
+        let modified_datum_1 = "A modified module datum 1";
+        let another_datum = "another module datum";
+        set_str_datum(&state, &key, modified_datum_1);
+        set_str_datum(&state, &another_key, another_datum);
+        assert_key_str_datum(&state, &key, Some(modified_datum_1));
+        state.create_checkpoint(CHECKPOINT_ID);
+
+        // state 3
+        let modified_datum_2 = "A modified module datum 2";
+        set_str_datum(&state, &key, modified_datum_2);
+        assert_key_str_datum(&state, &key, Some(modified_datum_2));
+        state.create_checkpoint(CHECKPOINT_ID);
+        assert!(state.has_key(&another_key).unwrap());
+
+        // state 3 checkpoint merged into state 2
+        state.discard_checkpoint(CHECKPOINT_ID);
+
+        // Revert to the state 2
+        state.revert_to_checkpoint(CHECKPOINT_ID);
+        assert_key_str_datum(&state, &key, Some(modified_datum_1));
+        assert!(state.has_key(&another_key).unwrap());
+
+        // Revert to the state 1
+        state.revert_to_checkpoint(CHECKPOINT_ID);
+        assert_key_str_datum(&state, &key, Some(datum));
+        assert!(!state.has_key(&another_key).unwrap());
+    }
+
+    #[test]
+    fn checkpoint_and_revert_with_remove() {
+        let mut state_db = RefCell::new(get_temp_state_db());
+        let mut module_cache = ModuleCache::default();
+        let mut state = get_temp_module_state(&mut state_db, STORAGE_ID, &mut module_cache);
+
+        // state 1
+        let key1 = "datum key1";
+        let datum1 = "module datum1";
+        set_str_datum(&state, &key1, datum1);
+        let key2 = "datum key2";
+        let datum2 = "module datum2";
+        set_str_datum(&state, &key2, datum2);
+        state.create_checkpoint(CHECKPOINT_ID);
+
+        // state 2: key2 removed
+        state.remove_key(&key2);
+        state.create_checkpoint(CHECKPOINT_ID);
+        assert!(!state.has_key(&key2).unwrap());
+
+        // state 3: key1 removed
+        state.remove_key(&key1);
+        assert!(!state.has_key(&key1).unwrap());
+
+        // state 4: key1 revived
+        state.revert_to_checkpoint(CHECKPOINT_ID);
+        assert!(state.has_key(&key1).unwrap());
+        assert!(!state.has_key(&key2).unwrap());
+
+        // state 5: key2 revived
+        state.revert_to_checkpoint(CHECKPOINT_ID);
+        assert!(state.has_key(&key1).unwrap());
+        assert!(state.has_key(&key2).unwrap());
+    }
+}

--- a/state/src/impls/test_helper.rs
+++ b/state/src/impls/test_helper.rs
@@ -69,84 +69,77 @@ macro_rules! transaction {
 }
 
 macro_rules! set_top_level_state {
-    ($state: expr, []) => {
-    };
-    ($state:expr, [(account: $addr:expr => balance: $quantity:expr) $(,$x:tt)*]) => {
+    // base cases
+    ($state:expr, [(account: $addr:expr => balance: $quantity:expr)]) => {
         assert_eq!(Ok(()), $state.set_balance(&$addr, $quantity));
-
-        set_top_level_state!($state, [$($x),*]);
     };
-    ($state:expr, [(account: $addr:expr => seq: $seq:expr) $(,$x:tt)*]) => {
+    ($state:expr, [(account: $addr:expr => seq: $seq:expr)]) => {
         assert_eq!(Ok(()), $state.set_seq(&$addr, $seq));
-
-        set_top_level_state!($state, [$($x),*]);
     };
-    ($state:expr, [(shard: $shard_id:expr => owners: [$($owner:expr),*]) $(,$x:tt)*]) => {
-        set_top_level_state!($state, [(shard: $shard_id => owners: [$($owner),*], users: Vec::new()) $(,$x)*]);
+    ($state:expr, [(shard: $shard_id:expr => owners: [$($owner:expr),*])]) => {
+        set_top_level_state!($state, [(shard: $shard_id => owners: [$($owner),*], users: Vec::new())]);
     };
-    ($state:expr, [(shard: $shard_id:expr => owners: [$($owner:expr),*], users: [$($user:expr),*]) $(,$x:tt)*]) => {
-        set_top_level_state!($state, [(shard: $shard_id => owners: [$($owner),*], users: vec![$($user),*]) $(,$x)*]);
+    ($state:expr, [(shard: $shard_id:expr => owners: [$($owner:expr),*], users: [$($user:expr),*])]) => {
+        set_top_level_state!($state, [(shard: $shard_id => owners: [$($owner),*], users: vec![$($user),*])]);
     };
-    ($state:expr, [(shard: $shard_id:expr => owners: [$($owner:expr),*], users: $users:expr) $(,$x:tt)*]) => {
-        set_top_level_state!($state, [(shard: $shard_id => owners: vec![$($owner),*], users: $users) $(,$x)*]);
+    ($state:expr, [(shard: $shard_id:expr => owners: [$($owner:expr),*], users: $users:expr)]) => {
+        set_top_level_state!($state, [(shard: $shard_id => owners: vec![$($owner),*], users: $users)]);
     };
-    ($state:expr, [(shard: $shard_id:expr => owners: $owners:expr, users: $users:expr) $(,$x:tt)*]) => {
+    ($state:expr, [(shard: $shard_id:expr => owners: $owners:expr, users: $users:expr)]) => {
         assert_eq!(Ok(()), $state.create_shard_level_state($shard_id, $owners, $users));
-
-        set_top_level_state!($state, [$($x),*]);
     };
-    ($state:expr, [(metadata: shards: $number_of_shards:expr) $(,$x:tt)*]) => {
+    ($state:expr, [(metadata: shards: $number_of_shards:expr)]) => {
         assert_eq!(Ok(()), $state.set_number_of_shards($number_of_shards));
-
-        set_top_level_state!($state, [$($x),*]);
+    };
+    // recursion
+    ($state:expr, [$head:tt, $($tail:tt),+]) => {
+        set_top_level_state!($state, [$head]);
+        set_top_level_state!($state, [$($tail),+]);
     };
 }
 
 macro_rules! check_top_level_state {
-    ($state: expr, []) => { };
-    ($state:expr, [(account: $addr:expr => (seq: $seq:expr, balance: $balance:expr)) $(,$x:tt)*]) => {
+    // base cases
+    ($state:expr, [(account: $addr:expr => (seq: $seq:expr, balance: $balance:expr))]) => {
         assert_eq!(Ok($seq), $state.seq(&$addr));
         assert_eq!(Ok($balance), $state.balance(&$addr));
-
-        check_top_level_state!($state, [$($x),*]);
     };
-    ($state:expr, [(account: $addr:expr) $(,$x:tt)*]) => {
-        check_top_level_state!($state, [(account: $addr => (seq: 0, balance: 0)) $(,$x)*]);
+    ($state:expr, [(account: $addr:expr)]) => {
+        check_top_level_state!($state, [(account: $addr => (seq: 0, balance: 0))]);
     };
-    ($state:expr, [(shard: $shard_id:expr => owners: [$($owner:expr),*]) $(,$x:tt)*]) => {
-        check_top_level_state!($state, [(shard: $shard_id => owners: vec![$($owner,)*]) $(,$x)*]);
+    ($state:expr, [(shard: $shard_id:expr => owners: [$($owner:expr),*])]) => {
+        check_top_level_state!($state, [(shard: $shard_id => owners: vec![$($owner,)*])]);
     };
-    ($state:expr, [(shard: $shard_id:expr => owners: $owners:expr) $(,$x:tt)*]) => {
+    ($state:expr, [(shard: $shard_id:expr => owners: $owners:expr)]) => {
         assert_eq!(Ok(Some($owners)), $state.shard_owners($shard_id));
-
-        check_top_level_state!($state, [$($x),*]);
     };
-    ($state:expr, [(shard: $shard_id:expr => owners: $owners:expr, users: $users:expr) $(,$x:tt)*]) => {
+    ($state:expr, [(shard: $shard_id:expr => owners: $owners:expr, users: $users:expr)]) => {
         assert_eq!(Ok(Some($users)), $state.shard_users($shard_id));
-
-        check_top_level_state!($state, [(shard: $shard_id => owners: $owners) $(,$x)*]);
     };
-    ($state:expr, [(shard: $shard_id:expr) $(,$x:tt)*]) => {
+    ($state:expr, [(shard: $shard_id:expr)]) => {
         assert_eq!(Ok(None), $state.shard_root($shard_id));
-
-        check_top_level_state!($state, [$($x),*]);
     };
-    ($state:expr, [(shard_text: ($shard_id:expr, $tracker:expr)) $(,$x:tt)*]) => {
+    ($state:expr, [(shard_text: ($shard_id:expr, $tracker:expr))]) => {
         assert_eq!(Ok(None), $state.shard_text($shard_id, $tracker));
-
-        check_top_level_state!($state, [$($x), *]);
     };
+    //recursion
+    ($state:expr, [$head:tt, $($tail:tt),+]) => {
+        check_top_level_state!($state, [$head]);
+        check_top_level_state!($state, [$($tail),+]);
+    }
 }
 
 macro_rules! check_shard_level_state {
-    ($state: expr, []) => { };
-    ($state:expr, [(text: ($tracker:expr) => { content: $content: expr}) $(,$x:tt)*]) => {
+    // base cases
+    ($state:expr, [(text: ($tracker:expr) => { content: $content: expr})]) => {
         let stored_text = $state.text($tracker)
             .expect(&format!("Cannot read Text from {}:{}", $state.shard_id(), $tracker))
             .expect(&format!("Text for {}:{} not exist", $state.shard_id(), $tracker));
-
         assert_eq!($content, stored_text.content());
-
-        check_shard_level_state!($state, [$($x), *])
     };
+    // recursion
+    ($state:expr, [$head:tt, $($tail:tt),+]) => {
+        check_shard_level_state!($state, [$head]);
+        check_shard_level_state!($state, [$($tail),+]);
+    }
 }

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -1526,7 +1526,7 @@ mod tests_tx {
             (account: owners[0] => seq: 1),
             (account: owners[1] => seq: 1),
             (account: owners[2] => seq: 1),
-            (shard: shard_id => owners: owners.clone(), users: old_users.clone()),
+            (shard: shard_id => owners: owners, users: old_users.clone()),
             (metadata: shards: 1)
         ]);
 

--- a/state/src/item/address.rs
+++ b/state/src/item/address.rs
@@ -36,6 +36,18 @@ macro_rules! define_address_constructor {
             $name(hash)
         }
     };
+    (MODULE, $name:ident, $prefix:expr) => {
+        fn from_key_with_storage_id<T: AsRef<[u8]>>(input: T, storage_id: ::ctypes::StorageId) -> Self {
+            let mut hash: ::primitives::H256 = ::ccrypto::Blake::blake(&input);
+            hash[0..2].copy_from_slice(&[$prefix, 0]);
+
+            debug_assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<::ctypes::StorageId>());
+            let storage_id_bytes: [u8; 2] = storage_id.to_be_bytes();
+            hash[2..4].copy_from_slice(&storage_id_bytes);
+
+            $name(hash)
+        }
+    };
 }
 
 macro_rules! define_id_getter {
@@ -45,6 +57,13 @@ macro_rules! define_id_getter {
             debug_assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<ShardId>());
             let shard_id_bytes: [u8; 2] = [self.0[2], self.0[3]];
             ::ctypes::ShardId::from_be_bytes(shard_id_bytes)
+        }
+    };
+    (MODULE) => {
+        pub fn storage_id(&self) -> ::ctypes::StorageId {
+            debug_assert_eq!(::std::mem::size_of::<u16>(), ::std::mem::size_of::<StorageId>());
+            let storage_id_bytes: [u8; 2] = [self.0[2], self.0[3]];
+            ::ctypes::StorageId::from_be_bytes(storage_id_bytes)
         }
     };
 }

--- a/state/src/item/mod.rs
+++ b/state/src/item/mod.rs
@@ -21,6 +21,7 @@ pub mod account;
 pub mod action_data;
 pub mod dummy_shard_text;
 pub mod metadata;
+pub mod module;
 pub mod module_datum;
 pub mod shard;
 
@@ -32,4 +33,5 @@ enum Prefix {
     Metadata = b'M',
     ShardText = b'X',
     ModuleDatum = b'S',
+    Module = b'U',
 }

--- a/state/src/item/mod.rs
+++ b/state/src/item/mod.rs
@@ -21,6 +21,7 @@ pub mod account;
 pub mod action_data;
 pub mod dummy_shard_text;
 pub mod metadata;
+pub mod module_datum;
 pub mod shard;
 
 #[derive(Clone, Copy)]
@@ -30,4 +31,5 @@ enum Prefix {
     Shard = b'H',
     Metadata = b'M',
     ShardText = b'X',
+    ModuleDatum = b'S',
 }

--- a/state/src/item/module.rs
+++ b/state/src/item/module.rs
@@ -1,0 +1,137 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::CacheableItem;
+use ccrypto::BLAKE_NULL_RLP;
+use ctypes::StorageId;
+use primitives::H256;
+use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+
+#[derive(Clone, Debug)]
+pub struct Module {
+    root: H256,
+}
+
+impl Module {
+    pub fn new(module_root: H256) -> Self {
+        Self {
+            root: module_root,
+        }
+    }
+
+    pub fn root(&self) -> &H256 {
+        &self.root
+    }
+
+    pub fn set_root(&mut self, root: H256) {
+        self.root = root;
+    }
+}
+
+impl Default for Module {
+    fn default() -> Self {
+        Self::new(BLAKE_NULL_RLP)
+    }
+}
+
+impl CacheableItem for Module {
+    type Address = ModuleAddress;
+
+    fn is_null(&self) -> bool {
+        self.root == BLAKE_NULL_RLP
+    }
+}
+
+const PREFIX: u8 = super::Prefix::Module as u8;
+
+impl Encodable for Module {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.begin_list(2).append(&PREFIX).append(&self.root);
+    }
+}
+
+impl Decodable for Module {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
+        let item_count = rlp.item_count()?;
+        if item_count != 2 {
+            return Err(DecoderError::RlpInvalidLength {
+                expected: 2,
+                got: item_count,
+            })
+        }
+        let prefix = rlp.val_at::<u8>(0)?;
+        if PREFIX != prefix {
+            cdebug!(STATE, "{} is not an expected prefix for module", prefix);
+            return Err(DecoderError::Custom("Unexpected prefix"))
+        }
+        Ok(Self {
+            root: rlp.val_at(1)?,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ModuleAddress(H256);
+
+impl_address!(TOP, ModuleAddress, PREFIX);
+
+impl ModuleAddress {
+    pub fn new(storage_id: StorageId) -> Self {
+        Self::from_transaction_hash(H256::from_slice(b"module"), storage_id.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn different_storage_id_makes_different_address() {
+        let address1 = ModuleAddress::new(0);
+        let address2 = ModuleAddress::new(1);
+        assert_ne!(address1, address2);
+        assert_eq!(address1[0], PREFIX);
+        assert_eq!(address2[0], PREFIX);
+    }
+
+    #[test]
+    fn parse_fail_return_none() {
+        let hash = {
+            let mut hash;
+            loop {
+                hash = H256::random();
+                if hash[0] == PREFIX {
+                    continue
+                }
+                break
+            }
+            hash
+        };
+        let address = ModuleAddress::from_hash(hash);
+        assert!(address.is_none());
+    }
+
+    #[test]
+    fn parse_return_some() {
+        let hash = {
+            let mut hash = H256::random();
+            hash[0] = PREFIX;
+            hash
+        };
+        let address = ModuleAddress::from_hash(hash);
+        assert_eq!(Some(ModuleAddress(hash)), address);
+    }
+}

--- a/state/src/item/module_datum.rs
+++ b/state/src/item/module_datum.rs
@@ -1,0 +1,135 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::CacheableItem;
+use ccrypto::Blake;
+use ctypes::StorageId;
+use primitives::H256;
+use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+
+/// Module level datum in the DB.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ModuleDatum {
+    // Content of the datum
+    datum: Vec<u8>,
+}
+
+impl ModuleDatum {
+    pub fn new(datum: Vec<u8>) -> Self {
+        Self {
+            datum,
+        }
+    }
+
+    /// Get clone of the datum
+    pub fn content(&self) -> Vec<u8> {
+        self.datum.clone()
+    }
+
+    /// Get blake hash of the content of the text
+    pub fn content_hash(&self) -> H256 {
+        let rlp = self.datum.rlp_bytes();
+        Blake::blake(rlp)
+    }
+}
+
+const PREFIX: u8 = super::Prefix::ModuleDatum as u8;
+
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ModuleDatumAddress(H256);
+
+impl_address!(MODULE, ModuleDatumAddress, PREFIX);
+
+impl ModuleDatumAddress {
+    pub fn new<T: AsRef<[u8]>>(key: T, storage_id: StorageId) -> Self {
+        Self::from_key_with_storage_id(key, storage_id)
+    }
+}
+
+impl CacheableItem for ModuleDatum {
+    type Address = ModuleDatumAddress;
+    /// Check if content is empty and certifier is null.
+    fn is_null(&self) -> bool {
+        self.datum.is_empty()
+    }
+}
+
+impl Encodable for ModuleDatum {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.begin_list(2);
+        s.append(&PREFIX);
+        s.append(&self.datum);
+    }
+}
+
+impl Decodable for ModuleDatum {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
+        let item_count = rlp.item_count()?;
+        if item_count != 2 {
+            return Err(DecoderError::RlpInvalidLength {
+                got: item_count,
+                expected: 2,
+            })
+        }
+        let prefix = rlp.val_at::<u8>(0)?;
+        if PREFIX != prefix {
+            cdebug!(STATE, "{} is not an expected prefix for module datum", prefix);
+            return Err(DecoderError::Custom("Unexpected prefix"))
+        }
+        Ok(Self {
+            datum: rlp.val_at(1)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rlp::rlp_encode_and_decode_test;
+
+    use super::*;
+
+    #[test]
+    fn rlp_encode_and_decode() {
+        rlp_encode_and_decode_test!(ModuleDatum {
+            datum: String::from("Foundry").into_bytes(),
+        });
+    }
+
+    #[test]
+    fn cachable_item_is_null() {
+        let datum: ModuleDatum = Default::default();
+        assert!(datum.is_null());
+    }
+
+    #[test]
+    fn address_prefix() {
+        let address = ModuleDatumAddress::new("Foundry", 500);
+        let ModuleDatumAddress(address) = address;
+        let module_prefix = [83, 0]; // ord('S') == 83
+        let storage_prefix = [1, 244]; // hex(500) == 0x1f4;
+        assert_eq!(&address[0..2], &module_prefix);
+        assert_eq!(&address[2..4], &storage_prefix);
+    }
+
+    #[test]
+    fn different_storage_id_makes_different_address() {
+        let address1 = ModuleDatumAddress::new("foundry", 1);
+        let address2 = ModuleDatumAddress::new("foundry", 2);
+        assert_ne!(address1, address2);
+        assert_eq!(address1[0], PREFIX);
+        assert_eq!(address2[0], PREFIX);
+    }
+}

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -40,7 +40,7 @@ pub use crate::action_handler::{ActionDataKeyBuilder, ActionHandler, FindActionH
 pub use crate::checkpoint::{CheckpointId, StateWithCheckpoint};
 pub use crate::db::StateDB;
 pub use crate::error::Error as StateError;
-pub use crate::impls::{ShardLevelState, TopLevelState};
+pub use crate::impls::{ModuleLevelState, ShardLevelState, TopLevelState};
 pub use crate::item::account::Account;
 pub use crate::item::action_data::ActionData;
 pub use crate::item::dummy_shard_text::{ShardText, ShardTextAddress};

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -45,6 +45,7 @@ pub use crate::item::account::Account;
 pub use crate::item::action_data::ActionData;
 pub use crate::item::dummy_shard_text::{ShardText, ShardTextAddress};
 pub use crate::item::metadata::{Metadata, MetadataAddress};
+pub use crate::item::module_datum::{ModuleDatum, ModuleDatumAddress};
 pub use crate::item::shard::{Shard, ShardAddress};
 pub use crate::traits::{ShardState, ShardStateView, StateWithCache, TopState, TopStateView};
 

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -45,6 +45,7 @@ pub use crate::item::account::Account;
 pub use crate::item::action_data::ActionData;
 pub use crate::item::dummy_shard_text::{ShardText, ShardTextAddress};
 pub use crate::item::metadata::{Metadata, MetadataAddress};
+pub use crate::item::module::{Module, ModuleAddress};
 pub use crate::item::module_datum::{ModuleDatum, ModuleDatumAddress};
 pub use crate::item::shard::{Shard, ShardAddress};
 pub use crate::traits::{ShardState, ShardStateView, StateWithCache, TopState, TopStateView};

--- a/state/src/traits.rs
+++ b/state/src/traits.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Account, ActionData, CacheableItem, Metadata, Shard, ShardText, StateDB, StateResult};
+use crate::{Account, ActionData, CacheableItem, Metadata, ModuleDatum, Shard, ShardText, StateDB, StateResult};
 use ckey::Address;
 use ctypes::transaction::ShardTransaction;
 use ctypes::{BlockNumber, CommonParams, ShardId, Tracker, TxHash};
@@ -89,6 +89,13 @@ pub trait TopStateView {
 pub trait ShardStateView {
     /// Get shard text.
     fn text(&self, tracker: Tracker) -> TrieResult<Option<ShardText>>;
+}
+
+pub trait ModuleStateView {
+    /// Get module datum from the key
+    fn get_datum(&self, key: &dyn AsRef<[u8]>) -> TrieResult<Option<ModuleDatum>>;
+    /// Check if the key exists
+    fn has_key(&self, key: &dyn AsRef<[u8]>) -> TrieResult<bool>;
 }
 
 pub trait ShardState {

--- a/types/src/errors/runtime_error.rs
+++ b/types/src/errors/runtime_error.rs
@@ -16,7 +16,7 @@
 
 use super::TaggedRlp;
 use crate::util::unexpected::Mismatch;
-use crate::ShardId;
+use crate::{ShardId, StorageId};
 use ckey::Address;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use std::fmt::{Display, Formatter, Result as FormatResult};
@@ -35,6 +35,7 @@ pub enum Error {
     InsufficientPermission,
     /// Returned when transaction seq does not match state seq
     InvalidShardId(ShardId),
+    InvalidStorageId(StorageId),
     InvalidTransferDestination,
     NewOwnersMustContainSender,
     InvalidSeq(Mismatch<u64>),
@@ -57,14 +58,15 @@ enum ErrorID {
     InsufficientBalance = 1,
     InsufficientPermission = 2,
     InvalidShardID = 3,
-    InvalidTransferDestination = 4,
-    NewOwnersMustContainSender = 5,
-    InvalidSeq = 6,
-    NonActiveAccount = 7,
-    FailedToHandleCustomAction = 8,
-    SignatureOfInvalid = 9,
-    InsufficientStakes = 10,
-    InvalidValidatorIndex = 11,
+    InvalidStorageID = 4,
+    InvalidTransferDestination = 5,
+    NewOwnersMustContainSender = 6,
+    InvalidSeq = 7,
+    NonActiveAccount = 8,
+    FailedToHandleCustomAction = 9,
+    SignatureOfInvalid = 10,
+    InsufficientStakes = 11,
+    InvalidValidatorIndex = 12,
 }
 
 impl Encodable for ErrorID {
@@ -104,6 +106,7 @@ impl TaggedRlp for RlpHelper {
             ErrorID::InsufficientPermission => 1,
             ErrorID::InvalidSeq => 2,
             ErrorID::InvalidShardID => 2,
+            ErrorID::InvalidStorageID => 2,
             ErrorID::InvalidTransferDestination => 1,
             ErrorID::NewOwnersMustContainSender => 1,
             ErrorID::NonActiveAccount => 3,
@@ -130,6 +133,9 @@ impl Encodable for Error {
             Error::InsufficientPermission => RlpHelper::new_tagged_list(s, ErrorID::InsufficientPermission),
             Error::InvalidSeq(mismatch) => RlpHelper::new_tagged_list(s, ErrorID::InvalidSeq).append(mismatch),
             Error::InvalidShardId(shard_id) => RlpHelper::new_tagged_list(s, ErrorID::InvalidShardID).append(shard_id),
+            Error::InvalidStorageId(storage_id) => {
+                RlpHelper::new_tagged_list(s, ErrorID::InvalidStorageID).append(storage_id)
+            }
             Error::InvalidTransferDestination => RlpHelper::new_tagged_list(s, ErrorID::InvalidTransferDestination),
             Error::NewOwnersMustContainSender => RlpHelper::new_tagged_list(s, ErrorID::NewOwnersMustContainSender),
             Error::NonActiveAccount {
@@ -164,6 +170,7 @@ impl Decodable for Error {
             ErrorID::InsufficientPermission => Error::InsufficientPermission,
             ErrorID::InvalidSeq => Error::InvalidSeq(rlp.val_at(1)?),
             ErrorID::InvalidShardID => Error::InvalidShardId(rlp.val_at(1)?),
+            ErrorID::InvalidStorageID => Error::InvalidStorageId(rlp.val_at(1)?),
             ErrorID::InvalidTransferDestination => Error::InvalidTransferDestination,
             ErrorID::NewOwnersMustContainSender => Error::NewOwnersMustContainSender,
             ErrorID::NonActiveAccount => Error::NonActiveAccount {
@@ -197,6 +204,7 @@ impl Display for Error {
             Error::InsufficientPermission => write!(f, "Sender doesn't have a permission"),
             Error::InvalidSeq(mismatch) => write!(f, "Invalid transaction seq {}", mismatch),
             Error::InvalidShardId(shard_id) => write!(f, "{} is an invalid shard id", shard_id),
+            Error::InvalidStorageId(storage_id) => write!(f, "{} is an invalid storage id", storage_id),
             Error::InvalidTransferDestination => write!(f, "Transfer receiver is not valid account"),
             Error::NewOwnersMustContainSender => write!(f, "New owners must contain the sender"),
             Error::NonActiveAccount {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -30,6 +30,7 @@ pub mod util;
 
 pub type BlockNumber = u64;
 pub type ShardId = u16;
+pub type StorageId = u16;
 
 pub use block_hash::BlockHash;
 pub use common_params::CommonParams;


### PR DESCRIPTION
Now, the `DbContext` is implemented for the minimal unit `TopLevelState`. In the future, the state manager, who owns or manages the latest top level state, can implement `DbContext` using the methods already implemented in `TopLevelState`