### PR TITLE
Remove tracker from invoice and body db

### DIFF
--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -160,7 +160,6 @@ impl<'x> OpenBlock<'x> {
         }
 
         let hash = tx.hash();
-        let tracker = tx.tracker();
         let error = match self.block.state.apply(
             &tx,
             &hash,
@@ -179,7 +178,6 @@ impl<'x> OpenBlock<'x> {
         };
         self.block.invoices.push(Invoice {
             hash,
-            tracker,
             error: error.clone().map(|err| err.to_string()),
         });
 

--- a/core/src/blockchain/blockchain.rs
+++ b/core/src/blockchain/blockchain.rs
@@ -28,7 +28,7 @@ use crate::encoded;
 use crate::invoice::Invoice;
 use crate::transaction::LocalizedTransaction;
 use crate::views::{BlockView, HeaderView};
-use ctypes::{BlockHash, BlockNumber, Tracker, TxHash};
+use ctypes::{BlockHash, BlockNumber, TxHash};
 use kvdb::{DBTransaction, KeyValueDB};
 use parking_lot::RwLock;
 use primitives::H256;
@@ -446,10 +446,6 @@ impl BodyProvider for BlockChain {
 
     fn transaction_address(&self, hash: &TxHash) -> Option<TransactionAddress> {
         self.body_db.transaction_address(hash)
-    }
-
-    fn transaction_address_by_tracker(&self, tracker: &Tracker) -> Option<TransactionAddress> {
-        self.body_db.transaction_address_by_tracker(tracker)
     }
 
     fn block_body(&self, hash: &BlockHash) -> Option<encoded::Body> {

--- a/core/src/blockchain/blockchain.rs
+++ b/core/src/blockchain/blockchain.rs
@@ -173,7 +173,7 @@ impl BlockChain {
         self.body_db.insert_body(batch, &new_block);
         self.body_db.update_best_block(batch, &best_block_changed);
         for invoice in invoices {
-            self.invoice_db.insert_invoice(batch, invoice.hash, invoice.tracker, invoice.error);
+            self.invoice_db.insert_invoice(batch, invoice.hash, invoice.error);
         }
 
         if let Some(best_block_hash) = best_block_changed.new_best_hash() {
@@ -461,10 +461,6 @@ impl InvoiceProvider for BlockChain {
     /// Returns true if invoices for given hash is known
     fn is_known_error_hint(&self, hash: &TxHash) -> bool {
         self.invoice_db.is_known_error_hint(hash)
-    }
-
-    fn error_hints_by_tracker(&self, tracker: &Tracker) -> Vec<(TxHash, Option<String>)> {
-        self.invoice_db.error_hints_by_tracker(tracker)
     }
 
     fn error_hint(&self, hash: &TxHash) -> Option<String> {

--- a/core/src/blockchain/extras.rs
+++ b/core/src/blockchain/extras.rs
@@ -16,9 +16,9 @@
 
 use crate::db::Key;
 use crate::types::TransactionId;
-use ctypes::{BlockHash, BlockNumber, Tracker, TxHash};
+use ctypes::{BlockHash, BlockNumber, TxHash};
 use primitives::{H256, H264};
-use std::ops::{Add, AddAssign, Deref, Sub, SubAssign};
+use std::ops::Deref;
 
 /// Represents index of extra data in database
 #[derive(Copy, Debug, Hash, Eq, PartialEq, Clone)]
@@ -29,10 +29,6 @@ enum ExtrasIndex {
     BlockHash = 1,
     /// Transaction address index
     TransactionAddress = 2,
-    /// Transaction addresses index
-    TransactionAddresses = 3,
-    // (Reserved) = 4,
-    // (Reserved) = 5,
 }
 
 fn with_index(hash: &H256, i: ExtrasIndex) -> H264 {
@@ -82,14 +78,6 @@ impl Key<TransactionAddress> for TxHash {
     }
 }
 
-impl Key<TransactionAddresses> for Tracker {
-    type Target = H264;
-
-    fn key(&self) -> H264 {
-        with_index(self, ExtrasIndex::TransactionAddresses)
-    }
-}
-
 /// Familial details concerning a block
 #[derive(Debug, Clone, RlpEncodable, RlpDecodable)]
 pub struct BlockDetails {
@@ -116,65 +104,6 @@ impl From<TransactionAddress> for TransactionId {
     }
 }
 
-/// Represents address of certain transaction that has the same tracker
-#[derive(Debug, Default, PartialEq, Clone, RlpEncodableWrapper, RlpDecodableWrapper)]
-pub struct TransactionAddresses {
-    addresses: Vec<TransactionAddress>,
-}
-
-impl TransactionAddresses {
-    pub fn new(address: TransactionAddress) -> Self {
-        Self {
-            addresses: vec![address],
-        }
-    }
-}
-
-impl IntoIterator for TransactionAddresses {
-    type Item = TransactionAddress;
-    type IntoIter = ::std::vec::IntoIter<<Self as IntoIterator>::Item>;
-
-    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
-        self.addresses.into_iter()
-    }
-}
-
-impl Add for TransactionAddresses {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> <Self as Add>::Output {
-        let mut s = self;
-        s += rhs;
-        s
-    }
-}
-
-impl AddAssign for TransactionAddresses {
-    fn add_assign(&mut self, rhs: Self) {
-        // FIXME: Please fix this O(n*m) algorithm
-        let new_addresses: Vec<_> = rhs.into_iter().filter(|addr| !self.addresses.contains(addr)).collect();
-        self.addresses.extend(new_addresses);
-    }
-}
-
-impl Sub for TransactionAddresses {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> <Self as Add>::Output {
-        let mut s = self;
-        s -= rhs;
-        s
-    }
-}
-
-impl SubAssign for TransactionAddresses {
-    fn sub_assign(&mut self, rhs: Self) {
-        // FIXME: Please fix this O(n*m) algorithm
-        self.addresses.retain(|addr| !rhs.addresses.contains(addr));
-        self.addresses.shrink_to_fit();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use rlp::rlp_encode_and_decode_test;
@@ -182,149 +111,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn encode_and_decode_transaction_address_with_single_address() {
-        rlp_encode_and_decode_test!(TransactionAddresses::new(TransactionAddress {
+    fn encode_and_decode_transaction_address() {
+        rlp_encode_and_decode_test!(TransactionAddress {
             block_hash: H256::random().into(),
             index: 0,
-        }));
-    }
-
-    #[test]
-    fn encode_and_decode_transaction_address_without_address() {
-        rlp_encode_and_decode_test!(TransactionAddresses::default());
-    }
-
-    #[test]
-    fn encode_and_decode_transaction_address_with_multiple_addresses() {
-        rlp_encode_and_decode_test!(TransactionAddresses {
-            addresses: vec![
-                TransactionAddress {
-                    block_hash: H256::random().into(),
-                    index: 0,
-                },
-                TransactionAddress {
-                    block_hash: H256::random().into(),
-                    index: 3,
-                },
-                TransactionAddress {
-                    block_hash: H256::random().into(),
-                    index: 1,
-                },
-            ],
         });
-    }
-
-    #[test]
-    fn add() {
-        let t1 = TransactionAddresses {
-            addresses: vec![TransactionAddress {
-                block_hash: H256::zero().into(),
-                index: 0,
-            }],
-        };
-        let t2 = TransactionAddresses {
-            addresses: vec![TransactionAddress {
-                block_hash: H256::from(1).into(),
-                index: 0,
-            }],
-        };
-        assert_eq!(
-            vec![
-                TransactionAddress {
-                    block_hash: H256::zero().into(),
-                    index: 0,
-                },
-                TransactionAddress {
-                    block_hash: H256::from(1).into(),
-                    index: 0,
-                }
-            ],
-            (t1 + t2).addresses
-        );
-    }
-
-    #[test]
-    fn do_not_add_duplicated_item() {
-        let t1 = TransactionAddresses {
-            addresses: vec![TransactionAddress {
-                block_hash: H256::zero().into(),
-                index: 0,
-            }],
-        };
-        let t2 = TransactionAddresses {
-            addresses: vec![TransactionAddress {
-                block_hash: H256::zero().into(),
-                index: 0,
-            }],
-        };
-        assert_eq!(
-            vec![TransactionAddress {
-                block_hash: H256::zero().into(),
-                index: 0,
-            },],
-            (t1 + t2).addresses
-        );
-    }
-
-    #[test]
-    fn remove() {
-        let t1 = TransactionAddresses {
-            addresses: vec![
-                TransactionAddress {
-                    block_hash: H256::zero().into(),
-                    index: 0,
-                },
-                TransactionAddress {
-                    block_hash: H256::from(1).into(),
-                    index: 0,
-                },
-                TransactionAddress {
-                    block_hash: H256::from(2).into(),
-                    index: 0,
-                },
-            ],
-        };
-        let t2 = TransactionAddresses {
-            addresses: vec![TransactionAddress {
-                block_hash: H256::from(1).into(),
-                index: 0,
-            }],
-        };
-        assert_eq!(
-            vec![
-                TransactionAddress {
-                    block_hash: H256::zero().into(),
-                    index: 0,
-                },
-                TransactionAddress {
-                    block_hash: H256::from(2).into(),
-                    index: 0,
-                }
-            ],
-            (t1 - t2).addresses
-        );
-    }
-
-    #[test]
-    fn remove_dont_touch_unmatched_item() {
-        let t1 = TransactionAddresses {
-            addresses: vec![TransactionAddress {
-                block_hash: H256::zero().into(),
-                index: 0,
-            }],
-        };
-        let t2 = TransactionAddresses {
-            addresses: vec![TransactionAddress {
-                block_hash: H256::from(1).into(),
-                index: 0,
-            }],
-        };
-        assert_eq!(
-            vec![TransactionAddress {
-                block_hash: H256::zero().into(),
-                index: 0,
-            },],
-            (t1 - t2).addresses
-        );
     }
 }

--- a/core/src/blockchain/invoice_db.rs
+++ b/core/src/blockchain/invoice_db.rs
@@ -15,21 +15,18 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::db::{self, CacheUpdatePolicy, Key, Readable, Writable};
-use ctypes::{Tracker, TxHash};
+use ctypes::TxHash;
 use kvdb::{DBTransaction, KeyValueDB};
 use parking_lot::RwLock;
-use primitives::{H256, H264};
-use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use primitives::H256;
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::sync::Arc;
 
 /// Structure providing fast access to blockchain data.
 ///
 /// **Does not do input data verification.**
 pub struct InvoiceDB {
-    // tracker -> transaction hash + error hint
-    tracker_cache: RwLock<HashMap<Tracker, TrackerInvoices>>,
     // transaction hash -> error hint
     hash_cache: RwLock<HashMap<TxHash, Option<String>>>,
 
@@ -40,7 +37,6 @@ impl InvoiceDB {
     /// Create new instance of blockchain from given Genesis.
     pub fn new(db: Arc<dyn KeyValueDB>) -> Self {
         Self {
-            tracker_cache: Default::default(),
             hash_cache: Default::default(),
 
             db,
@@ -54,23 +50,13 @@ impl InvoiceDB {
         &self,
         batch: &mut DBTransaction,
         hash: TxHash,
-        tracker: Option<Tracker>,
         error_hint: Option<String>,
     ) {
         if self.is_known_error_hint(&hash) {
             return
         }
 
-        let mut hashes_cache = self.tracker_cache.write();
         let mut hint_cache = self.hash_cache.write();
-
-        if let Some(tracker) = tracker {
-            let mut hashes =
-                self.db.read_with_cache(db::COL_ERROR_HINT, &mut *hashes_cache, &tracker).unwrap_or_default();
-            hashes.push((hash, error_hint.clone()));
-            batch.write_with_cache(db::COL_ERROR_HINT, &mut *hashes_cache, tracker, hashes, CacheUpdatePolicy::Remove)
-        }
-
         batch.write_with_cache(db::COL_ERROR_HINT, &mut *hint_cache, hash, error_hint, CacheUpdatePolicy::Remove);
     }
 }
@@ -79,9 +65,6 @@ impl InvoiceDB {
 pub trait InvoiceProvider {
     /// Returns true if invoices for given hash is known
     fn is_known_error_hint(&self, hash: &TxHash) -> bool;
-
-    /// Get error hints
-    fn error_hints_by_tracker(&self, tracker: &Tracker) -> Vec<(TxHash, Option<String>)>;
 
     /// Get error hint
     fn error_hint(&self, hash: &TxHash) -> Option<String>;
@@ -92,99 +75,15 @@ impl InvoiceProvider for InvoiceDB {
         self.db.exists_with_cache(db::COL_ERROR_HINT, &self.hash_cache, hash)
     }
 
-    fn error_hints_by_tracker(&self, tracker: &Tracker) -> Vec<(TxHash, Option<String>)> {
-        self.db
-            .read_with_cache(db::COL_ERROR_HINT, &mut *self.tracker_cache.write(), tracker)
-            .map(|hashes| (*hashes).clone())
-            .unwrap_or_default()
-    }
-
     fn error_hint(&self, hash: &TxHash) -> Option<String> {
         self.db.read_with_cache(db::COL_ERROR_HINT, &mut *self.hash_cache.write(), hash)?
     }
 }
 
-#[derive(Clone, Default)]
-pub struct TrackerInvoices(Vec<(TxHash, Option<String>)>);
-
-impl Encodable for TrackerInvoices {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(self.len() * 2);
-        for (hash, error) in self.iter() {
-            s.append(hash);
-            s.append(error);
-        }
-    }
-}
-
-impl Decodable for TrackerInvoices {
-    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
-        let item_count = rlp.item_count()?;
-        if item_count % 2 == 1 {
-            return Err(DecoderError::RlpInvalidLength {
-                expected: item_count + 1,
-                got: item_count,
-            })
-        }
-        let mut vec = Vec::with_capacity(item_count / 2);
-        // TODO: Optimize the below code
-        for i in 0..(item_count / 2) {
-            vec.push((rlp.val_at(i * 2)?, rlp.val_at(i * 2 + 1)?));
-        }
-        Ok(vec.into())
-    }
-}
-
-impl From<Vec<(TxHash, Option<String>)>> for TrackerInvoices {
-    fn from(f: Vec<(TxHash, Option<String>)>) -> Self {
-        TrackerInvoices(f)
-    }
-}
-
-impl Deref for TrackerInvoices {
-    type Target = Vec<(TxHash, Option<String>)>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for TrackerInvoices {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-enum ErrorHintIndex {
-    TrackerToHashes = 0,
-    HashToHint = 1,
-}
-
-impl From<ErrorHintIndex> for u8 {
-    fn from(e: ErrorHintIndex) -> Self {
-        e as Self
-    }
-}
-
 impl Key<Option<String>> for TxHash {
-    type Target = H264;
+    type Target = H256;
 
-    fn key(&self) -> H264 {
-        with_index(self, ErrorHintIndex::HashToHint)
+    fn key(&self) -> H256 {
+        *self.deref()
     }
-}
-
-impl Key<TrackerInvoices> for Tracker {
-    type Target = H264;
-
-    fn key(&self) -> H264 {
-        with_index(self, ErrorHintIndex::TrackerToHashes)
-    }
-}
-
-fn with_index(hash: &H256, i: ErrorHintIndex) -> H264 {
-    let mut result = H264::default();
-    result[0] = i as u8;
-    (*result)[1..].copy_from_slice(hash);
-    result
 }

--- a/core/src/blockchain/invoice_db.rs
+++ b/core/src/blockchain/invoice_db.rs
@@ -46,12 +46,7 @@ impl InvoiceDB {
     /// Inserts the block into backing cache database.
     /// Expects the block to be valid and already verified.
     /// If the block is already known, does nothing.
-    pub fn insert_invoice(
-        &self,
-        batch: &mut DBTransaction,
-        hash: TxHash,
-        error_hint: Option<String>,
-    ) {
+    pub fn insert_invoice(&self, batch: &mut DBTransaction, hash: TxHash, error_hint: Option<String>) {
         if self.is_known_error_hint(&hash) {
             return
         }

--- a/core/src/blockchain/mod.rs
+++ b/core/src/blockchain/mod.rs
@@ -26,7 +26,7 @@ mod update_result;
 
 pub use self::blockchain::{BlockChain, BlockProvider};
 pub use self::body_db::BodyProvider;
-pub use self::extras::{BlockDetails, TransactionAddress, TransactionAddresses};
+pub use self::extras::{BlockDetails, TransactionAddress};
 pub use self::headerchain::HeaderProvider;
 pub use self::invoice_db::InvoiceProvider;
 pub use self::update_result::ChainUpdateResult;

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -632,11 +632,6 @@ impl BlockChainClient for Client {
         let address = self.transaction_addresses(tracker);
         address.and_then(|address| chain.transaction(&address))
     }
-
-    fn error_hints_by_tracker(&self, tracker: &Tracker) -> Vec<(TxHash, Option<String>)> {
-        let chain = self.block_chain();
-        chain.error_hints_by_tracker(tracker)
-    }
 }
 
 impl TermInfo for Client {

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -40,7 +40,7 @@ use cstate::{ActionHandler, FindActionHandler, StateDB, StateResult, TopLevelSta
 use ctimer::{TimeoutHandler, TimerApi, TimerScheduleError, TimerToken};
 use ctypes::header::Header;
 use ctypes::transaction::ShardTransaction;
-use ctypes::{BlockHash, BlockNumber, CommonParams, ShardId, Tracker, TxHash};
+use ctypes::{BlockHash, BlockNumber, CommonParams, ShardId, TxHash};
 use kvdb::{DBTransaction, KeyValueDB};
 use parking_lot::{Mutex, RwLock, RwLockReadGuard};
 use primitives::{Bytes, H256};
@@ -197,10 +197,6 @@ impl Client {
                 })
             }
         }
-    }
-
-    fn transaction_addresses(&self, tracker: &Tracker) -> Option<TransactionAddress> {
-        self.block_chain().transaction_address_by_tracker(tracker)
     }
 
     /// Import transactions from the IO queue
@@ -450,10 +446,6 @@ impl BlockChainTrait for Client {
     fn transaction_block(&self, id: &TransactionId) -> Option<BlockHash> {
         self.transaction_address(id).map(|addr| addr.block_hash)
     }
-
-    fn transaction_header(&self, tracker: &Tracker) -> Option<encoded::Header> {
-        self.transaction_addresses(tracker).map(|addr| addr.block_hash).and_then(|hash| self.block_header(&hash.into()))
-    }
 }
 
 impl ImportBlock for Client {
@@ -625,12 +617,6 @@ impl BlockChainClient for Client {
     fn error_hint(&self, hash: &TxHash) -> Option<String> {
         let chain = self.block_chain();
         chain.error_hint(hash)
-    }
-
-    fn transaction_by_tracker(&self, tracker: &Tracker) -> Option<LocalizedTransaction> {
-        let chain = self.block_chain();
-        let address = self.transaction_addresses(tracker);
-        address.and_then(|address| chain.transaction(&address))
     }
 }
 

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -251,8 +251,6 @@ pub trait BlockChainClient: Sync + Send + AccountData + BlockChainTrait + Import
 
     /// Get the transaction with given tracker.
     fn transaction_by_tracker(&self, tracker: &Tracker) -> Option<LocalizedTransaction>;
-
-    fn error_hints_by_tracker(&self, tracker: &Tracker) -> Vec<(TxHash, Option<String>)>;
 }
 
 /// Result of import block operation.

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -42,7 +42,7 @@ use cnetwork::NodeId;
 use cstate::{FindActionHandler, StateResult, TopLevelState, TopStateView};
 use ctypes::header::Header;
 use ctypes::transaction::ShardTransaction;
-use ctypes::{BlockHash, BlockNumber, CommonParams, ShardId, Tracker, TxHash};
+use ctypes::{BlockHash, BlockNumber, CommonParams, ShardId, TxHash};
 use kvdb::KeyValueDB;
 use primitives::{Bytes, H256};
 use std::ops::Range;
@@ -72,16 +72,6 @@ pub trait BlockChainTrait {
 
     /// Get the hash of block that contains the transaction, if any.
     fn transaction_block(&self, id: &TransactionId) -> Option<BlockHash>;
-
-    fn transaction_header(&self, tracker: &Tracker) -> Option<encoded::Header>;
-
-    fn transaction_block_number(&self, tracker: &Tracker) -> Option<BlockNumber> {
-        self.transaction_header(tracker).map(|header| header.number())
-    }
-
-    fn transaction_block_timestamp(&self, tracker: &Tracker) -> Option<u64> {
-        self.transaction_header(tracker).map(|header| header.timestamp())
-    }
 }
 
 pub trait EngineInfo: Send + Sync {
@@ -248,9 +238,6 @@ pub trait BlockChainClient: Sync + Send + AccountData + BlockChainTrait + Import
 
     /// Get invoice with given hash.
     fn error_hint(&self, hash: &TxHash) -> Option<String>;
-
-    /// Get the transaction with given tracker.
-    fn transaction_by_tracker(&self, tracker: &Tracker) -> Option<LocalizedTransaction>;
 }
 
 /// Result of import block operation.

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -56,7 +56,7 @@ use cstate::{FindActionHandler, StateDB, TopLevelState};
 use ctimer::{TimeoutHandler, TimerToken};
 use ctypes::header::Header;
 use ctypes::transaction::{Action, Transaction};
-use ctypes::{BlockHash, BlockNumber, CommonParams, Header as BlockHeader, Tracker, TxHash};
+use ctypes::{BlockHash, BlockNumber, CommonParams, Header as BlockHeader, TxHash};
 use kvdb::KeyValueDB;
 use merkle_trie::skewed_merkle_root;
 use parking_lot::RwLock;
@@ -429,10 +429,6 @@ impl BlockChainTrait for TestBlockChainClient {
     fn transaction_block(&self, _id: &TransactionId) -> Option<BlockHash> {
         None // Simple default.
     }
-
-    fn transaction_header(&self, _tracker: &Tracker) -> Option<encoded::Header> {
-        None
-    }
 }
 
 impl ImportBlock for TestBlockChainClient {
@@ -575,10 +571,6 @@ impl BlockChainClient for TestBlockChainClient {
     }
 
     fn error_hint(&self, _hash: &TxHash) -> Option<String> {
-        unimplemented!();
-    }
-
-    fn transaction_by_tracker(&self, _: &Tracker) -> Option<LocalizedTransaction> {
         unimplemented!();
     }
 }

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -581,10 +581,6 @@ impl BlockChainClient for TestBlockChainClient {
     fn transaction_by_tracker(&self, _: &Tracker) -> Option<LocalizedTransaction> {
         unimplemented!();
     }
-
-    fn error_hints_by_tracker(&self, _: &Tracker) -> Vec<(TxHash, Option<String>)> {
-        unimplemented!();
-    }
 }
 
 impl TimeoutHandler for TestBlockChainClient {

--- a/core/src/invoice.rs
+++ b/core/src/invoice.rs
@@ -14,11 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use ctypes::{Tracker, TxHash};
+use ctypes::TxHash;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Invoice {
-    pub tracker: Option<Tracker>,
     pub hash: TxHash,
     pub error: Option<String>,
 }

--- a/rpc/src/v1/impls/chain.rs
+++ b/rpc/src/v1/impls/chain.rs
@@ -23,7 +23,7 @@ use cjson::uint::Uint;
 use ckey::{public_to_address, NetworkId, PlatformAddress};
 use cstate::FindActionHandler;
 use ctypes::transaction::Action;
-use ctypes::{BlockHash, BlockNumber, ShardId, Tracker, TxHash};
+use ctypes::{BlockHash, BlockNumber, ShardId, TxHash};
 use jsonrpc_core::Result;
 use primitives::H256;
 use std::convert::TryFrom;
@@ -76,10 +76,6 @@ where
 
     fn contain_transaction(&self, transaction_hash: TxHash) -> Result<bool> {
         self.contains_transaction(transaction_hash)
-    }
-
-    fn get_transaction_by_tracker(&self, tracker: Tracker) -> Result<Option<Transaction>> {
-        Ok(self.client.transaction_by_tracker(&tracker).map(From::from))
     }
 
     fn get_seq(&self, address: PlatformAddress, block_number: Option<u64>) -> Result<Option<u64>> {

--- a/rpc/src/v1/impls/mempool.rs
+++ b/rpc/src/v1/impls/mempool.rs
@@ -20,7 +20,7 @@ use super::super::types::{MemPoolMinFees, PendingTransactions};
 use ccore::{BlockChainClient, EngineInfo, MiningBlockChainClient, SignedTransaction};
 use cjson::bytes::Bytes;
 use ckey::{Address, PlatformAddress};
-use ctypes::{Tracker, TxHash};
+use ctypes::TxHash;
 use jsonrpc_core::Result;
 use rlp::Rlp;
 use std::sync::Arc;
@@ -54,15 +54,6 @@ where
                 }
             })
             .map(Into::into)
-    }
-
-    fn get_transaction_results_by_tracker(&self, tracker: Tracker) -> Result<Vec<bool>> {
-        Ok(self
-            .client
-            .error_hints_by_tracker(&tracker)
-            .into_iter()
-            .map(|(_hash, error_hint)| error_hint.is_none())
-            .collect())
     }
 
     fn get_error_hint(&self, transaction_hash: TxHash) -> Result<Option<String>> {

--- a/rpc/src/v1/traits/chain.rs
+++ b/rpc/src/v1/traits/chain.rs
@@ -18,7 +18,7 @@ use super::super::types::{Block, BlockNumberAndHash, Transaction, UnsignedTransa
 use cjson::scheme::Params;
 use cjson::uint::Uint;
 use ckey::{NetworkId, PlatformAddress};
-use ctypes::{BlockHash, BlockNumber, ShardId, Tracker, TxHash};
+use ctypes::{BlockHash, BlockNumber, ShardId, TxHash};
 use jsonrpc_core::Result;
 use primitives::H256;
 
@@ -38,10 +38,6 @@ pub trait Chain {
 
     #[rpc(name = "chain_containTransaction")]
     fn contain_transaction(&self, transaction_hash: TxHash) -> Result<bool>;
-
-    /// Gets transaction with given transaction tracker.
-    #[rpc(name = "chain_getTransactionByTracker")]
-    fn get_transaction_by_tracker(&self, tracker: Tracker) -> Result<Option<Transaction>>;
 
     /// Gets seq with given account.
     #[rpc(name = "chain_getSeq")]

--- a/rpc/src/v1/traits/mempool.rs
+++ b/rpc/src/v1/traits/mempool.rs
@@ -17,7 +17,7 @@
 use super::super::types::{MemPoolMinFees, PendingTransactions};
 use cjson::bytes::Bytes;
 use ckey::PlatformAddress;
-use ctypes::{Tracker, TxHash};
+use ctypes::TxHash;
 use jsonrpc_core::Result;
 
 #[rpc(server)]
@@ -25,10 +25,6 @@ pub trait Mempool {
     /// Sends signed transaction, returning its hash.
     #[rpc(name = "mempool_sendSignedTransaction")]
     fn send_signed_transaction(&self, raw: Bytes) -> Result<TxHash>;
-
-    /// Gets transaction results with given transaction tracker.
-    #[rpc(name = "mempool_getTransactionResultsByTracker")]
-    fn get_transaction_results_by_tracker(&self, tracker: Tracker) -> Result<Vec<bool>>;
 
     /// Gets a hint to find out why the transaction failed.
     #[rpc(name = "mempool_getErrorHint")]

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -263,7 +263,6 @@ When `Transaction` is included in any response, there will be an additional fiel
  * [chain_getTransaction](#chain_gettransaction)
  * [chain_getTransactionSigner](#chain_gettransactionsigner)
  * [chain_containsTransaction](#chain_containstransaction)
- * [chain_getTransactionByTracker](#chain_gettransactionbytracker)
  * [chain_getAssetSchemeByTracker](#chain_getassetschemebytracker)
  * [chain_getAssetSchemeByType](#chain_getassetschemebytype)
  * [chain_getAsset](#chain_getasset)
@@ -765,52 +764,6 @@ Errors: `Invalid Params`
   "id":null
 }
 ```
-
-[Back to **List of methods**](#list-of-methods)
-
-## chain_getTransactionByTracker
-Gets transaction with the given tracker.
-
-### Params
- 1. tracker - `H256`
-
-### Returns
-`Transaction`
-
-Errors: `Invalid Params`
-
-### Request Example
-```
-  curl \
-    -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "chain_getTransactionsByTracker", "params": ["0x24df02abcd4e984e90253dc344e89b8431bbb319c66643bfef566dfdf46ec6bc"], "id": null}' \
-    localhost:8080
-```
-
-### Response Example
-```
-{
-    "jsonrpc": "2.0",
-    "result": {
-        "action": {
-          "type":"pay",
-          "quantity":"0xa",
-          "receiver": "cccqzn9jjm3j6qg69smd7cn0eup4w7z2yu9myd6c4d7"
-          "hash": "0x24df02abcd4e984e90253dc344e89b8431bbb319c66643bfef566dfdf46ec6bc",
-        },
-        "blockHash": "0xfc196ede542b03b55aee9f106004e7e3d7ea6a9600692e964b4735a260356b50",
-        "blockNumber": 5,
-        "fee": "0xa",
-        "hash": "0xdb7c705d02e8961880783b4cb3dc051c41e551ade244bed5521901d8de190fc6",
-        "networkId": "cc",
-        "seq": 4,
-        "transactionIndex": 0,
-        "sig":"0x291d932e55162407eb01915923d68cf78df4815a25fc6033488b644bda44b02251123feac3a3c56a399a2b32331599fd50b7a39ec2c1a2325e37f383c6aeedc301"
-    },
-    "id": null,
-}
-```
-
 [Back to **List of methods**](#list-of-methods)
 
 ## chain_getAssetSchemeByTracker

--- a/spec/JSON-RPC.md
+++ b/spec/JSON-RPC.md
@@ -287,7 +287,6 @@ When `Transaction` is included in any response, there will be an additional fiel
 ***
  * [mempool_sendSignedTransaction](#mempool_sendsignedtransaction)
  * [mempool_getErrorHint](#mempool_geterrorhint)
- * [mempool_getTransactionResultsByTracker](#mempool_getTransactionResultsByTracker)
  * [mempool_getPendingTransactions](#mempool_getpendingtransactions)
  * [mempool_getPendingTransactionsCount](#mempool_getpendingtransactionscount)
  * [mempool_getBannedAccounts](#mempool_getbannedaccounts)
@@ -1562,36 +1561,6 @@ Errors: `Invalid Params`
 {
   "jsonrpc":"2.0",
   "result":"Text verification has failed: Invalid Signature",
-  "id":null
-}
-```
-
-[Back to **List of methods**](#list-of-methods)
-
-## mempool_getTransactionResultsByTracker
-Gets transaction results with the given tracker.
-
-### Params
- 1. tracker - `H256`
-
-### Returns
-`boolean[]`
-
-Errors: `Invalid Params`
-
-### Request Example
-```
-  curl \
-    -H 'Content-Type: application/json' \
-    -d '{"jsonrpc": "2.0", "method": "mempool_getTransactionResultsByTracker", "params": ["0x24df02abcd4e984e90253dc344e89b8431bbb319c66643bfef566dfdf46ec6bc"], "id": null}' \
-    localhost:8080
-```
-
-### Response Example
-```
-{
-  "jsonrpc":"2.0",
-  "result": [false, true],
   "id":null
 }
 ```


### PR DESCRIPTION
This PR will remove tracker from transaction invoice and body db.
I didn't remove tracker entirely, because currently `ShardState` makes use of it.
Since shard will be removed, eventually tracker will be removed as well.
Remaining work should be done after `ShardState` is removed.