### PR TITLE
Temporarily disable Travis CI in mold

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  except:
+    - mold
+
 language: rust
 rust:
   - 1.42.0


### PR DESCRIPTION
I'm not quite familiar with Travis CI configuration.
Please tell me if this is insufficient.
