### PR TITLE
Skip one of the snapshot test

### DIFF
--- a/test/src/e2e.dynval/2/snapshot.test.ts
+++ b/test/src/e2e.dynval/2/snapshot.test.ts
@@ -85,7 +85,7 @@ describe("Snapshot for Tendermint with Dynamic Validator", function() {
         ).to.satisfy(fs.existsSync);
     });
 
-    it("should be able to boot with the snapshot", async function() {
+    it.skip("should be able to boot with the snapshot", async function() {
         const termWaiter = setTermTestTimeout(this, {
             terms: 3
         });


### PR DESCRIPTION
This test becomes fragile. Let's skip it until we stabilize the snapshot feature.