### PR TITLE
Revise module protocols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,10 +550,11 @@ dependencies = [
 name = "codechain-module"
 version = "0.1.0"
 dependencies = [
- "crossbeam-channel 0.4.0",
+ "intertrait",
  "linkme",
  "once_cell",
  "primitives",
+ "serde",
  "thiserror",
 ]
 
@@ -777,7 +778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 dependencies = [
  "cfg-if",
- "crossbeam-channel 0.4.0",
+ "crossbeam-channel 0.4.2",
  "crossbeam-deque 0.7.3",
  "crossbeam-epoch 0.8.2",
  "crossbeam-queue",
@@ -796,11 +797,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 dependencies = [
  "crossbeam-utils 0.7.0",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -1505,6 +1507,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141340095b15ed7491bd3d4ced9d20cebfb826174b6bb03386381f62b01e3d77"
 
 [[package]]
+name = "intertrait"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034463dcfb688db21fdecb735a49a5f1ee500f025d44cd8f0b246f94cf32022"
+dependencies = [
+ "intertrait-macros",
+ "linkme",
+ "once_cell",
+]
+
+[[package]]
+name = "intertrait-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183aab39cf5e4b02d7526b770e35fd15f5f55bfd98a5370cb095800cb774998a"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn 1.0.17",
+ "uuid 0.8.1",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,7 +1563,7 @@ source = "git+https://github.com/paritytech/jsonrpc.git?tag=v14.0.3#2135c25df577
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -1755,21 +1780,21 @@ checksum = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 
 [[package]]
 name = "linkme"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a6e1cef9c14d507905870766a37cacdfae0fcc624c0b816436cbcd6847ac36"
+checksum = "79129206039467e7c6183fb36e8988eefa4c31e9c0aab171d0e2e53b655a4a8c"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c30526fa88b1827f5b54a1add45a9de867088ca2aceda9fda9a02d86c2a01b"
+checksum = "823073443c38057a4ee33af337e6796619c5ae0e298c29112d2ef85bad560663"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -1989,7 +2014,7 @@ name = "module-macros"
 version = "0.1.0"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -2449,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2 1.0.10",
 ]
@@ -2668,7 +2693,7 @@ dependencies = [
  "tokio 0.1.17",
  "tokio-io",
  "url 1.7.2",
- "uuid",
+ "uuid 0.7.4",
 ]
 
 [[package]]
@@ -2881,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.101"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
+checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
 
 [[package]]
 name = "serde_cbor"
@@ -3136,7 +3161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.2",
+ "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
 
@@ -3232,21 +3257,21 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee14bf8e6767ab4c687c9e8bc003879e042a96fd67a3ba5934eadb6536bef4db"
+checksum = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
+checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -3416,7 +3441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.10",
- "quote 1.0.2",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -3686,6 +3711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 dependencies = [
  "rand 0.6.1",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand 0.7.2",
 ]
 
 [[package]]

--- a/module/Cargo.toml
+++ b/module/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
-thiserror = "1.0.11"
-linkme = "0.1.6"
-crossbeam-channel = "0.4.0"
+thiserror = "1.0.15"
+linkme = "0.2.1"
+crossbeam-channel = "0.4.2"
 once_cell = "1.3.1"
+serde = "1.0.105"

--- a/module/Cargo.toml
+++ b/module/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
 thiserror = "1.0.15"
 linkme = "0.2.1"
-crossbeam-channel = "0.4.2"
 once_cell = "1.3.1"
 serde = "1.0.105"
+intertrait = "0.1.1"

--- a/module/src/link.rs
+++ b/module/src/link.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crossbeam_channel::{Receiver, Sender};
+use intertrait::CastFrom;
 use linkme::distributed_slice;
 use once_cell::sync;
 use thiserror::Error;
@@ -13,12 +13,12 @@ type Result<T> = std::result::Result<T, Error>;
 ///
 /// [`Linker`]: ./trait.Linker.html
 #[distributed_slice]
-static LINKER_CTORS: [fn() -> Arc<dyn Linker>] = [..];
+pub static LINKERS: [fn() -> Arc<dyn Linker>] = [..];
 
 /// Returns a `Linker` with the given `id`.
 pub fn linker(id: &str) -> Option<Arc<dyn Linker>> {
     static MAP: sync::Lazy<HashMap<&'static str, Arc<dyn Linker>>> = sync::Lazy::new(|| {
-        LINKER_CTORS
+        LINKERS
             .iter()
             .map(|new| {
                 let linker = new();
@@ -65,28 +65,49 @@ pub trait Linkable: Send + Sync {
 /// [`Linkable`]: ./trait.Linkable.html
 /// [`send`]: ./trait.Port.html#tymnethod.send
 /// [`receive`]: ./trait.Port.html#tymnethod.receive
-pub trait Port: Any + 'static {
-    /// Sets to send a list of handles to the other end on link.
-    ///
-    /// `desc` is encoded in `CBOR`.
-    fn send(&mut self, desc: &[u8]) -> &mut dyn Port;
+pub trait Port: CastFrom {
+    /// Sets to send a list of handles represented by the `ids` to the other end on link
+    /// creation. The `ids` are indices into a list of service objects created when the module
+    /// owning this port is loaded into a sandbox.CBOR map fed
+    /// to the constructor function.
+    fn export(&mut self, ids: &[usize]) -> &mut dyn Port;
 
     /// Sets to which slots the handles received from the other end are to be assigned.
     ///
     /// This way, a module can't assign to an arbitrary slot in the other end.
     /// Only to the slots set by the host.
-    fn receive(&mut self, slots: &[&str]) -> &mut dyn Port;
+    fn import(&mut self, slots: &[&str]) -> &mut dyn Port;
 
-    /// Sets the common `Sender` and `Receiver` to link two `BasePort`s.
+    /// Returns the [`Receiver`] for placing messages into the [`Linkable`] this `Port` is
+    /// created from. This method is used to implement the base link, which is required
+    /// for the minimum interoperability among [`Linkable`]s.
     ///
-    /// This method is to support the base link, which is required for the minimum
-    /// interoperability among [`Linkable`]s. Upon a call to this method, `Port` needs
-    /// to send and receive handles as configured with [`send`] and [`receive`].
+    /// [`Receiver`]: ./trait.Receiver.html
+    /// [`Linkable`]: ./trait.Linkable.html
+    fn receiver(&self) -> Arc<dyn Receiver>;
+
+    /// Links with another [`Linkable`] by passing in a [`Receiver`] taken from the [`Linkable`]
+    /// in the opposite side. This method is to support the base link, which is required
+    /// for the minimum interoperability among [`Linkable`]s. Upon a call to this method,
+    /// `Port`s need to send and receive handles as configured with [`export`] and [`import`].
     ///
     /// [`Linkable`]: ./trait.Linkable.html
-    /// [`send`]: #tymethod.send
-    /// [`receive`]: #tymethod.receive
-    fn link(&mut self, sender: Sender<Box<dyn AsRef<[u8]>>>, receiver: Receiver<Box<dyn AsRef<[u8]>>>);
+    /// [`export`]: #tymethod.export
+    /// [`import`]: #tymethod.import
+    fn link(&mut self, receiver: Arc<dyn Receiver>);
+}
+
+/// An endpoint implemented by a [`Linkable`] for receiving incoming calls
+/// from another [`Linkable`].
+///
+/// [`Linkable`]: ./trait.Linkable.html
+pub trait Receiver {
+    /// Places the given message (`[u8]`) and returns immediately.
+    /// The `message` is typed `Box<dyn AsRef<[u8]>>` to allow for zero copy sending
+    /// as much as possible. The intention is to wrap various types as they are if they
+    /// can be converted into a `&[u8]` to pass into this method. The `Box` is dropped
+    /// when done with the data, and the underlying data will also be dropped then.
+    fn receive(message: Box<dyn AsRef<[u8]>>);
 }
 
 #[derive(Debug, Error)]

--- a/module/src/sandbox.rs
+++ b/module/src/sandbox.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::path::Path;
 use std::sync::Arc;
@@ -6,11 +7,26 @@ use linkme::distributed_slice;
 use thiserror::Error;
 
 use crate::link::Linkable;
+use once_cell::sync;
 
 type Result<'a, T> = std::result::Result<T, Error<'a>>;
 
 #[distributed_slice]
 pub static SANDBOXERS: [fn() -> Arc<dyn Sandboxer>] = [..];
+
+/// Returns a `Sandboxer` with the given `id`.
+pub fn sandboxer(id: &str) -> Option<Arc<dyn Sandboxer>> {
+    static MAP: sync::Lazy<HashMap<&'static str, Arc<dyn Sandboxer>>> = sync::Lazy::new(|| {
+        SANDBOXERS
+            .iter()
+            .map(|new| {
+                let sandboxer = new();
+                (sandboxer.id(), sandboxer)
+            })
+            .collect()
+    });
+    MAP.get(id).map(Arc::clone)
+}
 
 /// An entity that can sandbox modules of types it supports.
 ///
@@ -22,13 +38,22 @@ pub trait Sandboxer {
     /// Returns a list of module types that can be loaded by this `Sandboxer`.
     fn supported_module_types(&self) -> &'static [&'static str];
 
-    /// Loads the module identified by the given `hash` into a [`Sandbox`].
+    /// Loads the module in the given `path` into a [`Sandbox`] and pass the given
+    /// `init` and `exports` to the module for initialization.
     ///
     /// The corresponding module must have been imported into the module repository
-    /// configured for the current Foundry host.
+    /// configured for the current Foundry host. That is why this method accepts a `path`
+    /// to identify a module.
+    ///
+    /// The `init` serves as configuration parameters for the module-wide initialization,
+    /// and must be CBOR encoded. The `exports` instruct how to instantiate an ordered list
+    /// of service objects to be exported via links. Each item in the `exports` designates
+    /// a call on a module's constructor function, where the first element is name
+    /// of a constructor function, and the second element is arguments to the constructor
+    /// function encoded in CBOR.
     ///
     /// [`Sandbox`]: ./trait.Sandbox.html
-    fn load(&self, hash: &dyn AsRef<Path>) -> Result<Arc<dyn Sandbox>>;
+    fn load(&self, path: &dyn AsRef<Path>, init: &[u8], exports: &[(&str, &[u8])]) -> Result<Arc<dyn Sandbox>>;
 }
 
 /// A sandbox instance hosting an instantiated module.
@@ -39,18 +64,18 @@ pub trait Sandbox: Linkable {
 
 #[derive(Debug, Error)]
 pub enum Error<'a> {
-    /// The module identified by the given `H256` is not in the module repository.
+    /// The module identified by the given `path` is not in the module repository.
     #[error("Could not find the specified module: {path:?}")]
     ModuleNotFound {
         path: &'a Path,
     },
 
-    /// The module identified by the given `H256` is not supported by the provider.
+    /// The module identified by the given `path` is not supported by the provider.
     #[error("The module is not supported: type '{ty:?}' at '{path:?}'")]
     UnsupportedModuleType {
         /// The identifier of the subject module.
         path: &'a Path,
-        /// The type of the subject module module.
+        /// The type of the subject module.
         ty: String,
     },
 }


### PR DESCRIPTION
This is what @junha1 will implement.

* Removed dependency on crossbeam in favor of simple Receiver trait. Messages are anyway likely queued elsewhere to send to a module, so we don't need to buffer them separately with crossbeam channels.
* Service objects are created at module creation time, and handles of some of them are exchanged at link creation time.
