### PR TITLE
Remove genesis_common_params from machine

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -548,7 +548,11 @@ impl BlockChainClient for Client {
     }
 
     fn ready_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions {
-        self.importer.miner.ready_transactions(range)
+        let size_limit = self
+            .common_params(BlockId::Latest)
+            .expect("Common params of the latest block always exists")
+            .max_body_size();
+        self.importer.miner.ready_transactions(size_limit, range)
     }
 
     fn count_pending_transactions(&self, range: Range<u64>) -> usize {

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -513,7 +513,11 @@ impl BlockChainClient for TestBlockChainClient {
     }
 
     fn ready_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions {
-        self.miner.ready_transactions(range)
+        let size_limit = self
+            .common_params(BlockId::Latest)
+            .expect("Common params of the latest block always exists")
+            .max_body_size();
+        self.miner.ready_transactions(size_limit, range)
     }
 
     fn future_pending_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions {
@@ -590,11 +594,11 @@ impl super::EngineClient for TestBlockChainClient {
 
 impl EngineInfo for TestBlockChainClient {
     fn network_id(&self) -> NetworkId {
-        self.scheme.engine.machine().genesis_common_params().network_id()
+        self.scheme.genesis_params().network_id()
     }
 
     fn common_params(&self, _block_id: BlockId) -> Option<CommonParams> {
-        Some(*self.scheme.engine.machine().genesis_common_params())
+        Some(self.scheme.genesis_params())
     }
 
     fn metadata_seq(&self, _block_id: BlockId) -> Option<u64> {

--- a/core/src/codechain_machine.rs
+++ b/core/src/codechain_machine.rs
@@ -21,25 +21,13 @@ use crate::error::Error;
 use crate::transaction::{UnverifiedTransaction, VerifiedTransaction};
 use ckey::Address;
 use cstate::{StateError, TopState, TopStateView};
-use ctypes::{CommonParams, Header};
+use ctypes::Header;
 use std::convert::TryInto;
 
-pub struct CodeChainMachine {
-    params: CommonParams,
-}
+#[derive(Default)]
+pub struct CodeChainMachine {}
 
 impl CodeChainMachine {
-    pub fn new(params: CommonParams) -> Self {
-        CodeChainMachine {
-            params,
-        }
-    }
-
-    /// Get the general parameters of the chain.
-    pub fn genesis_common_params(&self) -> &CommonParams {
-        &self.params
-    }
-
     /// Verify a particular transaction's seal is valid.
     pub fn verify_transaction_seal(p: UnverifiedTransaction, _header: &Header) -> Result<VerifiedTransaction, Error> {
         Ok(p.try_into()?)

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -103,7 +103,7 @@ pub trait MinerService: Send + Sync {
     ) -> Result<(TxHash, u64), Error>;
 
     /// Get a list of all pending transactions in the mem pool.
-    fn ready_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions;
+    fn ready_transactions(&self, size_limit: usize, range: Range<u64>) -> PendingVerifiedTransactions;
 
     /// Get list of all future transaction in the mem pool.
     fn future_pending_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions;


### PR DESCRIPTION
Since CommonParams is saved to and restored from the state, the machine does not need to hold it.
FIXME in ready_transactions is resolved accordingly.

Now CodeChainMachine has no field, so I'm not sure if we further refactor this or not.