### PR TITLE
Remove unnecessary initialization of genesis header extra data

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -98,7 +98,6 @@ impl Client {
 
         let gb = scheme.genesis_block();
         let chain = BlockChain::new(&gb, db.clone());
-        scheme.check_genesis_common_params(&chain)?;
 
         let engine = scheme.engine.clone();
 

--- a/core/src/scheme/scheme.rs
+++ b/core/src/scheme/scheme.rs
@@ -17,10 +17,9 @@
 use super::pod_state::PodAccounts;
 use super::seal::Generic as GenericSeal;
 use super::Genesis;
-use crate::blockchain::HeaderProvider;
 use crate::consensus::{CodeChainEngine, NullEngine, Solo, Tendermint};
 use crate::error::{Error, SchemeError};
-use ccrypto::{blake256, BLAKE_NULL_RLP};
+use ccrypto::BLAKE_NULL_RLP;
 use cdb::{AsHashDB, HashDB};
 use ckey::Address;
 use cstate::{Metadata, MetadataAddress, Shard, ShardAddress, StateDB, StateResult};
@@ -169,19 +168,6 @@ impl Scheme {
         Ok(self.initialize_state(db, self.genesis_params())?)
     }
 
-    pub fn check_genesis_common_params<HP: HeaderProvider>(&self, chain: &HP) -> Result<(), Error> {
-        let genesis_header = self.genesis_header();
-        let genesis_header_hash = genesis_header.hash();
-        let header =
-            chain.block_header(&genesis_header_hash).ok_or_else(|| Error::Scheme(SchemeError::InvalidCommonParams))?;
-        let extra_data = header.extra_data();
-        let common_params_hash = blake256(&self.genesis_params().rlp_bytes()).to_vec();
-        if extra_data != &common_params_hash {
-            return Err(Error::Scheme(SchemeError::InvalidCommonParams))
-        }
-        Ok(())
-    }
-
     /// Return the state root for the genesis state, memoising accordingly.
     pub fn state_root(&self) -> H256 {
         *self.state_root_memo.read()
@@ -225,7 +211,7 @@ impl Scheme {
         header.set_number(0);
         header.set_author(self.author);
         header.set_transactions_root(self.transactions_root);
-        header.set_extra_data(blake256(&self.genesis_params().rlp_bytes()).to_vec());
+        header.set_extra_data(self.extra_data.clone());
         header.set_state_root(self.state_root());
         header.set_next_validator_set_hash(BLAKE_NULL_RLP /* This will be calculated from state after https://github.com/CodeChain-io/foundry/issues/142*/);
         header.set_seal({
@@ -287,22 +273,4 @@ fn load_from(s: cjson::scheme::Scheme) -> Result<Scheme, Error> {
     }
 
     Ok(s)
-}
-
-#[cfg(test)]
-mod tests {
-    use ccrypto::Blake;
-
-    use super::*;
-
-    #[test]
-    fn extra_data_of_genesis_header_is_hash_of_common_params() {
-        let scheme = Scheme::new_test();
-        let common_params = scheme.genesis_params();
-        let hash_of_common_params = H256::blake(&common_params.rlp_bytes()).to_vec();
-
-        let genesis_header = scheme.genesis_header();
-        let result = genesis_header.extra_data();
-        assert_eq!(&hash_of_common_params, result);
-    }
 }


### PR DESCRIPTION
We gain nothing from initializing extra data of genesis header with
hash of common params, because the check will be done by the same node,
and it will always succeed.
We can just use extra_data written in scheme file.