### PR TITLE
Remove unnecessary serialize/deserialize while calling import_header

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -423,12 +423,12 @@ impl ImportBlock for Client {
         Ok(self.importer.header_queue.import(unverified)?)
     }
 
-    fn import_trusted_header(&self, header: &Header) -> Result<BlockHash, BlockImportError> {
+    fn import_trusted_header(&self, header: Header) -> Result<BlockHash, BlockImportError> {
         if self.block_chain().is_known_header(&header.hash()) {
             return Err(BlockImportError::Import(ImportError::AlreadyInChain))
         }
         let import_lock = self.importer.import_lock.lock();
-        self.importer.import_trusted_header(header, self, &import_lock);
+        self.importer.import_trusted_header(&header, self, &import_lock);
         Ok(header.hash())
     }
 

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -416,12 +416,9 @@ impl ImportBlock for Client {
         Ok(self.importer.block_queue.import(unverified)?)
     }
 
-    fn import_header(&self, bytes: Bytes) -> Result<BlockHash, BlockImportError> {
-        let unverified = encoded::Header::new(bytes).decode();
-        {
-            if self.block_chain().is_known_header(&unverified.hash()) {
-                return Err(BlockImportError::Import(ImportError::AlreadyInChain))
-            }
+    fn import_header(&self, unverified: Header) -> Result<BlockHash, BlockImportError> {
+        if self.block_chain().is_known_header(&unverified.hash()) {
+            return Err(BlockImportError::Import(ImportError::AlreadyInChain))
         }
         Ok(self.importer.header_queue.import(unverified)?)
     }

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -163,7 +163,7 @@ pub trait ImportBlock {
 
     /// Import a trusted header into the blockchain
     /// Trusted header doesn't go through any verifications and doesn't update the best header
-    fn import_trusted_header(&self, header: &Header) -> Result<BlockHash, BlockImportError>;
+    fn import_trusted_header(&self, header: Header) -> Result<BlockHash, BlockImportError>;
 
     /// Import a trusted block into the blockchain
     /// Trusted block doesn't go through any verifications and doesn't update the best block

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -159,7 +159,7 @@ pub trait ImportBlock {
     fn import_block(&self, bytes: Bytes) -> Result<BlockHash, BlockImportError>;
 
     /// Import a header into the blockchain
-    fn import_header(&self, bytes: Bytes) -> Result<BlockHash, BlockImportError>;
+    fn import_header(&self, header: Header) -> Result<BlockHash, BlockImportError>;
 
     /// Import a trusted header into the blockchain
     /// Trusted header doesn't go through any verifications and doesn't update the best header

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -458,7 +458,7 @@ impl ImportBlock for TestBlockChainClient {
         Ok(h)
     }
 
-    fn import_header(&self, _bytes: Bytes) -> Result<BlockHash, BlockImportError> {
+    fn import_header(&self, _bytes: Header) -> Result<BlockHash, BlockImportError> {
         unimplemented!()
     }
 

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -462,7 +462,7 @@ impl ImportBlock for TestBlockChainClient {
         unimplemented!()
     }
 
-    fn import_trusted_header(&self, _header: &Header) -> Result<BlockHash, BlockImportError> {
+    fn import_trusted_header(&self, _header: Header) -> Result<BlockHash, BlockImportError> {
         unimplemented!()
     }
 

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -985,7 +985,7 @@ impl Extension {
 
                 for header in completed {
                     let hash = header.hash();
-                    match self.client.import_header(header.rlp_bytes()) {
+                    match self.client.import_header(header) {
                         Err(BlockImportError::Import(ImportError::AlreadyInChain)) => exists.push(hash),
                         Err(BlockImportError::Import(ImportError::AlreadyQueued)) => queued.push(hash),
                         // FIXME: handle import errors


### PR DESCRIPTION
@sgkim126 I changed import_trusted_header to receive `Header` instead of `&Header`. When importing a header, I feel moving a header is more natural than borrowing the header. However, I'm not confident. Do you have any idea?