### PR TITLE
Convert hexadecimal string returned from getBalance to number

### DIFF
--- a/test/src/e2e.long/staking.test.ts
+++ b/test/src/e2e.long/staking.test.ts
@@ -894,7 +894,7 @@ describe("Staking", function() {
                 address: author.toString(),
                 blockNumber: blockNumber - 1
             }))!;
-            const authorBalance = (await nodes[0].rpc.chain.getBalance({
+            const authorBalance = +(await nodes[0].rpc.chain.getBalance({
                 address: author.toString()
             }))!;
             expect(authorBalance).to.be.deep.equal(


### PR DESCRIPTION
Other getBalance callers are converting the return value to number using "+". Only this line does not have it.