### PR TITLE
Modify impls.rs in Account module which was not compiled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,7 @@ dependencies = [
  "kvdb",
  "kvdb-rocksdb",
  "log 0.4.8",
+ "module_account",
  "never-type",
  "panic_hook",
  "parking_lot 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tokio-core = "0.1.17"
 toml = "0.4"
 cidr = "0.0.4"
 cbasesandbox = {package = "codechain-basesandbox", path = "basesandbox"}
+module_account = {path = "basic_module/account"}
 
 [build-dependencies]
 vergen = "2"

--- a/basic_module/account/src/core.rs
+++ b/basic_module/account/src/core.rs
@@ -15,13 +15,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::error::Error;
-use crate::types::{SignedTransaction, Transaction};
+use crate::types::SignedTransaction;
 pub use ckey::{Ed25519Private as Private, Ed25519Public as Public, Error as KeyError, Password, Signature};
 pub use coordinator::context::SubStorageAccess;
 pub use coordinator::types::{ErrorCode, TransactionExecutionOutcome};
 
 pub trait CheckTxHandler {
-    fn check_transaction(&self, tx: &Transaction) -> Result<(), ErrorCode>;
+    fn check_transaction(&self, tx: &SignedTransaction) -> Result<(), ErrorCode>;
 }
 
 pub trait TransactionExecutor {
@@ -44,10 +44,4 @@ pub trait AccountView {
     fn get_balance(&self, address: &Public) -> u64;
 
     fn get_sequence(&self, address: &Public) -> u64;
-}
-
-pub trait SignatureManager {
-    fn verify(&self, signature: &Signature, message: &[u8], public: &Public) -> bool;
-
-    fn sign(&self, message: &[u8], private: &Private) -> Signature;
 }

--- a/basic_module/account/src/lib.rs
+++ b/basic_module/account/src/lib.rs
@@ -24,11 +24,12 @@ extern crate codechain_key as ckey;
 
 mod core;
 mod error;
+mod impls;
 mod import;
 mod internal;
 mod types;
 
-use crate::core::SignatureManager;
+use ckey::verify;
 use ckey::NetworkId;
 use coordinator::context::Context;
 use std::sync::Mutex;
@@ -44,11 +45,11 @@ pub fn get_context() -> &'static mut dyn Context {
     unimplemented!();
 }
 
-pub fn check(sig_manager: Box<dyn SignatureManager>, signed_tx: &SignedTransaction) -> bool {
+pub fn check(signed_tx: &SignedTransaction) -> bool {
     let signature = signed_tx.signature;
     let network_id = signed_tx.tx.network_id;
 
-    sig_manager.verify(&signature, &signed_tx.tx.hash(), &signed_tx.signer_public) && check_network_id(network_id)
+    check_network_id(network_id) && verify(&signature, &signed_tx.tx.hash(), &signed_tx.signer_public)
 }
 
 pub fn check_network_id(network_id: NetworkId) -> bool {


### PR DESCRIPTION
When the prototype of the Account module was merged, there was a mistake that did not designate `impls.rs` as the build target. I modified it as a build target and some code, so that we could compile it.

The commit in this PR includes
- Modify impls.rs to complie it
- Remove the trait SignatureManager