### PR TITLE
Merge ClosedBlock and LockedBlock into one

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -20,7 +20,7 @@ use super::{
     DatabaseClient, EngineClient, EngineInfo, ExecuteClient, ImportBlock, ImportResult, MiningBlockChainClient, Shard,
     StateInfo, StateOrBlock,
 };
-use crate::block::{Block, ClosedBlock, IsBlock, OpenBlock, SealedBlock};
+use crate::block::{Block, IsBlock, OpenBlock, SealedBlock};
 use crate::blockchain::{BlockChain, BlockProvider, BodyProvider, HeaderProvider, InvoiceProvider, TransactionAddress};
 use crate::client::{ConsensusClient, SnapshotClient, TermInfo};
 use crate::consensus::{CodeChainEngine, EngineError};
@@ -720,11 +720,6 @@ impl Shard for Client {
 }
 
 impl BlockProducer for Client {
-    fn reopen_block(&self, block: ClosedBlock) -> OpenBlock<'_> {
-        let engine = &*self.engine;
-        block.reopen(engine)
-    }
-
     fn prepare_open_block(&self, parent_block_id: BlockId, author: Address, extra_data: Bytes) -> OpenBlock<'_> {
         let engine = &*self.engine;
         let chain = self.block_chain();

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -28,7 +28,7 @@ pub use self::client::Client;
 pub use self::config::ClientConfig;
 pub use self::test_client::TestBlockChainClient;
 
-use crate::block::{Block, ClosedBlock, OpenBlock, SealedBlock};
+use crate::block::{Block, OpenBlock, SealedBlock};
 use crate::blockchain_info::BlockChainInfo;
 use crate::consensus::EngineError;
 use crate::encoded;
@@ -261,9 +261,6 @@ pub type ImportResult = Result<BlockHash, DatabaseError>;
 
 /// Provides methods used for sealing new state
 pub trait BlockProducer {
-    /// Reopens an OpenBlock and updates uncles.
-    fn reopen_block(&self, block: ClosedBlock) -> OpenBlock<'_>;
-
     /// Returns OpenBlock prepared for closing.
     fn prepare_open_block(&self, parent_block: BlockId, author: Address, extra_data: Bytes) -> OpenBlock<'_>;
 }

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -30,7 +30,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::block::{Block, ClosedBlock, OpenBlock, SealedBlock};
+use crate::block::{Block, OpenBlock, SealedBlock};
 use crate::blockchain_info::BlockChainInfo;
 use crate::client::{
     AccountData, BlockChainClient, BlockChainTrait, BlockProducer, BlockStatus, ConsensusClient, EngineInfo,
@@ -332,10 +332,6 @@ pub fn get_temp_state_db() -> StateDB {
 }
 
 impl BlockProducer for TestBlockChainClient {
-    fn reopen_block(&self, block: ClosedBlock) -> OpenBlock<'_> {
-        block.reopen(&*self.scheme.engine)
-    }
-
     fn prepare_open_block(&self, _parent_block: BlockId, author: Address, extra_data: Bytes) -> OpenBlock<'_> {
         let engine = &*self.scheme.engine;
         let genesis_header = self.scheme.genesis_header();

--- a/core/src/consensus/solo/mod.rs
+++ b/core/src/consensus/solo/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Kodebox, Inc.
+// Copyright 2018-2020 Kodebox, Inc.
 // This file is part of CodeChain.
 //
 // This program is free software: you can redistribute it and/or modify
@@ -196,7 +196,7 @@ mod tests {
         let db = client.scheme.ensure_genesis_state(get_temp_state_db()).unwrap();
         let genesis_header = client.scheme.genesis_header();
         let b = OpenBlock::try_new(&*engine, db, &genesis_header, Default::default(), vec![]).unwrap();
-        let b = b.close_and_lock().unwrap();
+        let b = b.close().unwrap();
         if let Some(seal) = engine.generate_seal(Some(b.block()), &genesis_header).seal_fields() {
             b.seal_block(seal);
         }

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -406,7 +406,7 @@ impl Miner {
         C: BlockChainTrait + ImportBlock, {
         assert!(self.engine.seals_internally());
 
-        let sealed = block.lock().already_sealed();
+        let sealed = block.already_sealed();
 
         if self.engine.is_proposal(sealed.header()) {
             self.engine.proposal_generated(&sealed);


### PR DESCRIPTION
Resolves #261 

There is no reason to distinguish ClosedBlock and LockedBlock since
ClosedBlocks are never reopened.
reopen methods should be removed as well.