### PR TITLE
Remove omitted field from ImportRoute

### DIFF
--- a/core/src/blockchain/blockchain.rs
+++ b/core/src/blockchain/blockchain.rs
@@ -97,7 +97,7 @@ impl BlockChain {
         engine: &dyn CodeChainEngine,
     ) -> ImportRoute {
         match self.headerchain.insert_header(batch, header, engine) {
-            Some(c) => ImportRoute::new_from_best_header_changed(header.hash(), &c),
+            Some(c) => ImportRoute::new_from_best_header_changed(&c),
             None => ImportRoute::none(),
         }
     }
@@ -185,7 +185,7 @@ impl BlockChain {
             *pending_best_proposal_block_hash = Some(new_block_hash);
         }
 
-        ImportRoute::new(new_block_hash, &best_block_changed)
+        ImportRoute::new(&best_block_changed)
     }
 
     /// Apply pending insertion updates
@@ -322,7 +322,7 @@ impl BlockChain {
         batch.put(db::COL_EXTRA, BEST_PROPOSAL_BLOCK_KEY, &*block_hash);
         *pending_best_proposal_block_hash = Some(block_hash);
 
-        ImportRoute::new(block_hash, &best_block_changed)
+        ImportRoute::new(&best_block_changed)
     }
 
     /// Returns general blockchain information

--- a/core/src/blockchain/mod.rs
+++ b/core/src/blockchain/mod.rs
@@ -22,10 +22,11 @@ mod extras;
 mod headerchain;
 mod invoice_db;
 mod route;
+mod update_result;
 
 pub use self::blockchain::{BlockChain, BlockProvider};
 pub use self::body_db::BodyProvider;
 pub use self::extras::{BlockDetails, TransactionAddress, TransactionAddresses};
 pub use self::headerchain::HeaderProvider;
 pub use self::invoice_db::InvoiceProvider;
-pub use self::route::ImportRoute;
+pub use self::update_result::ChainUpdateResult;

--- a/core/src/blockchain/route.rs
+++ b/core/src/blockchain/route.rs
@@ -110,8 +110,9 @@ pub fn tree_route(db: &dyn HeaderProvider, from: BlockHash, to: BlockHash) -> Op
 /// Import route for newly inserted block.
 #[derive(Debug, PartialEq)]
 pub struct ImportRoute {
-    /// Blocks that were validated by new block.
-    pub enacted: Vec<BlockHash>,
+    // Some(updated_best_block_hash) if chain is updated
+    // None if chain is not updated
+    pub enacted: Option<BlockHash>,
 }
 
 impl ImportRoute {
@@ -120,14 +121,13 @@ impl ImportRoute {
             BestBlockChanged::CanonChainAppended {
                 ..
             } => {
-                let mut enacted = Vec::new();
-                enacted.push(best_block_changed.new_best_hash().unwrap());
+                let enacted = Some(best_block_changed.new_best_hash().unwrap());
                 ImportRoute {
                     enacted,
                 }
             }
             BestBlockChanged::None => ImportRoute {
-                enacted: vec![],
+                enacted: None,
             },
         }
     }
@@ -137,24 +137,24 @@ impl ImportRoute {
             BestHeaderChanged::CanonChainAppended {
                 ..
             } => {
-                let enacted = vec![best_header_changed.new_best_hash().unwrap()];
+                let enacted = Some(best_header_changed.new_best_hash().unwrap());
                 ImportRoute {
                     enacted,
                 }
             }
             BestHeaderChanged::None => ImportRoute {
-                enacted: vec![],
+                enacted: None,
             },
         }
     }
 
     pub fn none() -> Self {
         ImportRoute {
-            enacted: vec![],
+            enacted: None,
         }
     }
 
     pub fn is_none(&self) -> bool {
-        self.enacted.is_empty() 
+        self.enacted.is_none()
     }
 }

--- a/core/src/blockchain/route.rs
+++ b/core/src/blockchain/route.rs
@@ -112,17 +112,10 @@ pub fn tree_route(db: &dyn HeaderProvider, from: BlockHash, to: BlockHash) -> Op
 pub struct ImportRoute {
     /// Blocks that were validated by new block.
     pub enacted: Vec<BlockHash>,
-    /// Blocks which are not enacted.
-    pub omitted: Vec<BlockHash>,
 }
 
 impl ImportRoute {
-    pub fn new(new_block_hash: BlockHash, best_block_changed: &BestBlockChanged) -> Self {
-        let mut omitted = Vec::new();
-        if best_block_changed.new_best_hash() != Some(new_block_hash) {
-            omitted.push(new_block_hash);
-        }
-
+    pub fn new(best_block_changed: &BestBlockChanged) -> Self {
         match best_block_changed {
             BestBlockChanged::CanonChainAppended {
                 ..
@@ -131,22 +124,15 @@ impl ImportRoute {
                 enacted.push(best_block_changed.new_best_hash().unwrap());
                 ImportRoute {
                     enacted,
-                    omitted,
                 }
             }
             BestBlockChanged::None => ImportRoute {
                 enacted: vec![],
-                omitted,
             },
         }
     }
 
-    pub fn new_from_best_header_changed(new_block_hash: BlockHash, best_header_changed: &BestHeaderChanged) -> Self {
-        let mut omitted = Vec::new();
-        if best_header_changed.new_best_hash() != Some(new_block_hash) {
-            omitted.push(new_block_hash);
-        }
-
+    pub fn new_from_best_header_changed(best_header_changed: &BestHeaderChanged) -> Self {
         match best_header_changed {
             BestHeaderChanged::CanonChainAppended {
                 ..
@@ -154,12 +140,10 @@ impl ImportRoute {
                 let enacted = vec![best_header_changed.new_best_hash().unwrap()];
                 ImportRoute {
                     enacted,
-                    omitted,
                 }
             }
             BestHeaderChanged::None => ImportRoute {
                 enacted: vec![],
-                omitted,
             },
         }
     }
@@ -167,11 +151,10 @@ impl ImportRoute {
     pub fn none() -> Self {
         ImportRoute {
             enacted: vec![],
-            omitted: vec![],
         }
     }
 
     pub fn is_none(&self) -> bool {
-        self.enacted.is_empty() && self.omitted.is_empty()
+        self.enacted.is_empty() 
     }
 }

--- a/core/src/blockchain/route.rs
+++ b/core/src/blockchain/route.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use super::block_info::{BestBlockChanged, BestHeaderChanged};
 use super::headerchain::HeaderProvider;
 use ctypes::BlockHash;
 
@@ -105,56 +104,4 @@ pub fn tree_route(db: &dyn HeaderProvider, from: BlockHash, to: BlockHash) -> Op
         retracted,
         enacted,
     })
-}
-
-/// Import route for newly inserted block.
-#[derive(Debug, PartialEq)]
-pub struct ImportRoute {
-    // Some(updated_best_block_hash) if chain is updated
-    // None if chain is not updated
-    pub enacted: Option<BlockHash>,
-}
-
-impl ImportRoute {
-    pub fn new(best_block_changed: &BestBlockChanged) -> Self {
-        match best_block_changed {
-            BestBlockChanged::CanonChainAppended {
-                ..
-            } => {
-                let enacted = Some(best_block_changed.new_best_hash().unwrap());
-                ImportRoute {
-                    enacted,
-                }
-            }
-            BestBlockChanged::None => ImportRoute {
-                enacted: None,
-            },
-        }
-    }
-
-    pub fn new_from_best_header_changed(best_header_changed: &BestHeaderChanged) -> Self {
-        match best_header_changed {
-            BestHeaderChanged::CanonChainAppended {
-                ..
-            } => {
-                let enacted = Some(best_header_changed.new_best_hash().unwrap());
-                ImportRoute {
-                    enacted,
-                }
-            }
-            BestHeaderChanged::None => ImportRoute {
-                enacted: None,
-            },
-        }
-    }
-
-    pub fn none() -> Self {
-        ImportRoute {
-            enacted: None,
-        }
-    }
-
-    pub fn is_none(&self) -> bool {
-        self.enacted.is_none()
-    }
 }

--- a/core/src/blockchain/update_result.rs
+++ b/core/src/blockchain/update_result.rs
@@ -1,0 +1,69 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::block_info::{BestBlockChanged, BestHeaderChanged};
+use ctypes::BlockHash;
+
+#[derive(Debug, PartialEq)]
+pub struct ChainUpdateResult {
+    // Some(updated_best_block_hash) if chain is updated
+    // None if chain is not updated
+    pub enacted: Option<BlockHash>,
+}
+
+impl ChainUpdateResult {
+    pub fn new(best_block_changed: &BestBlockChanged) -> Self {
+        match best_block_changed {
+            BestBlockChanged::CanonChainAppended {
+                ..
+            } => {
+                let enacted = Some(best_block_changed.new_best_hash().unwrap());
+                ChainUpdateResult {
+                    enacted,
+                }
+            }
+            BestBlockChanged::None => ChainUpdateResult {
+                enacted: None,
+            },
+        }
+    }
+
+    pub fn new_from_best_header_changed(best_header_changed: &BestHeaderChanged) -> Self {
+        match best_header_changed {
+            BestHeaderChanged::CanonChainAppended {
+                ..
+            } => {
+                let enacted = Some(best_header_changed.new_best_hash().unwrap());
+                ChainUpdateResult {
+                    enacted,
+                }
+            }
+            BestHeaderChanged::None => ChainUpdateResult {
+                enacted: None,
+            },
+        }
+    }
+
+    pub fn none() -> Self {
+        ChainUpdateResult {
+            enacted: None,
+        }
+    }
+
+    pub fn is_none(&self) -> bool {
+        self.enacted.is_none()
+    }
+}


### PR DESCRIPTION
Resolves #230 

We don't use the `omitted` field anymore.

I'm not sure if I should remove `ImportRoute` struct at all, or leave it. 
Please give a comment.