### PR TITLE
Resolve `UnhandledRejectionWarning` in e2e tests

### DIFF
--- a/test/src/e2e/changeParams.test.ts
+++ b/test/src/e2e/changeParams.test.ts
@@ -123,7 +123,8 @@ describe("ChangeParams", function() {
             ).be.true;
         }
         try {
-            await expect(node.sendPayTx({ fee: 10 }));
+            await node.sendPayTx({ fee: 10 });
+            expect.fail();
         } catch (e) {
             expect(e.toString()).is.include(
                 ERROR.ACTION_DATA_HANDLER_NOT_FOUND


### PR DESCRIPTION
### Problem

Some e2e tests are emitting `UnhandledPromiseRejectionWarning`. When we run the tests, we can see the following warning:
```
ChangeParams
    ✓ change (38ms)
(node:13789) UnhandledPromiseRejectionWarning: Error: CodeChain(3) process state is invalid: {
    "state": "stopping"
}
    at CodeChain.get testFramework [as testFramework] (/home/spkim2/foundry/test/src/helper/spawn.ts:100:19)
    at CodeChain.createPayTx (/home/spkim2/foundry/test/src/helper/spawn.ts:547:21)
    at CodeChain.sendPayTx (/home/spkim2/foundry/test/src/helper/spawn.ts:572:25)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
(node:13789) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:13789) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```



---
### Cause

This warning message has occurred since [Remove all sdk functtions from e2e tests](https://github.com/CodeChain-io/foundry/pull/189/commits/9cfe07c610730ad660f1fb65a719caec4fc5746a) was merged. I suspect a small mistake was made in this work of modifying the test code. Fundamentally, the reason for `UnhandledPromiseRejectionWarning` occurring is related to the process state below.
```
(node:13789) UnhandledPromiseRejectionWarning: Error: CodeChain(3) process state is invalid: {
    "state": "stopping"
}
```
In this test, the process state of the node must be `running` state. Here the node is the object of class `CodeChain`. If the process state is `stopping` or others, `Error: CodeChain(3) process state is invalid:` occurs. Some logic was misimplemented, so I assumed the state has a `stopping` state. 



I found the problem part, which is as follows:
```typescript
        try {
            await expect(node.sendPayTx({ fee: 10 }));
        } catch (e) {
            expect(e.toString()).is.include(
                ERROR.ACTION_DATA_HANDLER_NOT_FOUND
            );
        }
```
In normal case, `sendPayTx()` should be executed and `createPayTx()` in `sendPayTx()` sholud be executed too. In this case, however, `sendPayTx()` does not work because it is wrapped by `expect()`. Then, another code outside the try block is executed without `sendPayTx()` and `createPayTx()` running. Interestingly, the test ends with a message that the test is completed. After the test, `sendPayTx()` and `createPayTx()` is run and the node with the `stopping` state fails in the following process on `createPayTx()`:
```typescript
    public get testFramework(): SDK {
        if (this.process.state === "running") {
            return this._testFramework;
        } else {
            throw new ProcessStateError(this.id, this.process);
        }
    }
```
Since the node is not `running` state, an error occurs with `UnhandledPromiseRejectionWarning` during this process.



---
### Solution

If the problem is modified as follows, no further errors will occur.
```typescript
        try {
            await node.sendPayTx({ fee: 10 });
            expect.fail();
        } catch (e) {
            expect(e.toString()).is.include(
                ERROR.ACTION_DATA_HANDLER_NOT_FOUND
            );
        }
```
resolved #276 