### PR TITLE
Modify BlockExecutor trait methods' return types

### DIFF
--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -48,7 +48,7 @@ impl BlockExecutor for Coordinator {
         unimplemented!()
     }
 
-    fn close_block(&self, context: &mut dyn StorageAccess) -> BlockOutcome {
+    fn close_block(&self, context: &mut dyn StorageAccess) -> Result<BlockOutcome, CloseBlockError> {
         unimplemented!()
     }
 }

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -44,7 +44,11 @@ impl BlockExecutor for Coordinator {
         unimplemented!()
     }
 
-    fn execute_transactions(&self, context: &mut dyn StorageAccess, transactions: &[Transaction]) {
+    fn execute_transactions(
+        &self,
+        context: &mut dyn StorageAccess,
+        transactions: &[Transaction],
+    ) -> Result<Vec<TransactionExecutionOutcome>, ExecuteTransactionError> {
         unimplemented!()
     }
 

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -40,7 +40,12 @@ impl Initializer for Coordinator {
 }
 
 impl BlockExecutor for Coordinator {
-    fn open_block(&self, context: &mut dyn StorageAccess, header: &Header, verified_crime: &[VerifiedCrime]) {
+    fn open_block(
+        &self,
+        context: &mut dyn StorageAccess,
+        header: &Header,
+        verified_crime: &[VerifiedCrime],
+    ) -> Result<(), HeaderError> {
         unimplemented!()
     }
 

--- a/coordinator/src/test_coordinator.rs
+++ b/coordinator/src/test_coordinator.rs
@@ -61,8 +61,8 @@ impl BlockExecutor for TestCoordinator {
         let is_success = self.body_size.load(Ordering::SeqCst) > self.consensus_params.max_body_size();
         BlockOutcome {
             is_success,
-            updated_validator_set: self.validator_set.clone(),
-            updated_consensus_params: self.consensus_params,
+            updated_validator_set: Some(self.validator_set.clone()),
+            updated_consensus_params: Some(self.consensus_params),
             transaction_results: (0..self.body_count.load(Ordering::SeqCst))
                 .map(|_| TransactionExecutionOutcome {
                     events: Vec::new(),

--- a/coordinator/src/test_coordinator.rs
+++ b/coordinator/src/test_coordinator.rs
@@ -46,9 +46,15 @@ impl Initializer for TestCoordinator {
 }
 
 impl BlockExecutor for TestCoordinator {
-    fn open_block(&self, _context: &mut dyn StorageAccess, _header: &Header, _verified_crime: &[VerifiedCrime]) {
+    fn open_block(
+        &self,
+        _context: &mut dyn StorageAccess,
+        _header: &Header,
+        _verified_crime: &[VerifiedCrime],
+    ) -> Result<(), HeaderError> {
         self.body_count.store(0, Ordering::SeqCst);
         self.body_size.store(0, Ordering::SeqCst);
+        Ok(())
     }
 
     fn execute_transactions(

--- a/coordinator/src/traits.rs
+++ b/coordinator/src/traits.rs
@@ -22,7 +22,12 @@ pub trait Initializer: Send + Sync {
     fn initialize_chain(&self, app_state: String) -> (CompactValidatorSet, ConsensusParams);
 }
 pub trait BlockExecutor: Send + Sync {
-    fn open_block(&self, context: &mut dyn StorageAccess, header: &Header, verified_crime: &[VerifiedCrime]);
+    fn open_block(
+        &self,
+        context: &mut dyn StorageAccess,
+        header: &Header,
+        verified_crime: &[VerifiedCrime],
+    ) -> Result<(), HeaderError>;
     fn execute_transactions(
         &self,
         context: &mut dyn StorageAccess,

--- a/coordinator/src/traits.rs
+++ b/coordinator/src/traits.rs
@@ -23,7 +23,11 @@ pub trait Initializer: Send + Sync {
 }
 pub trait BlockExecutor: Send + Sync {
     fn open_block(&self, context: &mut dyn StorageAccess, header: &Header, verified_crime: &[VerifiedCrime]);
-    fn execute_transactions(&self, context: &mut dyn StorageAccess, transactions: &[Transaction]);
+    fn execute_transactions(
+        &self,
+        context: &mut dyn StorageAccess,
+        transactions: &[Transaction],
+    ) -> Result<Vec<TransactionExecutionOutcome>, ()>;
     fn close_block(&self, context: &mut dyn StorageAccess) -> Result<BlockOutcome, CloseBlockError>;
 }
 

--- a/coordinator/src/traits.rs
+++ b/coordinator/src/traits.rs
@@ -24,7 +24,7 @@ pub trait Initializer: Send + Sync {
 pub trait BlockExecutor: Send + Sync {
     fn open_block(&self, context: &mut dyn StorageAccess, header: &Header, verified_crime: &[VerifiedCrime]);
     fn execute_transactions(&self, context: &mut dyn StorageAccess, transactions: &[Transaction]);
-    fn close_block(&self, context: &mut dyn StorageAccess) -> BlockOutcome;
+    fn close_block(&self, context: &mut dyn StorageAccess) -> Result<BlockOutcome, CloseBlockError>;
 }
 
 pub trait TxFilter: Send + Sync {

--- a/coordinator/src/types.rs
+++ b/coordinator/src/types.rs
@@ -256,12 +256,12 @@ pub struct TransactionExecutionOutcome {
     pub events: Vec<Event>,
 }
 
+pub type ExecuteTransactionError = ();
 pub type CloseBlockError = String;
 
 pub struct BlockOutcome {
     pub updated_validator_set: Option<CompactValidatorSet>,
     pub updated_consensus_params: Option<ConsensusParams>,
-    pub transaction_results: Vec<TransactionExecutionOutcome>,
     pub events: Vec<Event>,
 }
 

--- a/coordinator/src/types.rs
+++ b/coordinator/src/types.rs
@@ -256,8 +256,9 @@ pub struct TransactionExecutionOutcome {
     pub events: Vec<Event>,
 }
 
+pub type CloseBlockError = String;
+
 pub struct BlockOutcome {
-    pub is_success: bool,
     pub updated_validator_set: Option<CompactValidatorSet>,
     pub updated_consensus_params: Option<ConsensusParams>,
     pub transaction_results: Vec<TransactionExecutionOutcome>,

--- a/coordinator/src/types.rs
+++ b/coordinator/src/types.rs
@@ -258,8 +258,8 @@ pub struct TransactionExecutionOutcome {
 
 pub struct BlockOutcome {
     pub is_success: bool,
-    pub updated_validator_set: CompactValidatorSet,
-    pub updated_consensus_params: ConsensusParams,
+    pub updated_validator_set: Option<CompactValidatorSet>,
+    pub updated_consensus_params: Option<ConsensusParams>,
     pub transaction_results: Vec<TransactionExecutionOutcome>,
     pub events: Vec<Event>,
 }

--- a/coordinator/src/types.rs
+++ b/coordinator/src/types.rs
@@ -256,6 +256,7 @@ pub struct TransactionExecutionOutcome {
     pub events: Vec<Event>,
 }
 
+pub type HeaderError = String;
 pub type ExecuteTransactionError = ();
 pub type CloseBlockError = String;
 

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -175,11 +175,7 @@ impl<'x> OpenBlock<'x> {
 
     /// Turn this into a `ClosedBlock`.
     pub fn close(mut self, block_executor: &dyn BlockExecutor) -> Result<ClosedBlock, Error> {
-        let block_outcome = block_executor.close_block(self.state_mut());
-        if !block_outcome.is_success {
-            return Err(Error::Other("The application rejected the block".to_string()))
-        }
-
+        let block_outcome = block_executor.close_block(self.state_mut())?;
         // TODO: How to do this without copy?
         let mut tx_events: HashMap<TxHash, Vec<Event>> = HashMap::new();
         for (tx, result) in self.transactions().iter().zip(block_outcome.transaction_results.iter()) {

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -149,7 +149,7 @@ impl<'x> OpenBlock<'x> {
         Ok(r)
     }
 
-    pub fn open(&mut self, block_executor: &dyn BlockExecutor, evidences: Vec<Evidence>) {
+    pub fn open(&mut self, block_executor: &dyn BlockExecutor, evidences: Vec<Evidence>) -> Result<(), Error> {
         let pre_header = PreHeader::new(
             self.header().timestamp(),
             self.header().number(),
@@ -165,7 +165,7 @@ impl<'x> OpenBlock<'x> {
                 self.block.evidences.iter().map(Encodable::rlp_bytes),
             ));
         }
-        block_executor.open_block(self.state_mut(), &pre_header, &verified_crimes);
+        block_executor.open_block(self.state_mut(), &pre_header, &verified_crimes).map_err(From::from)
     }
 
     pub fn execute_transactions(
@@ -366,7 +366,7 @@ pub fn enact(
     b.populate_from(header);
     engine.on_open_block(b.inner_mut())?;
 
-    b.open(block_executor, evidences.to_vec());
+    b.open(block_executor, evidences.to_vec())?;
     b.execute_transactions(block_executor, transactions.to_vec())?;
     b.close(block_executor)
 }

--- a/core/src/block.rs
+++ b/core/src/block.rs
@@ -191,9 +191,7 @@ impl<'x> OpenBlock<'x> {
     pub fn close(mut self, block_executor: &dyn BlockExecutor) -> Result<ClosedBlock, Error> {
         let block_outcome = block_executor.close_block(self.state_mut())?;
 
-        let block_events = block_outcome.events.clone();
-        self.block.block_events = block_events;
-
+        self.block.block_events = block_outcome.events;
         let updated_validator_set = block_outcome.updated_validator_set;
         let next_validator_set_hash = match updated_validator_set {
             Some(ref set) => set.hash(),

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -167,8 +167,8 @@ pub trait ConsensusEngine: Sync + Send {
     fn on_close_block(
         &self,
         _block: &mut ExecutedBlock,
-        _updated_validator_set: CompactValidatorSet,
-        _updated_consensus_params: ConsensusParams,
+        _updated_validator_set: Option<CompactValidatorSet>,
+        _updated_consensus_params: Option<ConsensusParams>,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/core/src/consensus/solo/mod.rs
+++ b/core/src/consensus/solo/mod.rs
@@ -61,8 +61,8 @@ impl ConsensusEngine for Solo {
     fn on_close_block(
         &self,
         block: &mut ExecutedBlock,
-        _updated_validator_set: CompactValidatorSet,
-        _updated_consensus_params: ConsensusParams,
+        _updated_validator_set: Option<CompactValidatorSet>,
+        _updated_consensus_params: Option<ConsensusParams>,
     ) -> Result<(), Error> {
         let client = self.client().ok_or(EngineError::CannotOpenBlock)?;
 

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -114,15 +114,19 @@ impl ConsensusEngine for Tendermint {
     fn on_close_block(
         &self,
         block: &mut ExecutedBlock,
-        updated_validator_set: CompactValidatorSet,
-        updated_consensus_params: ConsensusParams,
+        updated_validator_set: Option<CompactValidatorSet>,
+        updated_consensus_params: Option<ConsensusParams>,
     ) -> Result<(), Error> {
         let state = block.state_mut();
 
-        let validators = NextValidatorSet::from_compact_validator_set(updated_validator_set);
-        validators.save_to_state(state)?;
+        if let Some(set) = updated_validator_set {
+            let validators = NextValidatorSet::from_compact_validator_set(set);
+            validators.save_to_state(state)?;
+        }
 
-        state.update_consensus_params(updated_consensus_params)?;
+        if let Some(params) = updated_consensus_params {
+            state.update_consensus_params(params)?;
+        }
         Ok(())
     }
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -19,6 +19,7 @@ use crate::consensus::EngineError;
 use cdb::DatabaseError;
 use cio::IoError;
 use ckey::{Address, Error as KeyError};
+use coordinator::types::CloseBlockError;
 use cstate::StateError;
 use ctypes::errors::{HistoryError, RuntimeError, SyntaxError};
 use ctypes::util::unexpected::{Mismatch, OutOfBounds};
@@ -299,5 +300,11 @@ impl From<DatabaseError> for Error {
 impl From<DecoderError> for Error {
     fn from(err: DecoderError) -> Error {
         Error::Rlp(err)
+    }
+}
+
+impl From<CloseBlockError> for Error {
+    fn from(err: CloseBlockError) -> Error {
+        Error::Other(err)
     }
 }

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -245,7 +245,7 @@ impl Miner {
 
         let block_executor = &*self.block_executor;
 
-        open_block.open(block_executor, evidences);
+        open_block.open(block_executor, evidences)?;
         open_block.execute_transactions(block_executor, transactions)?;
         let closed_block = open_block.close(block_executor)?;
         Ok(Some(closed_block))

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -246,7 +246,7 @@ impl Miner {
         let block_executor = &*self.block_executor;
 
         open_block.open(block_executor, evidences);
-        open_block.execute_transactions(block_executor, transactions);
+        open_block.execute_transactions(block_executor, transactions)?;
         let closed_block = open_block.close(block_executor)?;
         Ok(Some(closed_block))
     }


### PR DESCRIPTION
Now BlockOutcome contains a reason for a block rejection and
update_validator_set and updated_consensus_params are optional.
Also, execute_transactions returns execution outcome.