### PR TITLE
Rename Builder::create to Builder::new

### DIFF
--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -54,9 +54,9 @@ pub struct Builder<C: context::Context> {
 }
 
 impl<C: context::Context> Builder<C> {
-    fn create<CTX: context::Context>(ctx: CTX) -> Builder<CTX> {
+    fn new(context: C) -> Self {
         Builder {
-            context: ctx,
+            context,
         }
     }
 


### PR DESCRIPTION
The function doesn't need a new type parameter.