### PR TITLE
Implement MemPoolAccess as a part of the context

### DIFF
--- a/coordinator/src/context.rs
+++ b/coordinator/src/context.rs
@@ -14,13 +14,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use crate::Transaction;
 pub use ctypes::StorageId;
 
-/// A `Context` provides the interface against the system services such as DB access,
-pub trait Context: SubStorageAccess {}
+/// A `Context` provides the interface against the system services such as moulde substorage access,
+/// mempool access
+pub trait Context: SubStorageAccess + MemPoolAccess {}
 
 pub type Key = dyn AsRef<[u8]>;
 pub type Value = Vec<u8>;
+
 pub trait SubStorageAccess {
     fn get(&self, storage_id: StorageId, key: &Key) -> Option<Value>;
     fn set(&mut self, storage_id: StorageId, key: &Key, value: Value);
@@ -33,4 +36,8 @@ pub trait SubStorageAccess {
     fn revert_to_the_checkpoint(&mut self);
     /// Merge last checkpoint with the previous
     fn discard_checkpoint(&mut self);
+}
+
+pub trait MemPoolAccess {
+    fn inject_transactions(&self, txs: Vec<Transaction>) -> Vec<Result<(), String>>;
 }

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -35,6 +35,7 @@ use ccrypto::BLAKE_NULL_RLP;
 use cdb::{new_journaldb, Algorithm, AsHashDB};
 use cio::IoChannel;
 use ckey::{Address, NetworkId, PlatformAddress};
+use coordinator::context::MemPoolAccess;
 use coordinator::traits::{BlockExecutor, Initializer};
 use coordinator::types::{Event, Transaction};
 use cstate::{Metadata, MetadataAddress, NextValidatorSet, StateDB, StateWithCache, TopLevelState, TopStateView};
@@ -536,6 +537,12 @@ impl ImportBlock for Client {
             }
             Err(err) => unreachable!("Reseal min timer should not fail but failed with {:?}", err),
         }
+    }
+}
+
+impl MemPoolAccess for Client {
+    fn inject_transactions(&self, transactions: Vec<Transaction>) -> Vec<Result<(), String>> {
+        transactions.into_iter().map(|tx| self.queue_own_transaction(tx).map_err(|e| format!("{}", e))).collect()
     }
 }
 


### PR DESCRIPTION
~~It can only be merged after @Byeongjee 's branch `byeongjee/implement.validator.interface.call` is landed.
This pr includes only one commit `80bdd5`~~