### PR TITLE
Change fetch_transactions_for_block interface

### DIFF
--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -77,7 +77,7 @@ impl TxFilter for Coordinator {
 
     fn filter_transactions<'a>(
         &self,
-        transactions: &'a [&'a TransactionWithMetadata],
+        transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
         memory_limit: Option<usize>,
         size_limit: Option<usize>,
     ) -> (Vec<&'a TransactionWithMetadata>, Vec<&'a TransactionWithMetadata>) {

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -57,6 +57,14 @@ impl BlockExecutor for Coordinator {
         unimplemented!()
     }
 
+    fn prepare_block<'a>(
+        &self,
+        context: &mut dyn StorageAccess,
+        transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
+    ) -> Vec<&'a Transaction> {
+        unimplemented!()
+    }
+
     fn close_block(&self, context: &mut dyn StorageAccess) -> Result<BlockOutcome, CloseBlockError> {
         unimplemented!()
     }
@@ -64,13 +72,6 @@ impl BlockExecutor for Coordinator {
 
 impl TxFilter for Coordinator {
     fn check_transaction(&self, transaction: &Transaction) -> Result<(), ErrorCode> {
-        unimplemented!()
-    }
-
-    fn fetch_transactions_for_block<'a>(
-        &self,
-        transactions: &'a [&'a TransactionWithMetadata],
-    ) -> Vec<TransactionWithGas<'a>> {
         unimplemented!()
     }
 

--- a/coordinator/src/test_coordinator.rs
+++ b/coordinator/src/test_coordinator.rs
@@ -105,7 +105,7 @@ impl TxFilter for TestCoordinator {
 
     fn filter_transactions<'a>(
         &self,
-        transactions: &'a [&'a TransactionWithMetadata],
+        transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
         memory_limit: Option<usize>,
         size_limit: Option<usize>,
     ) -> (Vec<&'a TransactionWithMetadata>, Vec<&'a TransactionWithMetadata>) {
@@ -113,8 +113,6 @@ impl TxFilter for TestCoordinator {
         let mut memory = 0;
         let mut size = 0;
         let low_priority = transactions
-            .to_vec()
-            .into_iter()
             .skip_while(|tx| {
                 memory += (*tx).size();
                 size += 1;

--- a/coordinator/src/test_coordinator.rs
+++ b/coordinator/src/test_coordinator.rs
@@ -72,6 +72,14 @@ impl BlockExecutor for TestCoordinator {
             .collect())
     }
 
+    fn prepare_block<'a>(
+        &self,
+        context: &mut dyn StorageAccess,
+        transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
+    ) -> Vec<&'a Transaction> {
+        transactions.map(|tx_with_metadata| &tx_with_metadata.tx).collect()
+    }
+
     fn close_block(&self, context: &mut dyn StorageAccess) -> Result<BlockOutcome, CloseBlockError> {
         if self.body_size.load(Ordering::SeqCst) > self.consensus_params.max_body_size() {
             Ok(BlockOutcome {
@@ -93,19 +101,6 @@ impl TxFilter for TestCoordinator {
         } else {
             Ok(())
         }
-    }
-
-    fn fetch_transactions_for_block<'a>(
-        &self,
-        transactions: &'a [&'a TransactionWithMetadata],
-    ) -> Vec<TransactionWithGas<'a>> {
-        transactions
-            .iter()
-            .map(|tx_with_metadata| TransactionWithGas {
-                tx_with_metadata,
-                gas: 0,
-            })
-            .collect()
     }
 
     fn filter_transactions<'a>(

--- a/coordinator/src/traits.rs
+++ b/coordinator/src/traits.rs
@@ -33,15 +33,16 @@ pub trait BlockExecutor: Send + Sync {
         context: &mut dyn StorageAccess,
         transactions: &[Transaction],
     ) -> Result<Vec<TransactionExecutionOutcome>, ()>;
+    fn prepare_block<'a>(
+        &self,
+        context: &mut dyn StorageAccess,
+        transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
+    ) -> Vec<&'a Transaction>;
     fn close_block(&self, context: &mut dyn StorageAccess) -> Result<BlockOutcome, CloseBlockError>;
 }
 
 pub trait TxFilter: Send + Sync {
     fn check_transaction(&self, transaction: &Transaction) -> Result<(), ErrorCode>;
-    fn fetch_transactions_for_block<'a>(
-        &self,
-        transactions: &'a [&'a TransactionWithMetadata],
-    ) -> Vec<TransactionWithGas<'a>>;
     fn filter_transactions<'a>(
         &self,
         transactions: &'a [&'a TransactionWithMetadata],

--- a/coordinator/src/traits.rs
+++ b/coordinator/src/traits.rs
@@ -45,7 +45,7 @@ pub trait TxFilter: Send + Sync {
     fn check_transaction(&self, transaction: &Transaction) -> Result<(), ErrorCode>;
     fn filter_transactions<'a>(
         &self,
-        transactions: &'a [&'a TransactionWithMetadata],
+        transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
         memory_limit: Option<usize>,
         size_limit: Option<usize>,
     ) -> (Vec<&'a TransactionWithMetadata>, Vec<&'a TransactionWithMetadata>);

--- a/coordinator/src/types.rs
+++ b/coordinator/src/types.rs
@@ -222,28 +222,6 @@ impl Decodable for TransactionWithMetadata {
     }
 }
 
-// TransactionWithGas will be returned by fetch_transactions_for_block
-pub struct TransactionWithGas<'a> {
-    pub tx_with_metadata: &'a TransactionWithMetadata,
-    pub gas: usize,
-}
-
-impl<'a> TransactionWithGas<'a> {
-    fn new(tx_with_metadata: &'a TransactionWithMetadata, gas: usize) -> Self {
-        Self {
-            tx_with_metadata,
-            gas,
-        }
-    }
-
-    pub fn size(&self) -> usize {
-        self.tx_with_metadata.size()
-    }
-
-    pub fn hash(&self) -> TxHash {
-        self.tx_with_metadata.hash()
-    }
-}
 pub enum VerifiedCrime {
     DoubleVote {
         height: u64,

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -319,7 +319,7 @@ impl TimeoutHandler for Client {
         match token {
             RESEAL_MIN_TIMER_TOKEN => {
                 // Checking self.pending_transactions() for efficiency
-                if !self.engine().engine_type().ignore_reseal_min_period() && !self.is_pending_queue_empty() {
+                if !self.engine().engine_type().ignore_reseal_min_period() && !self.is_mem_pool_empty() {
                     self.update_sealing(BlockId::Latest, false);
                 }
             }
@@ -580,10 +580,6 @@ impl BlockChainClient for Client {
         }
     }
 
-    fn delete_all_pending_transactions(&self) {
-        self.importer.miner.delete_all_pending_transactions();
-    }
-
     fn pending_transactions(&self, range: Range<u64>) -> PendingTransactions {
         self.importer.miner.pending_transactions(range)
     }
@@ -592,7 +588,11 @@ impl BlockChainClient for Client {
         self.importer.miner.count_pending_transactions(range)
     }
 
-    fn is_pending_queue_empty(&self) -> bool {
+    fn delete_all_pending_transactions(&self) {
+        self.importer.miner.delete_all_pending_transactions();
+    }
+
+    fn is_mem_pool_empty(&self) -> bool {
         self.importer.miner.num_pending_transactions() == 0
     }
 

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -593,7 +593,7 @@ impl BlockChainClient for Client {
     }
 
     fn is_pending_queue_empty(&self) -> bool {
-        self.importer.miner.status().transactions_in_pending_queue == 0
+        self.importer.miner.num_pending_transactions() == 0
     }
 
     fn block_number(&self, id: &BlockId) -> Option<BlockNumber> {

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -318,7 +318,7 @@ impl TimeoutHandler for Client {
     fn on_timeout(&self, token: TimerToken) {
         match token {
             RESEAL_MIN_TIMER_TOKEN => {
-                // Checking self.ready_transactions() for efficiency
+                // Checking self.pending_transactions() for efficiency
                 if !self.engine().engine_type().ignore_reseal_min_period() && !self.is_pending_queue_empty() {
                     self.update_sealing(BlockId::Latest, false);
                 }
@@ -584,11 +584,8 @@ impl BlockChainClient for Client {
         self.importer.miner.delete_all_pending_transactions();
     }
 
-    fn ready_transactions(&self, range: Range<u64>) -> PendingTransactions {
-        let params =
-            self.consensus_params(BlockId::Latest).expect("Consensus params of the latest block always exists");
-
-        self.importer.miner.ready_transactions(params.max_body_size(), params.max_body_size(), range)
+    fn pending_transactions(&self, range: Range<u64>) -> PendingTransactions {
+        self.importer.miner.pending_transactions(range)
     }
 
     fn count_pending_transactions(&self, range: Range<u64>) -> usize {

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -162,10 +162,10 @@ pub trait BlockChainClient: Sync + Send + BlockChainTrait + ImportBlock {
     /// Delete all pending transactions.
     fn delete_all_pending_transactions(&self);
 
-    /// List all transactions that are allowed into the next block.
-    fn ready_transactions(&self, range: Range<u64>) -> PendingTransactions;
+    /// List all transactions in the mem_pool
+    fn pending_transactions(&self, range: Range<u64>) -> PendingTransactions;
 
-    /// Get the count of all pending transactions currently in the mem_pool.
+    /// Get the count of all pending transactions.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;
 
     /// Check there are transactions which are allowed into the next block.

--- a/core/src/client/mod.rs
+++ b/core/src/client/mod.rs
@@ -153,23 +153,23 @@ pub trait BlockChainClient: Sync + Send + BlockChainTrait + ImportBlock {
     /// Get block queue information.
     fn queue_info(&self) -> BlockQueueInfo;
 
-    /// Queue own transaction for importing
+    /// Queue own transaction to mem_pool for importing
     fn queue_own_transaction(&self, transaction: Transaction) -> Result<(), Error>;
 
-    /// Queue transactions for importing.
+    /// Queue transactions to mem_pool for importing.
     fn queue_transactions(&self, transactions: Vec<Bytes>);
 
-    /// Delete all pending transactions.
-    fn delete_all_pending_transactions(&self);
-
-    /// List all transactions in the mem_pool
+    /// List all transactions in the mem_pool a.k.a pending transactions
     fn pending_transactions(&self, range: Range<u64>) -> PendingTransactions;
 
     /// Get the count of all pending transactions.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;
 
-    /// Check there are transactions which are allowed into the next block.
-    fn is_pending_queue_empty(&self) -> bool;
+    /// Delete all pending transactions.
+    fn delete_all_pending_transactions(&self);
+
+    /// Check whether there is any pending transactions or not.
+    fn is_mem_pool_empty(&self) -> bool;
 
     /// Look up the block number for the given block ID.
     fn block_number(&self, id: &BlockId) -> Option<BlockNumber>;

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -441,10 +441,8 @@ impl BlockChainClient for TestBlockChainClient {
         self.miner.delete_all_pending_transactions();
     }
 
-    fn ready_transactions(&self, range: Range<u64>) -> PendingTransactions {
-        let params =
-            self.consensus_params(BlockId::Latest).expect("Consensus params of the latest block always exists");
-        self.miner.ready_transactions(params.max_body_size(), params.max_body_size(), range)
+    fn pending_transactions(&self, range: Range<u64>) -> PendingTransactions {
+        self.miner.pending_transactions(range)
     }
 
     fn count_pending_transactions(&self, range: Range<u64>) -> usize {

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -450,7 +450,7 @@ impl BlockChainClient for TestBlockChainClient {
     }
 
     fn is_pending_queue_empty(&self) -> bool {
-        self.miner.status().transactions_in_pending_queue == 0
+        self.miner.num_pending_transactions() == 0
     }
 
     fn block_number(&self, _id: &BlockId) -> Option<BlockNumber> {

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -437,10 +437,6 @@ impl BlockChainClient for TestBlockChainClient {
         self.miner.import_external_transactions(self, transactions);
     }
 
-    fn delete_all_pending_transactions(&self) {
-        self.miner.delete_all_pending_transactions();
-    }
-
     fn pending_transactions(&self, range: Range<u64>) -> PendingTransactions {
         self.miner.pending_transactions(range)
     }
@@ -449,7 +445,11 @@ impl BlockChainClient for TestBlockChainClient {
         self.miner.count_pending_transactions(range)
     }
 
-    fn is_pending_queue_empty(&self) -> bool {
+    fn delete_all_pending_transactions(&self) {
+        self.miner.delete_all_pending_transactions();
+    }
+
+    fn is_mem_pool_empty(&self) -> bool {
         self.miner.num_pending_transactions() == 0
     }
 

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -99,9 +99,9 @@ impl MemPool {
     /// Enforce the limit to the current/future queue
     fn enforce_limit(&mut self, batch: &mut DBTransaction) {
         let to_drop: Vec<TxHash> = {
-            let transactions: Vec<_> = self.transaction_pool.pool.values().collect();
+            let transactions = Box::new(self.transaction_pool.pool.values());
             let (invalid, low_priority) = self.tx_filter.filter_transactions(
-                &transactions,
+                transactions,
                 Some(self.queue_memory_limit),
                 Some(self.queue_count_limit),
             );
@@ -234,8 +234,8 @@ impl MemPool {
     pub fn remove_old(&mut self) {
         let mut batch = backup::backup_batch_with_capacity(self.transaction_pool.count);
         let to_be_removed: Vec<TxHash> = {
-            let transactions: Vec<_> = self.transaction_pool.pool.values().collect();
-            let (invalid, low_priority) = self.tx_filter.filter_transactions(&transactions, None, None);
+            let transactions = Box::new(self.transaction_pool.pool.values());
+            let (invalid, low_priority) = self.tx_filter.filter_transactions(transactions, None, None);
             let transactions_to_be_removed = [invalid, low_priority].concat();
             transactions_to_be_removed.iter().map(|tx| tx.hash()).collect()
         };

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -207,6 +207,17 @@ impl MemPool {
         self.transaction_pool.clear();
     }
 
+    pub fn pending_transactions(&self, range: Range<u64>) -> PendingTransactions {
+        let tx_with_metadatas: Vec<_> =
+            self.transaction_pool.pool.values().filter(|tx| range.contains(&tx.inserted_timestamp)).collect();
+        let last_timestamp = tx_with_metadatas.iter().map(|tx_with_metadata| tx_with_metadata.inserted_timestamp).max();
+
+        PendingTransactions {
+            transactions: tx_with_metadatas.into_iter().map(|tx_with_metadata| tx_with_metadata.tx.clone()).collect(),
+            last_timestamp,
+        }
+    }
+
     pub fn top_transactions(&self, gas_limit: usize, size_limit: usize, range: Range<u64>) -> PendingTransactions {
         let mut current_gas: usize = 0;
         let mut current_size: usize = 0;

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use super::backup;
-use super::mem_pool_types::{MemPoolStatus, PoolingInstant, TransactionPool};
+use super::mem_pool_types::{PoolingInstant, TransactionPool};
 use crate::transaction::PendingTransactions;
 use crate::Error as CoreError;
 use coordinator::traits::TxFilter;
@@ -118,11 +118,9 @@ impl MemPool {
         self.queue_count_limit
     }
 
-    /// Returns current status for this pool
-    pub fn status(&self) -> MemPoolStatus {
-        MemPoolStatus {
-            pending: self.transaction_pool.len(),
-        }
+    /// Returns the number of transactions in the pool
+    pub fn num_pending_transactions(&self) -> usize {
+        self.transaction_pool.len()
     }
 
     /// Add signed transaction to pool to be verified and imported.

--- a/core/src/miner/mem_pool_types.rs
+++ b/core/src/miner/mem_pool_types.rs
@@ -68,10 +68,3 @@ impl TransactionPool {
         }
     }
 }
-
-#[derive(Debug)]
-/// Current status of the pool
-pub struct MemPoolStatus {
-    /// Number of pending transactions (ready to go to block)
-    pub pending: usize,
-}

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -448,9 +448,8 @@ impl MinerService for Miner {
         imported
     }
 
-    fn ready_transactions(&self, gas_limit: usize, size_limit: usize, range: Range<u64>) -> PendingTransactions {
-        // TODO: Create a gas_limit parameter and use it.
-        self.mem_pool.read().top_transactions(gas_limit, size_limit, range)
+    fn pending_transactions(&self, range: Range<u64>) -> PendingTransactions {
+        self.mem_pool.read().pending_transactions(range)
     }
 
     fn count_pending_transactions(&self, range: Range<u64>) -> usize {

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use super::mem_pool::{Error as MemPoolError, MemPool};
-use super::{MinerService, MinerStatus};
+use super::MinerService;
 use crate::account_provider::{AccountProvider, Error as AccountProviderError};
 use crate::block::{ClosedBlock, IsBlock};
 use crate::client::{BlockChainClient, BlockChainTrait, BlockProducer, EngineInfo, ImportBlock, TermInfo};
@@ -273,11 +273,8 @@ impl Miner {
 impl MinerService for Miner {
     type State = TopLevelState;
 
-    fn status(&self) -> MinerStatus {
-        let status = self.mem_pool.read().status();
-        MinerStatus {
-            transactions_in_pending_queue: status.pending,
-        }
+    fn num_pending_transactions(&self) -> usize {
+        self.mem_pool.read().num_pending_transactions()
     }
 
     fn authoring_params(&self) -> AuthoringParams {
@@ -421,10 +418,10 @@ impl MinerService for Miner {
 
             match import {
                 Ok(_) => {
-                    ctrace!(OWN_TX, "Status: {:?}", mem_pool.status());
+                    ctrace!(OWN_TX, "Number of pending transactions: {:?}", mem_pool.num_pending_transactions());
                 }
                 Err(ref e) => {
-                    ctrace!(OWN_TX, "Status: {:?}", mem_pool.status());
+                    ctrace!(OWN_TX, "Number of pending transactions: {:?}", mem_pool.num_pending_transactions());
                     cwarn!(OWN_TX, "Error importing transaction: {:?}", e);
                 }
             }

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -41,8 +41,8 @@ pub trait MinerService: Send + Sync {
     /// Type representing chain state
     type State: TopStateView + 'static;
 
-    /// Returns miner's status.
-    fn status(&self) -> MinerStatus;
+    /// Returns the number of pending transactions.
+    fn num_pending_transactions(&self) -> usize;
 
     /// Get current authoring parameters.
     fn authoring_params(&self) -> AuthoringParams;

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -89,10 +89,10 @@ pub trait MinerService: Send + Sync {
         tx: Transaction,
     ) -> Result<(), Error>;
 
-    /// Get a list of all pending transactions in the mem pool.
-    fn ready_transactions(&self, gas_limit: usize, size_limit: usize, range: Range<u64>) -> PendingTransactions;
+    /// Get a list of all transactions in the mem pool.
+    fn pending_transactions(&self, range: Range<u64>) -> PendingTransactions;
 
-    /// Get a count of all pending transactions in the mem pool.
+    /// Get a count of all pending transactions.
     fn count_pending_transactions(&self, range: Range<u64>) -> usize;
 
     /// Start sealing.

--- a/rpc/src/v1/impls/mempool.rs
+++ b/rpc/src/v1/impls/mempool.rs
@@ -61,7 +61,7 @@ where
     }
 
     fn get_pending_transactions(&self, from: Option<u64>, to: Option<u64>) -> Result<PendingTransactions> {
-        Ok(self.client.ready_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)).into())
+        Ok(self.client.pending_transactions(from.unwrap_or(0)..to.unwrap_or(::std::u64::MAX)).into())
     }
 
     fn get_pending_transactions_count(&self, from: Option<u64>, to: Option<u64>) -> Result<usize> {

--- a/sync/src/transaction/extension.rs
+++ b/sync/src/transaction/extension.rs
@@ -144,7 +144,7 @@ impl NetworkExtension<Never> for Extension {
 
 impl Extension {
     fn random_broadcast(&mut self) {
-        let transactions = self.client.ready_transactions(0..u64::MAX).transactions;
+        let transactions = self.client.pending_transactions(0..u64::MAX).transactions;
         if transactions.is_empty() {
             ctrace!(SYNC_TX, "No transactions to propagate");
             return


### PR DESCRIPTION
Resolves #370 
`mem_pool.top_transactions` should be removed.
We may need a separate interface dedicated to handle `ready_transactions` method.