### PR TITLE
Use parking_lot instead of the standard sync primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "ipc-channel",
  "nix",
  "once_cell",
+ "parking_lot 0.6.4",
  "primitives",
  "serde",
  "serde_cbor",

--- a/basesandbox/Cargo.toml
+++ b/basesandbox/Cargo.toml
@@ -14,6 +14,7 @@ serde = "1.0"
 serde_cbor = "0.11.1"
 serde_derive = "1.0"
 once_cell = "1.3.1"
+parking_lot = "0.6.0"
 ipc-channel = "0.14.1"
 
 [[bin]]

--- a/basesandbox/src/execution/executor.rs
+++ b/basesandbox/src/execution/executor.rs
@@ -16,9 +16,10 @@
 
 use crate::ipc::*;
 use once_cell::sync::OnceCell;
+use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::process::Command;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 pub trait Executor: Send {
@@ -62,11 +63,11 @@ pub type ThreadAsProcesss = Arc<dyn Fn(Vec<String>) -> () + Send + Sync>;
 static POOL: OnceCell<RwLock<HashMap<String, ThreadAsProcesss>>> = OnceCell::new();
 
 fn get_function_pool(key: &str) -> ThreadAsProcesss {
-    POOL.get_or_init(|| RwLock::new(HashMap::new())).read().unwrap().get(key).unwrap().clone()
+    POOL.get_or_init(Default::default).read().get(key).unwrap().clone()
 }
 
 pub fn add_function_pool(key: String, f: ThreadAsProcesss) {
-    assert!(POOL.get_or_init(|| RwLock::new(HashMap::new())).write().unwrap().insert(key, f).is_none());
+    assert!(POOL.get_or_init(Default::default).write().insert(key, f).is_none());
 }
 
 pub struct PlainThread {

--- a/basesandbox/src/ipc.rs
+++ b/basesandbox/src/ipc.rs
@@ -18,8 +18,9 @@ pub mod domain_socket;
 pub mod intra;
 pub mod multiplex;
 pub mod servo_channel;
+
 use once_cell::sync::OnceCell;
-use std::sync::Mutex;
+use parking_lot::Mutex;
 
 pub trait IpcSend: Send {
     /// It might block until counterparty's recv(). Even if not, the order is still guaranteed.
@@ -69,7 +70,7 @@ pub trait Ipc: IpcSend + IpcRecv {
 /// possible attack. Rather, generating a random name would be more secure.
 pub fn generate_random_name() -> String {
     static MONOTONIC: OnceCell<Mutex<u64>> = OnceCell::new();
-    let mut mono = MONOTONIC.get_or_init(|| Mutex::new(0)).lock().unwrap();
+    let mut mono = MONOTONIC.get_or_init(|| Mutex::new(0)).lock();
     *mono += 1;
     let mono = *mono;
     let pid = std::process::id();

--- a/basesandbox/src/ipc/intra.rs
+++ b/basesandbox/src/ipc/intra.rs
@@ -17,8 +17,8 @@
 use super::*;
 use crossbeam::channel::{bounded, Receiver, RecvTimeoutError, Sender};
 use once_cell::sync::OnceCell;
+use parking_lot::Mutex;
 use std::collections::hash_map::HashMap;
-use std::sync::Mutex;
 
 struct RegisteredIpcEnds {
     is_server: bool,
@@ -34,11 +34,11 @@ fn get_pool_raw() -> &'static Mutex<HashMap<String, RegisteredIpcEnds>> {
 }
 
 fn add_ends(key: String, ends: RegisteredIpcEnds) {
-    assert!(get_pool_raw().lock().unwrap().insert(key, ends).is_none())
+    assert!(get_pool_raw().lock().insert(key, ends).is_none())
 }
 
 fn take_ends(key: &str) -> RegisteredIpcEnds {
-    get_pool_raw().lock().unwrap().remove(key).unwrap()
+    get_pool_raw().lock().remove(key).unwrap()
 }
 
 pub struct IntraSend(Sender<Vec<u8>>);

--- a/basesandbox/src/ipc/multiplex.rs
+++ b/basesandbox/src/ipc/multiplex.rs
@@ -16,7 +16,7 @@
 
 use super::{IpcRecv, IpcSend, RecvError, Terminate};
 use crossbeam::channel::bounded;
-use std::sync::Mutex;
+use parking_lot::Mutex;
 use std::thread;
 
 type Sender = crossbeam::channel::Sender<Vec<u8>>;
@@ -93,7 +93,7 @@ impl Multiplexer {
 
 impl Drop for Multiplexer {
     fn drop(&mut self) {
-        self.termiantor.take().unwrap().into_inner().unwrap().terminate();
+        self.termiantor.take().unwrap().into_inner().terminate();
         self.sender_send.send(Vec::new()).unwrap();
         self.receiver_thread.take().unwrap().join().unwrap();
         self.sender_thread.take().unwrap().join().unwrap();

--- a/basic_module/account/src/lib.rs
+++ b/basic_module/account/src/lib.rs
@@ -31,7 +31,7 @@ mod types;
 use crate::core::SignatureManager;
 use ckey::NetworkId;
 use coordinator::context::Context;
-use std::sync::Mutex;
+use parking_lot::Mutex;
 use std::unimplemented;
 use types::SignedTransaction;
 
@@ -52,7 +52,7 @@ pub fn check(sig_manager: Box<dyn SignatureManager>, signed_tx: &SignedTransacti
 }
 
 pub fn check_network_id(network_id: NetworkId) -> bool {
-    let mut saved_network_id = NETWORK_ID.lock().unwrap();
+    let mut saved_network_id = NETWORK_ID.lock();
     if saved_network_id.is_none() {
         *saved_network_id = Some(network_id);
     }


### PR DESCRIPTION
We use `parking_lot` instead of the standard Mutex.
It's more efficient and easy to use.