### PR TITLE
Modify logic related to the Tx type for checking whether a Tx is verified or not

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -29,7 +29,9 @@ use crate::error::{BlockImportError, Error, ImportError, SchemeError};
 use crate::miner::{Miner, MinerService};
 use crate::scheme::Scheme;
 use crate::service::ClientIoMessage;
-use crate::transaction::{LocalizedTransaction, PendingSignedTransactions, SignedTransaction, UnverifiedTransaction};
+use crate::transaction::{
+    LocalizedTransaction, PendingVerifiedTransactions, UnverifiedTransaction, VerifiedTransaction,
+};
 use crate::types::{BlockId, BlockStatus, TransactionId, VerificationQueueInfo as BlockQueueInfo};
 use crate::MemPoolMinFees;
 use cdb::{new_journaldb, Algorithm, AsHashDB};
@@ -528,7 +530,7 @@ impl BlockChainClient for Client {
     }
 
     /// Import own transaction
-    fn queue_own_transaction(&self, transaction: SignedTransaction) -> Result<(), Error> {
+    fn queue_own_transaction(&self, transaction: VerifiedTransaction) -> Result<(), Error> {
         self.importer.miner.import_own_transaction(self, transaction)?;
         Ok(())
     }
@@ -555,7 +557,7 @@ impl BlockChainClient for Client {
         self.importer.miner.delete_all_pending_transactions();
     }
 
-    fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
+    fn ready_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions {
         self.importer.miner.ready_transactions(range)
     }
 
@@ -563,7 +565,7 @@ impl BlockChainClient for Client {
         self.importer.miner.count_pending_transactions(range)
     }
 
-    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions {
+    fn future_pending_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions {
         self.importer.miner.future_pending_transactions(range)
     }
 

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -34,7 +34,7 @@ use crate::consensus::EngineError;
 use crate::encoded;
 use crate::error::{BlockImportError, Error as GenericError};
 use crate::miner::MemPoolMinFees;
-use crate::transaction::{LocalizedTransaction, PendingSignedTransactions, SignedTransaction};
+use crate::transaction::{LocalizedTransaction, PendingVerifiedTransactions, VerifiedTransaction};
 use crate::types::{BlockId, BlockStatus, TransactionId, VerificationQueueInfo as BlockQueueInfo};
 use cdb::DatabaseError;
 use ckey::{Address, NetworkId, PlatformAddress};
@@ -195,7 +195,7 @@ pub trait BlockChainClient: Sync + Send + AccountData + BlockChainTrait + Import
     fn queue_info(&self) -> BlockQueueInfo;
 
     /// Queue own transaction for importing
-    fn queue_own_transaction(&self, transaction: SignedTransaction) -> Result<(), GenericError>;
+    fn queue_own_transaction(&self, transaction: VerifiedTransaction) -> Result<(), GenericError>;
 
     /// Queue transactions for importing.
     fn queue_transactions(&self, transactions: Vec<Bytes>, peer_id: NodeId);
@@ -204,10 +204,10 @@ pub trait BlockChainClient: Sync + Send + AccountData + BlockChainTrait + Import
     fn delete_all_pending_transactions(&self);
 
     /// List all transactions that are allowed into the next block.
-    fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
+    fn ready_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions;
 
     /// List all transactions in future block.
-    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
+    fn future_pending_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions;
 
     /// Get the count of all pending transactions currently in the mem_pool.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -206,7 +206,7 @@ pub trait ConsensusEngine: Sync + Send {
     fn register_time_gap_config_to_worker(&self, _time_gap_params: TimeGapParams) {}
 
     fn block_fee(&self, transactions: Box<dyn Iterator<Item = UnverifiedTransaction>>) -> u64 {
-        transactions.map(|tx| tx.fee).sum()
+        transactions.map(|tx| tx.transaction().fee).sum()
     }
 
     fn recommended_confirmation(&self) -> u32;
@@ -326,7 +326,7 @@ pub trait CodeChainEngine: ConsensusEngine {
         if let Action::Custom {
             handler_id,
             bytes,
-        } = &tx.action
+        } = &tx.transaction().action
         {
             let handler = self
                 .find_action_handler_for(*handler_id)

--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -35,7 +35,7 @@ use crate::consensus::{EngineError, Seal};
 use crate::encoded;
 use crate::error::{BlockError, Error};
 use crate::snapshot_notify::NotifySender as SnapshotNotifySender;
-use crate::transaction::{SignedTransaction, UnverifiedTransaction};
+use crate::transaction::UnverifiedTransaction;
 use crate::types::BlockStatus;
 use crate::views::BlockView;
 use crate::BlockId;
@@ -49,6 +49,7 @@ use primitives::Bytes;
 use rlp::{Encodable, Rlp};
 use std::cell::Cell;
 use std::cmp::Ordering;
+use std::convert::TryInto;
 use std::iter::Iterator;
 use std::mem;
 use std::sync::{Arc, Weak};
@@ -1475,7 +1476,7 @@ impl Worker {
         };
         let signer_public = *self.signer.public().expect("Signer must be initialized");
         let unverified = UnverifiedTransaction::new(tx, signature, signer_public);
-        let signed = SignedTransaction::try_new(unverified).expect("secret is valid so it's recoverable");
+        let signed = unverified.try_into().expect("secret is valid so it's recoverable");
 
         match self.client().queue_own_transaction(signed) {
             Ok(_) => {}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -66,7 +66,7 @@ pub use crate::peer_db::PeerDb;
 pub use crate::scheme::Scheme;
 pub use crate::service::ClientService;
 pub use crate::transaction::{
-    LocalizedTransaction, PendingSignedTransactions, SignedTransaction, UnverifiedTransaction,
+    LocalizedTransaction, PendingVerifiedTransactions, UnverifiedTransaction, VerifiedTransaction,
 };
 pub use crate::types::{BlockId, BlockStatus, TransactionId};
 pub use rlp::Encodable;

--- a/core/src/miner/mem_pool_benches.rs
+++ b/core/src/miner/mem_pool_benches.rs
@@ -17,7 +17,7 @@
 use self::test::{black_box, Bencher};
 use super::mem_pool::MemPool;
 use super::mem_pool_types::{AccountDetails, MemPoolInput, PoolingInstant, TxOrigin};
-use crate::transaction::SignedTransaction;
+use crate::transaction::VerifiedTransaction;
 use ckey::{Ed25519KeyPair as KeyPair, Ed25519Public as Public, Generator, Random};
 use ctypes::transaction::{Action, Transaction};
 use rand::prelude::SliceRandom;
@@ -36,7 +36,7 @@ fn create_input(keypair: &KeyPair, seq: u64, block: Option<PoolingInstant>, time
             quantity: 100,
         },
     };
-    let signed = SignedTransaction::new_with_sign(tx, keypair.private());
+    let signed = Verified::new_with_sign(tx, keypair.private());
 
     MemPoolInput::new(signed, TxOrigin::Local)
 }

--- a/core/src/miner/mem_pool_types.rs
+++ b/core/src/miner/mem_pool_types.rs
@@ -174,7 +174,7 @@ impl Ord for TransactionOrder {
 }
 
 /// Transaction item in the mem pool.
-#[derive(Clone, Eq, PartialEq, Debug, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Eq, PartialEq, Debug, RlpEncodable)]
 pub struct MemPoolItem {
     /// Transaction.
     pub tx: VerifiedTransaction,

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -36,7 +36,7 @@ use crate::client::{
 };
 use crate::consensus::EngineType;
 use crate::error::Error;
-use crate::transaction::{PendingSignedTransactions, SignedTransaction, UnverifiedTransaction};
+use crate::transaction::{PendingVerifiedTransactions, UnverifiedTransaction, VerifiedTransaction};
 use crate::BlockId;
 
 /// Miner client API
@@ -89,7 +89,7 @@ pub trait MinerService: Send + Sync {
     fn import_own_transaction<C: MiningBlockChainClient + EngineInfo + TermInfo>(
         &self,
         chain: &C,
-        tx: SignedTransaction,
+        tx: VerifiedTransaction,
     ) -> Result<TransactionImportResult, Error>;
 
     /// Imports incomplete (node owner) transaction to mem pool.
@@ -104,10 +104,10 @@ pub trait MinerService: Send + Sync {
     ) -> Result<(TxHash, u64), Error>;
 
     /// Get a list of all pending transactions in the mem pool.
-    fn ready_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
+    fn ready_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions;
 
     /// Get list of all future transaction in the mem pool.
-    fn future_pending_transactions(&self, range: Range<u64>) -> PendingSignedTransactions;
+    fn future_pending_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions;
 
     /// Get a count of all pending transactions in the mem pool.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;
@@ -116,7 +116,7 @@ pub trait MinerService: Send + Sync {
     fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize;
 
     /// Get a list of all future transactions.
-    fn future_transactions(&self) -> Vec<SignedTransaction>;
+    fn future_transactions(&self) -> Vec<VerifiedTransaction>;
 
     /// Start sealing.
     fn start_sealing<C: MiningBlockChainClient + EngineInfo + TermInfo>(&self, client: &C);

--- a/core/src/tests/helpers.rs
+++ b/core/src/tests/helpers.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::scheme::Scheme;
-use crate::transaction::SignedTransaction;
+use crate::transaction::VerifiedTransaction;
 use ctypes::{BlockHash, Header};
 use primitives::Bytes;
 use rlp::RlpStream;
@@ -28,7 +28,7 @@ pub fn create_test_block(header: &Header) -> Bytes {
 }
 
 #[allow(dead_code)]
-pub fn create_test_block_with_data(header: &Header, txs: &[SignedTransaction], uncles: &[Header]) -> Bytes {
+pub fn create_test_block_with_data(header: &Header, txs: &[VerifiedTransaction], uncles: &[Header]) -> Bytes {
     let mut rlp = RlpStream::new_list(3);
     rlp.append(header);
     rlp.begin_list(txs.len());

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -16,16 +16,16 @@
 
 use crate::error::Error;
 use ccrypto::blake256;
-use ckey::{sign, Ed25519Private as Private, Ed25519Public as Public, Signature};
+use ckey::{sign, verify, Ed25519Private as Private, Ed25519Public as Public, Error as KeyError, Signature};
 use ctypes::errors::SyntaxError;
 use ctypes::transaction::Transaction;
 use ctypes::{BlockHash, BlockNumber, CommonParams, TxHash};
 use rlp::{DecoderError, Encodable, Rlp, RlpStream};
-use std::ops::Deref;
+use std::convert::{TryFrom, TryInto};
 
 /// Signed transaction information without verified signature.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct UnverifiedTransaction {
+pub struct SignedTransaction {
     /// Plain Transaction.
     unsigned: Transaction,
     /// Signature.
@@ -36,21 +36,13 @@ pub struct UnverifiedTransaction {
     hash: TxHash,
 }
 
-impl Deref for UnverifiedTransaction {
-    type Target = Transaction;
-
-    fn deref(&self) -> &Self::Target {
-        &self.unsigned
+impl rlp::Encodable for SignedTransaction {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        self.rlp_append_sealed_transaction(s)
     }
 }
 
-impl From<UnverifiedTransaction> for Transaction {
-    fn from(tx: UnverifiedTransaction) -> Self {
-        tx.unsigned
-    }
-}
-
-impl rlp::Decodable for UnverifiedTransaction {
+impl rlp::Decodable for SignedTransaction {
     fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
         let item_count = d.item_count()?;
         if item_count != 6 {
@@ -60,7 +52,7 @@ impl rlp::Decodable for UnverifiedTransaction {
             })
         }
         let hash = blake256(d.as_raw()).into();
-        Ok(UnverifiedTransaction {
+        Ok(SignedTransaction {
             unsigned: Transaction {
                 seq: d.val_at(0)?,
                 fee: d.val_at(1)?,
@@ -74,141 +66,158 @@ impl rlp::Decodable for UnverifiedTransaction {
     }
 }
 
+impl SignedTransaction {
+    /// Append object with a signature into RLP stream
+    fn rlp_append_sealed_transaction(&self, s: &mut RlpStream) {
+        s.begin_list(6);
+        s.append(&self.unsigned.seq);
+        s.append(&self.unsigned.fee);
+        s.append(&self.unsigned.network_id);
+        s.append(&self.unsigned.action);
+        s.append(&self.sig);
+        s.append(&self.signer_public);
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct VerifiedTransaction(SignedTransaction);
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct UnverifiedTransaction(SignedTransaction);
+
+impl rlp::Encodable for VerifiedTransaction {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        self.0.rlp_append(s);
+    }
+}
+
+impl rlp::Decodable for VerifiedTransaction {
+    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
+        let transaction = d.as_val()?;
+        let verified = UnverifiedTransaction(transaction).try_into().expect("Invalid signature");
+        Ok(verified)
+    }
+}
+
+impl From<VerifiedTransaction> for UnverifiedTransaction {
+    fn from(tx: VerifiedTransaction) -> Self {
+        UnverifiedTransaction(tx.0)
+    }
+}
+
+impl VerifiedTransaction {
+    /// Signs the transaction as coming from `signer`.
+    pub fn new_with_sign(tx: Transaction, private: &Private) -> VerifiedTransaction {
+        let sig = sign(&tx.hash(), private);
+        UnverifiedTransaction::new(tx, sig, private.public_key())
+            .try_into()
+            .expect("The transaction's signature is invalid")
+    }
+
+    /// Returns a public key of the signer.
+    pub fn signer_public(&self) -> Public {
+        self.0.signer_public
+    }
+
+    /// Returns a public key of the signer.
+    pub fn signature(&self) -> Signature {
+        self.0.sig
+    }
+
+    pub fn transaction(&self) -> &Transaction {
+        &self.0.unsigned
+    }
+
+    pub fn hash(&self) -> TxHash {
+        self.0.hash
+    }
+}
+
 impl rlp::Encodable for UnverifiedTransaction {
     fn rlp_append(&self, s: &mut RlpStream) {
-        self.rlp_append_sealed_transaction(s)
+        self.0.rlp_append(s);
+    }
+}
+
+impl rlp::Decodable for UnverifiedTransaction {
+    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
+        let transaction = d.as_val()?;
+        Ok(Self(transaction))
+    }
+}
+
+impl TryFrom<UnverifiedTransaction> for VerifiedTransaction {
+    type Error = Error;
+    fn try_from(tx: UnverifiedTransaction) -> Result<Self, Error> {
+        if tx.verify_transaction() {
+            Ok(VerifiedTransaction(tx.0))
+        } else {
+            Err(Error::Key(KeyError::InvalidSignature))
+        }
     }
 }
 
 impl UnverifiedTransaction {
     pub fn new(unsigned: Transaction, sig: Signature, signer_public: Public) -> Self {
-        UnverifiedTransaction {
+        UnverifiedTransaction(SignedTransaction {
             unsigned,
             sig,
             signer_public,
             hash: Default::default(),
-        }
+        })
         .compute_hash()
     }
 
     /// Used to compute hash of created transactions
     fn compute_hash(mut self) -> UnverifiedTransaction {
         let hash = blake256(&*self.rlp_bytes()).into();
-        self.hash = hash;
+        self.0.hash = hash;
         self
-    }
-
-    /// Append object with a signature into RLP stream
-    fn rlp_append_sealed_transaction(&self, s: &mut RlpStream) {
-        s.begin_list(6);
-        s.append(&self.seq);
-        s.append(&self.fee);
-        s.append(&self.network_id);
-        s.append(&self.action);
-        s.append(&self.sig);
-        s.append(&self.signer_public);
-    }
-
-    /// Get the hash of this header (blake256 of the RLP).
-    pub fn hash(&self) -> TxHash {
-        self.hash
     }
 
     /// Construct a signature object from the sig.
     pub fn signature(&self) -> Signature {
-        self.sig
+        self.0.sig
+    }
+
+    /// Get the hash of this header (blake256 of the RLP).
+    pub fn hash(&self) -> TxHash {
+        self.0.hash
     }
 
     pub fn signer_public(&self) -> Public {
-        self.signer_public
+        self.0.signer_public
     }
 
     /// Verify basic signature params. Does not attempt signer recovery.
     pub fn verify_basic(&self) -> Result<(), SyntaxError> {
-        self.action.verify()
+        self.transaction().action.verify()
     }
 
     /// Verify transactiosn with the common params. Does not attempt signer recovery.
     pub fn verify_with_params(&self, params: &CommonParams) -> Result<(), SyntaxError> {
-        if self.network_id != params.network_id() {
-            return Err(SyntaxError::InvalidNetworkId(self.network_id))
+        if self.transaction().network_id != params.network_id() {
+            return Err(SyntaxError::InvalidNetworkId(self.transaction().network_id))
         }
         let byte_size = rlp::encode(self).to_vec().len();
         if byte_size >= params.max_body_size() {
             return Err(SyntaxError::TransactionIsTooBig)
         }
-        self.action.verify_with_params(params)
+        self.transaction().action.verify_with_params(params)
+    }
+
+    pub fn verify_transaction(&self) -> bool {
+        verify(&self.0.sig, &self.0.unsigned.hash(), &self.0.signer_public)
+    }
+
+    pub fn transaction(&self) -> &Transaction {
+        &self.0.unsigned
     }
 }
 
-/// A `UnverifiedTransaction` with successfully recovered `signer`.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct SignedTransaction {
-    tx: UnverifiedTransaction,
-    signer_public: Public,
-}
-
-pub struct PendingSignedTransactions {
-    pub transactions: Vec<SignedTransaction>,
+pub struct PendingVerifiedTransactions {
+    pub transactions: Vec<VerifiedTransaction>,
     pub last_timestamp: Option<u64>,
-}
-
-impl rlp::Encodable for SignedTransaction {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        self.tx.rlp_append_sealed_transaction(s)
-    }
-}
-
-impl rlp::Decodable for SignedTransaction {
-    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
-        let unverified_transaction: UnverifiedTransaction = UnverifiedTransaction::decode(d)?;
-        let signer_public = unverified_transaction.signer_public();
-        Ok(SignedTransaction {
-            tx: unverified_transaction,
-            signer_public,
-        })
-    }
-}
-
-impl Deref for SignedTransaction {
-    type Target = UnverifiedTransaction;
-    fn deref(&self) -> &Self::Target {
-        &self.tx
-    }
-}
-
-impl From<SignedTransaction> for UnverifiedTransaction {
-    fn from(tx: SignedTransaction) -> Self {
-        tx.tx
-    }
-}
-
-impl SignedTransaction {
-    /// Try to verify transaction and recover public.
-    pub fn try_new(tx: UnverifiedTransaction) -> Result<Self, Error> {
-        let signer_public = tx.signer_public();
-        Ok(SignedTransaction {
-            tx,
-            signer_public,
-        })
-    }
-
-    /// Signs the transaction as coming from `signer`.
-    pub fn new_with_sign(tx: Transaction, private: &Private) -> SignedTransaction {
-        let sig = sign(&tx.hash(), private);
-        SignedTransaction::try_new(UnverifiedTransaction::new(tx, sig, private.public_key()))
-            .expect("secret is valid so it's recoverable")
-    }
-
-    /// Returns a public key of the signer.
-    pub fn signer_public(&self) -> Public {
-        self.signer_public
-    }
-
-    /// Deconstructs this transaction back into `UnverifiedTransaction`
-    pub fn deconstruct(self) -> (UnverifiedTransaction, Public) {
-        (self.tx, self.signer_public)
-    }
 }
 
 /// Signed Transaction that is a part of canon blockchain.
@@ -237,19 +246,15 @@ impl LocalizedTransaction {
         self.cached_signer_public = Some(public);
         public
     }
-}
 
-impl Deref for LocalizedTransaction {
-    type Target = UnverifiedTransaction;
-
-    fn deref(&self) -> &Self::Target {
+    pub fn unverified_tx(&self) -> &UnverifiedTransaction {
         &self.signed
     }
 }
 
 impl From<LocalizedTransaction> for Transaction {
     fn from(tx: LocalizedTransaction) -> Self {
-        tx.signed.into()
+        tx.signed.0.unsigned
     }
 }
 
@@ -264,7 +269,7 @@ mod tests {
 
     #[test]
     fn unverified_transaction_rlp() {
-        rlp_encode_and_decode_test!(UnverifiedTransaction {
+        rlp_encode_and_decode_test!(UnverifiedTransaction(SignedTransaction {
             unsigned: Transaction {
                 seq: 0,
                 fee: 10,
@@ -276,13 +281,13 @@ mod tests {
             sig: Signature::default(),
             hash: H256::default().into(),
             signer_public: Public::random(),
-        }
+        })
         .compute_hash());
     }
 
     #[test]
     fn encode_and_decode_pay_transaction() {
-        rlp_encode_and_decode_test!(UnverifiedTransaction {
+        rlp_encode_and_decode_test!(UnverifiedTransaction(SignedTransaction {
             unsigned: Transaction {
                 seq: 30,
                 fee: 40,
@@ -295,13 +300,13 @@ mod tests {
             sig: Signature::default(),
             hash: H256::default().into(),
             signer_public: Public::random(),
-        }
+        })
         .compute_hash());
     }
 
     #[test]
     fn encode_and_decode_create_shard_transaction() {
-        rlp_encode_and_decode_test!(UnverifiedTransaction {
+        rlp_encode_and_decode_test!(UnverifiedTransaction(SignedTransaction {
             unsigned: Transaction {
                 seq: 30,
                 fee: 40,
@@ -313,7 +318,7 @@ mod tests {
             sig: Signature::default(),
             hash: H256::default().into(),
             signer_public: Public::random(),
-        }
+        })
         .compute_hash());
     }
 }

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -91,14 +91,6 @@ impl rlp::Encodable for VerifiedTransaction {
     }
 }
 
-impl rlp::Decodable for VerifiedTransaction {
-    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
-        let transaction = d.as_val()?;
-        let verified = UnverifiedTransaction(transaction).try_into().expect("Invalid signature");
-        Ok(verified)
-    }
-}
-
 impl From<VerifiedTransaction> for UnverifiedTransaction {
     fn from(tx: VerifiedTransaction) -> Self {
         UnverifiedTransaction(tx.0)

--- a/core/src/verification/verification.rs
+++ b/core/src/verification/verification.rs
@@ -19,7 +19,7 @@ use crate::client::BlockChainTrait;
 use crate::codechain_machine::CodeChainMachine;
 use crate::consensus::CodeChainEngine;
 use crate::error::{BlockError, Error};
-use crate::transaction::{SignedTransaction, UnverifiedTransaction};
+use crate::transaction::{UnverifiedTransaction, VerifiedTransaction};
 use crate::views::BlockView;
 use ccrypto::BLAKE_NULL_RLP;
 use ctypes::util::unexpected::{Mismatch, OutOfBounds};
@@ -34,7 +34,7 @@ pub struct PreverifiedBlock {
     /// Populated block header
     pub header: Header,
     /// Populated block transactions
-    pub transactions: Vec<SignedTransaction>,
+    pub transactions: Vec<VerifiedTransaction>,
     /// Block bytes
     pub bytes: Bytes,
 }
@@ -187,7 +187,7 @@ pub struct FullFamilyParams<'a, C: BlockChainTrait> {
     pub block_bytes: &'a [u8],
 
     /// Signed transactions
-    pub transactions: &'a [SignedTransaction],
+    pub transactions: &'a [VerifiedTransaction],
 
     /// Block provider to use during verification
     pub block_provider: &'a dyn BlockProvider,

--- a/foundry/auto_self_nominate.rs
+++ b/foundry/auto_self_nominate.rs
@@ -17,16 +17,14 @@
 use crate::config::load_config;
 use ccore::stake::Action::SelfNominate;
 use ccore::stake::{Banned, Candidates, Jail, CUSTOM_ACTION_HANDLER_ID};
-use ccore::{
-    AccountProvider, AccountProviderError, BlockId, ConsensusClient, Encodable, SignedTransaction,
-    UnverifiedTransaction,
-};
+use ccore::{AccountProvider, AccountProviderError, BlockId, ConsensusClient, Encodable, UnverifiedTransaction};
 use ckey::PlatformAddress;
 use ckey::{Address, Ed25519Public as Public, Signature};
 use ckeystore::DecryptedAccount;
 use clap::ArgMatches;
 use ctypes::transaction::{Action, Transaction};
 use primitives::{Bytes, H256};
+use std::convert::TryInto;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -195,7 +193,7 @@ impl AutoSelfNomination {
         };
         let signer_public = *signer.public().expect("Signer must be initialized");
         let unverified = UnverifiedTransaction::new(tx, signature, signer_public);
-        let signed = SignedTransaction::try_new(unverified).expect("secret is valid so it's recoverable");
+        let signed = unverified.try_into().expect("secret is valid so it's recoverable");
 
         match client.queue_own_transaction(signed) {
             Ok(_) => {

--- a/rpc/src/v1/impls/chain.rs
+++ b/rpc/src/v1/impls/chain.rs
@@ -66,7 +66,7 @@ where
         let id = transaction_hash.into();
         Ok(self.client.transaction(&id).map(|mut tx| {
             let address = public_to_address(&tx.signer());
-            PlatformAddress::new_v1(tx.network_id, address)
+            PlatformAddress::new_v1(tx.unverified_tx().transaction().network_id, address)
         }))
     }
 

--- a/rpc/src/v1/impls/devel.rs
+++ b/rpc/src/v1/impls/devel.rs
@@ -18,8 +18,8 @@ use super::super::errors;
 use super::super::traits::Devel;
 use super::super::types::TPSTestSetting;
 use ccore::{
-    BlockId, DatabaseClient, EngineClient, EngineInfo, MinerService, MiningBlockChainClient, SignedTransaction,
-    SnapshotClient, TermInfo, COL_STATE,
+    BlockId, DatabaseClient, EngineClient, EngineInfo, MinerService, MiningBlockChainClient, SnapshotClient, TermInfo,
+    VerifiedTransaction, COL_STATE,
 };
 use cjson::bytes::Bytes;
 use ckey::{Address, Ed25519KeyPair as KeyPair, Generator, KeyPairTrait, Random};
@@ -155,8 +155,8 @@ where
         }
 
         // Helper functions
-        fn sign_tx(tx: Transaction, key_pair: &KeyPair) -> SignedTransaction {
-            SignedTransaction::new_with_sign(tx, key_pair.private())
+        fn sign_tx(tx: Transaction, key_pair: &KeyPair) -> VerifiedTransaction {
+            VerifiedTransaction::new_with_sign(tx, key_pair.private())
         }
 
         fn tps(count: u64, start_time: PreciseTime, end_time: PreciseTime) -> f64 {

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -930,7 +930,7 @@ impl Extension {
                 }
                 for body in bodies {
                     for tx in body {
-                        let is_valid = match &tx.action {
+                        let is_valid = match &tx.transaction().action {
                             Action::Custom {
                                 handler_id,
                                 ..

--- a/sync/src/transaction/extension.rs
+++ b/sync/src/transaction/extension.rs
@@ -153,7 +153,7 @@ impl Extension {
             let unsent: Vec<_> = transactions
                 .iter()
                 .filter(|tx| !peer.contains(&tx.hash()))
-                .map(|signed| signed.clone().deconstruct().0)
+                .map(|signed| UnverifiedTransaction::from(signed.clone()))
                 .collect();
             if unsent.is_empty() {
                 continue


### PR DESCRIPTION
Summary: We modified logic related to the transaction type for checking whether a transaction is verified or not. From now on, there are two transaction types, `UnverifiedTransaction` and `VerifiedTransaction`, and the `UnverifiedTransaction` can be converted to `VerifiedTransaction` using the method `try_into()`. During this conversion, the signature is verified through the method `verify_transaction()`.

---

We were using two transaction types, `UnverifiedTransaction` and `SignedTransaction`. The `SignedTransaction` was constructed from an `UnverifiedTransaction` when the signature recovery returned a public key without errors. These structs were as follows:
```rust
pub struct UnverifiedTransaction {
    /// Plain Transaction.
    unsigned: Transaction,
    /// Signature.
    sig: Signature,
    /// Signer's public key
    signer_public: Public,
    /// Hash of the transaction
    hash: TxHash,
}

pub struct SignedTransaction {
    tx: UnverifiedTransaction,
    signer_public: Public,
}
```

We don't need such an indirection because `UnverifiedTransaction` should include a public key. Then, we had thought it would be good to unify `SignedTransaction` and `UnverifiedTransaction`. However, we still need logic to distinguish whether each transaction is verified or not. 


Therefore, we modified the logic we were used(`UnverifiedTransaction` and `SignedTransaction`) to `UnverifiedTransaction` and `VerifiedTransaction`. These struct have the same components and we can check whether it is a verified transaction or not. These structs are as follows:
```rust
pub struct SignedTransaction {
    /// Plain Transaction.
    unsigned: Transaction,
    /// Signature.
    sig: Signature,
    /// Signer's public key
    signer_public: Public,
    /// Hash of the transaction
    hash: TxHash,
}

pub struct VerifiedTransaction(SignedTransaction);

pub struct UnverifiedTransaction(pub SignedTransaction);
```

From now on, we can verify transactions in the process of converting from `UnverifiedTransaction` to `VerifiedTransaction`. The trait `TryFrom` is implemented for `VerifiedTransaction` and we can convert the unverified transaction to it using a method `.try_into()`. During this conversion, the signature is verified the method `verify_transaction()`.