### PR TITLE
Remove block_fee method

### DIFF
--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -200,10 +200,6 @@ pub trait ConsensusEngine: Sync + Send {
 
     fn register_time_gap_config_to_worker(&self, _time_gap_params: TimeGapParams) {}
 
-    fn block_fee(&self, transactions: Box<dyn Iterator<Item = UnverifiedTransaction>>) -> u64 {
-        transactions.map(|tx| tx.transaction().fee).sum()
-    }
-
     fn register_chain_notify(&self, _: &Client) {}
 
     fn complete_register(&self) {}


### PR DESCRIPTION
It is not used.
Furthermore, the concept of block fee will be removed from the host side at all, eventually.