### PR TITLE
Add missed promiseExpect.checkfulfilled

### DIFF
--- a/test/src/e2e.long/bootstrap.test.ts
+++ b/test/src/e2e.long/bootstrap.test.ts
@@ -69,6 +69,7 @@ describe("bootstrap", function() {
 
         afterEach(async function() {
             this.timeout(5_000 + 3_000 * NUM_NODES);
+            promiseExpect.checkFulfilled();
 
             if (this.currentTest!.state === "failed") {
                 bootstrap.keepLogs();


### PR DESCRIPTION
We should call checkfulfilled to ensure the promise is called.