### PR TITLE
Sort validator set in public key order

### DIFF
--- a/core/src/blockchain/body_db.rs
+++ b/core/src/blockchain/body_db.rs
@@ -19,7 +19,7 @@ use super::extras::TransactionAddress;
 use crate::db::{self, CacheUpdatePolicy, Readable, Writable};
 use crate::encoded;
 use crate::views::BlockView;
-use ctypes::{BlockHash, TxHash};
+use ctypes::{BlockHash, TransactionIndex, TxHash};
 use kvdb::{DBTransaction, KeyValueDB};
 use lru_cache::LruCache;
 use parking_lot::{Mutex, RwLock};
@@ -179,7 +179,7 @@ fn tx_hash_and_address_entries(
     tx_hashes.into_iter().enumerate().map(move |(index, tx_hash)| {
         (tx_hash, TransactionAddress {
             block_hash,
-            index,
+            index: index as TransactionIndex,
         })
     })
 }

--- a/core/src/blockchain/extras.rs
+++ b/core/src/blockchain/extras.rs
@@ -16,7 +16,7 @@
 
 use crate::db::Key;
 use crate::types::TransactionId;
-use ctypes::{BlockHash, BlockNumber, TxHash};
+use ctypes::{BlockHash, BlockNumber, TransactionIndex, TxHash};
 use primitives::{H256, H264};
 use std::ops::Deref;
 
@@ -95,7 +95,7 @@ pub struct TransactionAddress {
     /// Block hash
     pub block_hash: BlockHash,
     /// Transaction index within the block
-    pub index: usize,
+    pub index: TransactionIndex,
 }
 
 impl From<TransactionAddress> for TransactionId {

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -310,7 +310,7 @@ impl TestBlockChainClient {
             pubkeys.push(public);
         }
         let fixed_validators: NextValidators =
-            pubkeys.into_iter().map(|pubkey| Validator::new(0, 0, pubkey)).collect::<Vec<_>>().into();
+            pubkeys.into_iter().map(|pubkey| Validator::new(0, 0, pubkey, 0, 0)).collect::<Vec<_>>().into();
 
         self.validators = fixed_validators;
     }

--- a/core/src/consensus/tendermint/worker.rs
+++ b/core/src/consensus/tendermint/worker.rs
@@ -1528,7 +1528,7 @@ impl Worker {
         assert_eq!(header.number(), self.height);
 
         let parent_hash = header.parent_hash();
-        let signer_index = self.validators.proposer_index(*parent_hash, self.view as usize);
+        let signer_index = self.validators.proposer_index(*parent_hash, self.view);
 
         let on = VoteOn {
             step: VoteStep::new(self.height, self.view, Step::Propose),
@@ -1555,7 +1555,7 @@ impl Worker {
         proposed_view: View,
         signature: Signature,
     ) -> Option<ConsensusMessage> {
-        let signer_index = self.validators.proposer_index(*header.parent_hash(), proposed_view as usize);
+        let signer_index = self.validators.proposer_index(*header.parent_hash(), proposed_view);
 
         let on = VoteOn {
             step: VoteStep::new(header.number(), proposed_view, Step::Propose),
@@ -1571,7 +1571,6 @@ impl Worker {
 
     fn signer_index(&self) -> Option<usize> {
         let parent = self.prev_block_hash();
-        // FIXME: More effecient way to find index
         self.signer.public().and_then(|public| self.validators.get_index(&parent, public))
     }
 

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -19,7 +19,7 @@ use ccrypto::blake256;
 use ckey::{sign, verify, Ed25519Private as Private, Ed25519Public as Public, Error as KeyError, Signature};
 use ctypes::errors::SyntaxError;
 use ctypes::transaction::Transaction;
-use ctypes::{BlockHash, BlockNumber, CommonParams, TxHash};
+use ctypes::{BlockHash, BlockNumber, CommonParams, TransactionIndex, TxHash};
 use rlp::{DecoderError, Encodable, Rlp, RlpStream};
 use std::convert::{TryFrom, TryInto};
 
@@ -222,7 +222,7 @@ pub struct LocalizedTransaction {
     /// Block hash.
     pub block_hash: BlockHash,
     /// Transaction index within block.
-    pub transaction_index: usize,
+    pub transaction_index: TransactionIndex,
     /// Cached public
     pub cached_signer_public: Option<Public>,
 }

--- a/core/src/types/transaction_id.rs
+++ b/core/src/types/transaction_id.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use ctypes::{BlockId, TxHash};
+use ctypes::{BlockId, TransactionIndex, TxHash};
 
 /// Uniquely identifies transaction.
 #[derive(Debug, PartialEq, Clone, Hash, Eq)]
@@ -23,7 +23,7 @@ pub enum TransactionId {
     Hash(TxHash),
     /// Block id and transaction index within this block.
     /// Querying by block position is always faster.
-    Location(BlockId, usize),
+    Location(BlockId, TransactionIndex),
 }
 
 impl From<TxHash> for TransactionId {

--- a/core/src/views/block.rs
+++ b/core/src/views/block.rs
@@ -17,7 +17,7 @@
 use super::{HeaderView, TransactionView};
 use crate::transaction::{LocalizedTransaction, UnverifiedTransaction};
 use ccrypto::blake256;
-use ctypes::{BlockHash, Header, TxHash};
+use ctypes::{BlockHash, Header, TransactionIndex, TxHash};
 use rlp::Rlp;
 
 /// View onto block rlp.
@@ -82,7 +82,7 @@ impl<'a> BlockView<'a> {
                 signed,
                 block_hash,
                 block_number,
-                transaction_index,
+                transaction_index: transaction_index as TransactionIndex,
                 cached_signer_public: None,
             })
             .collect()
@@ -104,12 +104,12 @@ impl<'a> BlockView<'a> {
     }
 
     /// Returns transaction at given index without deserializing unnecessary data.
-    pub fn transaction_at(&self, index: usize) -> Option<UnverifiedTransaction> {
-        self.rlp.at(1).unwrap().iter().nth(index).map(|rlp| rlp.as_val().unwrap())
+    pub fn transaction_at(&self, index: TransactionIndex) -> Option<UnverifiedTransaction> {
+        self.rlp.at(1).unwrap().iter().nth(index as usize).map(|rlp| rlp.as_val().unwrap())
     }
 
     /// Returns localized transaction at given index.
-    pub fn localized_transaction_at(&self, transaction_index: usize) -> Option<LocalizedTransaction> {
+    pub fn localized_transaction_at(&self, transaction_index: TransactionIndex) -> Option<LocalizedTransaction> {
         let header = self.header_view();
         let block_hash = header.hash();
         let block_number = header.number();

--- a/core/src/views/body.rs
+++ b/core/src/views/body.rs
@@ -17,7 +17,7 @@
 use super::TransactionView;
 use crate::transaction::{LocalizedTransaction, UnverifiedTransaction};
 use ccrypto::blake256;
-use ctypes::{BlockHash, BlockNumber, TxHash};
+use ctypes::{BlockHash, BlockNumber, TransactionIndex, TxHash};
 use rlp::Rlp;
 
 /// View onto block rlp.
@@ -63,7 +63,7 @@ impl<'a> BodyView<'a> {
                 signed,
                 block_hash: *block_hash,
                 block_number,
-                transaction_index,
+                transaction_index: transaction_index as TransactionIndex,
                 cached_signer_public: None,
             })
             .collect()
@@ -85,8 +85,8 @@ impl<'a> BodyView<'a> {
     }
 
     /// Returns transaction at given index without deserializing unnecessary data.
-    pub fn transaction_at(&self, index: usize) -> Option<UnverifiedTransaction> {
-        self.rlp.at(0).unwrap().iter().nth(index).map(|rlp| rlp.as_val().unwrap())
+    pub fn transaction_at(&self, index: TransactionIndex) -> Option<UnverifiedTransaction> {
+        self.rlp.at(0).unwrap().iter().nth(index as usize).map(|rlp| rlp.as_val().unwrap())
     }
 
     /// Returns localized transaction at given index.
@@ -94,7 +94,7 @@ impl<'a> BodyView<'a> {
         &self,
         block_hash: &BlockHash,
         block_number: BlockNumber,
-        transaction_index: usize,
+        transaction_index: TransactionIndex,
     ) -> Option<LocalizedTransaction> {
         self.transaction_at(transaction_index).map(|signed| LocalizedTransaction {
             signed,

--- a/rpc/src/v1/types/block.rs
+++ b/rpc/src/v1/types/block.rs
@@ -17,7 +17,7 @@
 use super::Transaction;
 use ccore::{Block as CoreBlock, LocalizedTransaction};
 use ckey::{NetworkId, PlatformAddress};
-use ctypes::{BlockHash, BlockNumber};
+use ctypes::{BlockHash, BlockNumber, TransactionIndex};
 use primitives::H256;
 
 #[derive(Debug, Serialize)]
@@ -49,7 +49,7 @@ impl Block {
                 signed,
                 block_number,
                 block_hash,
-                transaction_index,
+                transaction_index: transaction_index as TransactionIndex,
                 cached_signer_public: None,
             });
         Block {

--- a/rpc/src/v1/types/transaction.rs
+++ b/rpc/src/v1/types/transaction.rs
@@ -18,14 +18,14 @@ use super::Action;
 use ccore::{LocalizedTransaction, PendingVerifiedTransactions, VerifiedTransaction};
 use cjson::uint::Uint;
 use ckey::{NetworkId, Signature};
-use ctypes::{BlockHash, TxHash};
+use ctypes::{BlockHash, TransactionIndex, TxHash};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
     pub block_number: Option<u64>,
     pub block_hash: Option<BlockHash>,
-    pub transaction_index: Option<usize>,
+    pub transaction_index: Option<TransactionIndex>,
     pub result: Option<bool>,
     pub seq: u64,
     pub fee: Uint,

--- a/test/src/e2e.long/tendermint.test.ts
+++ b/test/src/e2e.long/tendermint.test.ts
@@ -63,8 +63,8 @@ describe("Tendermint ", function() {
     describe("getPossibleAuthors", function() {
         it("latest", async function() {
             const validators = [
-                "rjmxg19kCmkCxROEoV0QYsrDpOYsjQwusCtN5_oKMEzk-I6kgtAtc0",
                 "szff1322BHP3gsOuwFPDf-K8zvqSmNz4rj3CJirlQKFKWA_3c-Ytc0",
+                "rjmxg19kCmkCxROEoV0QYsrDpOYsjQwusCtN5_oKMEzk-I6kgtAtc0",
                 "qwfj0xwkJQLV5iEGeaGeRfPA-TJX56Mnuq9fQD9coasmhanhck4tc0",
                 "dbqtds3w6QnzEf0RXuQS7c_N6IzFBzcBAfdjWme5y0U5DxzLS14tc0"
             ];

--- a/test/src/stakeholder/actionData.ts
+++ b/test/src/stakeholder/actionData.ts
@@ -115,7 +115,7 @@ export async function getCandidates(
     }
     const decoded = RLP.decode(Buffer.from(data, "hex"));
     function isCandidateShape(entry: any): entry is Buffer[] {
-        return entry != null && Array.isArray(entry) && entry.length === 4;
+        return entry != null && Array.isArray(entry) && entry.length === 6;
     }
     if (!isArrayOf<Buffer[]>(decoded, isCandidateShape)) {
         throw new Error(
@@ -263,7 +263,7 @@ export async function getValidators(
     }
     const decoded = RLP.decode(Buffer.from(data, "hex"));
     function isValidatorShape(entry: any): entry is Buffer[] {
-        return entry != null && Array.isArray(entry) && entry.length === 4;
+        return entry != null && Array.isArray(entry) && entry.length === 6;
     }
     if (!isArrayOf<Buffer[]>(decoded, isValidatorShape)) {
         throw new Error(

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -33,6 +33,7 @@ pub mod transaction;
 pub mod util;
 
 pub type BlockNumber = u64;
+pub type TransactionIndex = u32;
 pub type ShardId = u16;
 pub type StorageId = u16;
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -37,6 +37,12 @@ pub type TransactionIndex = u32;
 pub type ShardId = u16;
 pub type StorageId = u16;
 
+#[derive(Copy, Clone)]
+pub struct TransactionLocation {
+    pub block_number: BlockNumber,
+    pub transaction_index: TransactionIndex,
+}
+
 pub use block_hash::BlockHash;
 pub use block_id::BlockId;
 pub use common_params::CommonParams;

--- a/types/src/transaction/action.rs
+++ b/types/src/transaction/action.rs
@@ -574,7 +574,10 @@ mod tests {
     #[test]
     fn rlp_of_update_validators() {
         rlp_encode_and_decode_test!(Action::UpdateValidators {
-            validators: vec![Validator::new(1, 2, Public::random()), Validator::new(3, 4, Public::random())],
+            validators: vec![
+                Validator::new(1, 2, Public::random(), 0, 0),
+                Validator::new(3, 4, Public::random(), 0, 0)
+            ],
         });
     }
 

--- a/types/src/transaction/validator.rs
+++ b/types/src/transaction/validator.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use crate::{BlockNumber, TransactionIndex};
 use ckey::Ed25519Public as Public;
 
 pub type StakeQuantity = u64;
@@ -25,15 +26,25 @@ pub struct Validator {
     delegation: StakeQuantity,
     deposit: DepositQuantity,
     pubkey: Public,
+    nominated_at_block_number: BlockNumber,
+    nominated_at_transaction_index: TransactionIndex,
 }
 
 impl Validator {
-    pub fn new(delegation: StakeQuantity, deposit: DepositQuantity, pubkey: Public) -> Self {
+    pub fn new(
+        delegation: StakeQuantity,
+        deposit: DepositQuantity,
+        pubkey: Public,
+        nominated_at_block_number: BlockNumber,
+        nominated_at_transaction_index: TransactionIndex,
+    ) -> Self {
         Self {
             weight: delegation,
             delegation,
             deposit,
             pubkey,
+            nominated_at_block_number,
+            nominated_at_transaction_index,
         }
     }
 
@@ -75,6 +86,8 @@ mod tests {
             delegation: 2,
             deposit: 3,
             pubkey: Public::random(),
+            nominated_at_block_number: 3,
+            nominated_at_transaction_index: 2
         });
     }
 }

--- a/types/src/transaction/validator.rs
+++ b/types/src/transaction/validator.rs
@@ -20,7 +20,7 @@ use ckey::Ed25519Public as Public;
 pub type StakeQuantity = u64;
 pub type DepositQuantity = u64;
 
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, RlpDecodable, RlpEncodable)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, RlpDecodable, RlpEncodable)]
 pub struct Validator {
     weight: StakeQuantity,
     delegation: StakeQuantity,
@@ -70,6 +70,14 @@ impl Validator {
 
     pub fn deposit(&self) -> DepositQuantity {
         self.deposit
+    }
+
+    pub fn nominated_at_block_number(&self) -> BlockNumber {
+        self.nominated_at_block_number
+    }
+
+    pub fn nominated_at_transaction_index(&self) -> TransactionIndex {
+        self.nominated_at_transaction_index
     }
 }
 


### PR DESCRIPTION
By sorting the validator set using public keys, we can make validator set hash consistent. We can use this property to omit the validator set hash in Header Sync.

If two validators have the same delegation and deposit, the one who became the candidate first will be validator first. We didn't change the rule in this commit. Previously we kept the order of Candidates and Validators to remember who became the candidate first. Now we are saving nomination_starts_at variable to remember it.
