### PR TITLE
Disconnect a socket If Foundry meets EOF while reading the socket

### DIFF
--- a/network/src/p2p/handler.rs
+++ b/network/src/p2p/handler.rs
@@ -941,32 +941,56 @@ impl IoHandler<Message> for Handler {
         Ok(())
     }
 
-    fn stream_writable(&self, _io: &IoContext<Message>, stream: StreamToken) -> IoHandlerResult<()> {
+    fn stream_writable(&self, io: &IoContext<Message>, stream: StreamToken) -> IoHandlerResult<()> {
         match stream {
             FIRST_INBOUND..=LAST_INBOUND => {
                 if let Some(con) = self.inbound_connections.write().get_mut(&stream) {
-                    con.flush()?;
+                    let flush_result = con.flush();
+                    if let Err(P2PConnectionError::IoError(io_error)) = &flush_result {
+                        if io_error.kind() == std::io::ErrorKind::BrokenPipe {
+                            io.deregister_stream(stream);
+                        }
+                    }
+                    flush_result?;
                 } else {
                     cdebug!(NETWORK, "Invalid inbound token({}) on write", stream);
                 }
             }
             FIRST_OUTBOUND..=LAST_OUTBOUND => {
                 if let Some(con) = self.outbound_connections.write().get_mut(&stream) {
-                    con.flush()?;
+                    let flush_result = con.flush();
+                    if let Err(P2PConnectionError::IoError(io_error)) = &flush_result {
+                        if io_error.kind() == std::io::ErrorKind::BrokenPipe {
+                            io.deregister_stream(stream);
+                        }
+                    }
+                    flush_result?;
                 } else {
                     cdebug!(NETWORK, "Invalid outbound token({}) on write", stream);
                 }
             }
             FIRST_INCOMING..=LAST_INCOMING => {
                 if let Some(con) = self.incoming_connections.write().get_mut(&stream) {
-                    con.flush()?;
+                    let flush_result = con.flush();
+                    if let Err(P2PConnectionError::IoError(io_error)) = &flush_result {
+                        if io_error.kind() == std::io::ErrorKind::BrokenPipe {
+                            io.deregister_stream(stream);
+                        }
+                    }
+                    flush_result?;
                 } else {
                     cdebug!(NETWORK, "Invalid incoming token({}) on write", stream);
                 }
             }
             FIRST_OUTGOING..=LAST_OUTGOING => {
                 if let Some(con) = self.outgoing_connections.write().get_mut(&stream) {
-                    con.flush()?;
+                    let flush_result = con.flush();
+                    if let Err(P2PConnectionError::IoError(io_error)) = &flush_result {
+                        if io_error.kind() == std::io::ErrorKind::BrokenPipe {
+                            io.deregister_stream(stream);
+                        }
+                    }
+                    flush_result?;
                 } else {
                     cdebug!(NETWORK, "Invalid outgoing token({}) on write", stream);
                 }


### PR DESCRIPTION
This PR fixes https://github.com/CodeChain-io/foundry/issues/308

There are a few things to do more.

1. Should we catch the error in the places?
2. What should we do when we met other IO errors? Should we disconnect the socket?
3. What happens if we write bytes to a disconnected socket? (This PR only checks the `read` call).