### PR TITLE
Implement IPC for basesandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,7 @@ dependencies = [
  "hex",
  "nix",
  "once_cell",
+ "parking_lot 0.6.4",
  "primitives",
  "serde",
  "serde_cbor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+
+[[package]]
 name = "backtrace"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,9 +156,9 @@ checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
 
 [[package]]
 name = "bitflags"
-version = "1.0.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitstring"
@@ -324,6 +330,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "codechain-basesandbox"
+version = "0.1.0"
+dependencies = [
+ "codechain-crypto",
+ "crossbeam 0.7.3",
+ "hex",
+ "nix",
+ "once_cell",
+ "primitives",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+]
+
+[[package]]
 name = "codechain-core"
 version = "0.1.0"
 dependencies = [
@@ -338,7 +359,7 @@ dependencies = [
  "codechain-state",
  "codechain-timer",
  "codechain-types",
- "crossbeam-channel",
+ "crossbeam-channel 0.3.8",
  "hyper 0.10.0-a.0",
  "kvdb",
  "kvdb-memorydb",
@@ -420,7 +441,7 @@ dependencies = [
  "codechain-rpc",
  "codechain-types",
  "codechain_informer_courier",
- "crossbeam-channel",
+ "crossbeam-channel 0.3.8",
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
@@ -447,7 +468,7 @@ name = "codechain-io"
 version = "1.9.0"
 dependencies = [
  "codechain-logger",
- "crossbeam",
+ "crossbeam 0.5.0",
  "log 0.4.8",
  "mio",
  "parking_lot 0.6.4",
@@ -537,7 +558,7 @@ dependencies = [
  "codechain-logger",
  "codechain-timer",
  "codechain_informer_courier",
- "crossbeam-channel",
+ "crossbeam-channel 0.3.8",
  "finally-block",
  "kvdb",
  "log 0.4.8",
@@ -663,7 +684,7 @@ dependencies = [
 name = "codechain_informer_courier"
 version = "0.1.0"
 dependencies = [
- "crossbeam-channel",
+ "crossbeam-channel 0.3.8",
  "serde",
  "serde_derive",
  "serde_json",
@@ -720,13 +741,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c92ff2d7a202d592f5a412d75cf421495c913817781c1cb383bf12a77e185f"
 dependencies = [
  "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-channel 0.3.8",
+ "crossbeam-deque 0.6.2",
+ "crossbeam-epoch 0.6.1",
+ "crossbeam-utils 0.6.5",
  "lazy_static 1.4.0",
  "num_cpus",
  "parking_lot 0.6.4",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel 0.4.2",
+ "crossbeam-deque 0.7.3",
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-queue",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -735,8 +770,18 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.6.5",
  "smallvec 0.6.4",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -745,8 +790,19 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe1b6f945f824c7a25afe44f62e25d714c0cc523f8e99d8db5cd1026e1269d3"
 dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-epoch 0.6.1",
+ "crossbeam-utils 0.6.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+dependencies = [
+ "crossbeam-epoch 0.8.2",
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -757,10 +813,35 @@ checksum = "2449aaa4ec7ef96e5fb24db16024b935df718e9ae1cec0a1e68feeca2efca7b8"
 dependencies = [
  "arrayvec",
  "cfg-if",
- "crossbeam-utils",
+ "crossbeam-utils 0.6.5",
  "lazy_static 1.4.0",
- "memoffset",
+ "memoffset 0.2.1",
  "scopeguard 0.3.3",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg 1.0.0",
+ "cfg-if",
+ "crossbeam-utils 0.7.2",
+ "lazy_static 1.4.0",
+ "maybe-uninit",
+ "memoffset 0.5.4",
+ "scopeguard 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -769,6 +850,17 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 dependencies = [
+ "cfg-if",
+ "lazy_static 1.4.0",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg 1.0.0",
  "cfg-if",
  "lazy_static 1.4.0",
 ]
@@ -1051,6 +1143,7 @@ dependencies = [
  "app_dirs",
  "cidr",
  "clap",
+ "codechain-basesandbox",
  "codechain-core",
  "codechain-discovery",
  "codechain-informer",
@@ -1063,7 +1156,7 @@ dependencies = [
  "codechain-sync",
  "codechain-timer",
  "codechain-types",
- "crossbeam-channel",
+ "crossbeam-channel 0.3.8",
  "ctrlc",
  "env_logger 0.5.10",
  "fdlimit",
@@ -1233,6 +1326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+
+[[package]]
 name = "heapsize"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hmac"
@@ -1698,6 +1797,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1813,15 @@ name = "memoffset"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+
+[[package]]
+name = "memoffset"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+dependencies = [
+ "autocfg 1.0.0",
+]
 
 [[package]]
 name = "merkle-trie"
@@ -1875,6 +1989,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c026cbdf8890d6cab75bd177f36e948bf3a512c61f3e93898fd288f571da6551"
 
 [[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,6 +2064,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,7 +2101,7 @@ version = "0.9.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.4",
  "cc",
  "libc",
  "pkg-config",
@@ -2704,6 +2837,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,7 +3314,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.6.5",
  "futures",
 ]
 
@@ -3274,9 +3417,9 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17465013014410310f9f61fa10bf4724803c149ea1d51efece131c38efca93aa"
 dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-channel 0.3.8",
+ "crossbeam-deque 0.6.2",
+ "crossbeam-utils 0.6.5",
  "futures",
  "log 0.4.8",
  "num_cpus",
@@ -3290,7 +3433,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.6.5",
  "futures",
  "slab 0.4.2",
  "tokio-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ serde_json = "1.0"
 tokio-core = "0.1.17"
 toml = "0.4"
 cidr = "0.0.4"
+cbasesandbox = {package = "codechain-basesandbox", path = "basesandbox"}
 
 [build-dependencies]
 vergen = "2"
@@ -74,4 +75,5 @@ members = [
     "informer_courier",
     "sync",
     "types",
+    "basesandbox",
 ]

--- a/basesandbox/Cargo.toml
+++ b/basesandbox/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "codechain-basesandbox"
+version = "0.1.0"
+authors = ["CodeChain Team <hi@codechain.io>"]
+edition = "2018"
+
+[dependencies]
+ccrypto = { package = "codechain-crypto", git = "https://github.com/CodeChain-io/rust-codechain-crypto.git", version = "0.2" }
+crossbeam = "0.7.3"
+hex = "0.4.2"
+nix = "0.17.0"
+once_cell = "1.3.1"
+primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
+serde = "1.0"
+serde_cbor = "0.11.1"
+serde_derive = "1.0"

--- a/basesandbox/Cargo.toml
+++ b/basesandbox/Cargo.toml
@@ -15,3 +15,7 @@ primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.
 serde = "1.0"
 serde_cbor = "0.11.1"
 serde_derive = "1.0"
+
+[[bin]]
+path = "./tests/simple/simple.rs"
+name = "test_simple_rs"

--- a/basesandbox/Cargo.toml
+++ b/basesandbox/Cargo.toml
@@ -10,6 +10,7 @@ crossbeam = "0.7.3"
 hex = "0.4.2"
 nix = "0.17.0"
 once_cell = "1.3.1"
+parking_lot = "0.6.0"
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
 serde = "1.0"
 serde_cbor = "0.11.1"

--- a/basesandbox/src/execution.rs
+++ b/basesandbox/src/execution.rs
@@ -14,5 +14,5 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pub mod execution;
-pub mod ipc;
+pub mod executee;
+pub mod executor;

--- a/basesandbox/src/execution/executee.rs
+++ b/basesandbox/src/execution/executee.rs
@@ -1,0 +1,41 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::ipc::*;
+
+// Interface for the sandboxee written in Rust
+pub struct Context<T: Ipc> {
+    /// ipc will be given with Some, but module may take it
+    /// However, the ipc must be return back here before the module terminates
+    pub ipc: Option<T>,
+}
+
+pub fn start<T: Ipc>(mut args: Vec<String>) -> Context<T> {
+    let ipc = T::new(hex::decode(args.remove(1)).unwrap());
+    ipc.send(b"#INIT\0");
+    Context {
+        ipc: Some(ipc),
+    }
+}
+
+impl<T: Ipc> Context<T> {
+    /// Tell the executor that I will exit asap after this byebye handshake.
+    pub fn terminate(self) {
+        let ipc = self.ipc.unwrap();
+        ipc.send(b"#TERMINATE\0");
+        assert_eq!(ipc.recv(Some(std::time::Duration::from_millis(1000))).unwrap(), b"#TERMINATE\0");
+    }
+}

--- a/basesandbox/src/execution/executor.rs
+++ b/basesandbox/src/execution/executor.rs
@@ -1,0 +1,137 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::ipc::*;
+use once_cell::sync::OnceCell;
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+pub trait Executor: Send {
+    fn new(path: &str, args: &[&str]) -> Self;
+    fn join(&mut self);
+}
+
+pub struct Executable {
+    child: std::process::Child,
+}
+
+impl Executor for Executable {
+    fn new(path: &str, args: &[&str]) -> Self {
+        let mut command = Command::new(path);
+        command.args(args);
+        Executable {
+            child: command.spawn().unwrap(),
+        }
+    }
+
+    fn join(&mut self) {
+        // This is synchronized with excutee's signal (#TERMINATE),
+        // which is supposed to be sent in termination step.
+        // Thus, in normal case, it won't take much time to be in a waitable status.
+        // However a malicous excutee might send a signal arbitrarily before the termination.
+        // For that, we have a timeout for the wait.
+        for _ in 0..10 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            if self.child.try_wait().unwrap().is_some() {
+                return // successful
+            }
+        }
+        panic!("Module hasn't terminated itself. Protocol Error")
+    }
+}
+
+/// This is for the intra-process tasks. You can register a runnable function,
+/// and it will be executed later as an instance of 'process' (which is actually not).
+pub type ThreadAsProcesss = Arc<dyn Fn(Vec<String>) -> () + Send + Sync>;
+
+static POOL: OnceCell<RwLock<HashMap<String, ThreadAsProcesss>>> = OnceCell::new();
+
+fn get_function_pool(key: &str) -> ThreadAsProcesss {
+    POOL.get_or_init(|| RwLock::new(HashMap::new())).read().unwrap().get(key).unwrap().clone()
+}
+
+pub fn add_function_pool(key: String, f: ThreadAsProcesss) {
+    assert!(POOL.get_or_init(|| RwLock::new(HashMap::new())).write().unwrap().insert(key, f).is_none());
+}
+
+pub struct PlainThread {
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Executor for PlainThread {
+    fn new(path: &str, args: &[&str]) -> Self {
+        let path = path.to_owned();
+        let mut args: Vec<String> = args.iter().map(|&x| x.to_string()).collect();
+        args.insert(0, "Thread".to_owned()); // corresponding to program path
+        let handle = std::thread::spawn(move || get_function_pool(&path)(args));
+
+        PlainThread {
+            handle: Some(handle),
+        }
+    }
+
+    fn join(&mut self) {
+        // PlainThread Executor is for test, so no worry for malicous unresponsiveness
+        self.handle.take().unwrap().join().unwrap();
+    }
+}
+
+/// Rust doesn't allow Drop for trait, so we need this. See E0120
+struct ExecutorDropper<T: Executor> {
+    executor: T,
+}
+
+impl<T: Executor> Drop for ExecutorDropper<T> {
+    fn drop(&mut self) {
+        self.executor.join();
+    }
+}
+
+/// declaration order of fields is important because of Drop dependencies
+pub struct Context<T: Ipc, E: Executor> {
+    pub ipc: T,
+    _child: ExecutorDropper<E>,
+}
+
+/// id must be unique for each instance.
+pub fn execute<T: Ipc + 'static, E: Executor>(path: &str) -> Result<Context<T, E>, String> {
+    let (config_server, config_client) = T::arguments_for_both_ends();
+    let ipc = std::thread::spawn(move || T::new(config_server));
+    let config_client = hex::encode(&config_client);
+    let args: Vec<&str> = vec![&config_client];
+    let child = ExecutorDropper {
+        executor: Executor::new(path, &args),
+    };
+    let ipc = ipc.join().unwrap();
+    let ping = ipc.recv(Some(Duration::from_millis(1000))).unwrap();
+    assert_eq!(ping, b"#INIT\0");
+    Ok(Context {
+        ipc,
+        _child: child,
+    })
+}
+
+impl<T: Ipc, E: Executor> Context<T, E> {
+    /// Call this when you're sure that the excutee is ready to teminate; i.e.
+    /// it will call excutee::terminate() asap.
+    pub fn terminate(self) {
+        let signal = self.ipc.recv(Some(Duration::from_millis(1000))).unwrap();
+        assert_eq!(signal, b"#TERMINATE\0");
+        self.ipc.send(b"#TERMINATE\0");
+    }
+}

--- a/basesandbox/src/ipc.rs
+++ b/basesandbox/src/ipc.rs
@@ -1,0 +1,75 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use once_cell::sync::OnceCell;
+use parking_lot::Mutex;
+
+pub trait IpcSend: Send {
+    /// It might block until counterparty's recv(). Even if not, the order is still guaranteed.
+    fn send(&self, data: &[u8]);
+}
+
+#[derive(Debug, PartialEq)]
+pub enum RecvError {
+    TimeOut,
+    Termination,
+}
+
+pub trait Terminate: Send {
+    /// Wake up block on recv with a special flag
+    fn terminate(&self);
+}
+
+pub trait IpcRecv: Send {
+    type Terminator: Terminate;
+
+    /// Returns Err only for the timeout or termination wake-up(otherwise panic)
+    fn recv(&self, timeout: Option<std::time::Duration>) -> Result<Vec<u8>, RecvError>;
+    /// Create a terminate switch that can be sent to another thread
+    fn create_terminator(&self) -> Self::Terminator;
+}
+
+pub trait Ipc: IpcSend + IpcRecv {
+    /// Generate two configurations
+    /// which will be feeded to Ipc::new(),
+    /// for both two ends in two different processes, to initialize each IPC end.
+    /// Note that both sides' new() must be called concurrently; they will be completed only if
+    /// both run at the same time.
+    fn arguments_for_both_ends() -> (Vec<u8>, Vec<u8>);
+
+    type SendHalf: IpcSend;
+    type RecvHalf: IpcRecv;
+
+    /// Constructs itself with an opaque data that would have been transported by some IPC
+    fn new(data: Vec<u8>) -> Self;
+    /// split itself into Send-only and Recv-only. This is helpful for a threading
+    /// When you design both halves, you might consider who's in charge of cleaning up things.
+    /// Common implementation is making both to have Arc<SomethingDroppable>.
+    fn split(self) -> (Self::SendHalf, Self::RecvHalf);
+}
+
+/// Most of IPC depends on a system-wide name, which looks quite vulnerable for
+/// possible attack. Rather, generating a random name would be more secure.
+pub fn generate_random_name() -> String {
+    static MONOTONIC: OnceCell<Mutex<u64>> = OnceCell::new();
+    let mut mono = MONOTONIC.get_or_init(|| Mutex::new(0)).lock();
+    *mono += 1;
+    let mono = *mono;
+    let pid = std::process::id();
+    let time = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap();
+    let hash = ccrypto::blake256(format!("{:?}{}{}", time, pid, mono));
+    format!("{:?}", hash)[0..16].to_string()
+}

--- a/basesandbox/src/ipc.rs
+++ b/basesandbox/src/ipc.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+pub mod domain_socket;
+
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 

--- a/basesandbox/src/ipc.rs
+++ b/basesandbox/src/ipc.rs
@@ -16,6 +16,7 @@
 
 pub mod domain_socket;
 pub mod intra;
+pub mod multiplex;
 
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;

--- a/basesandbox/src/ipc.rs
+++ b/basesandbox/src/ipc.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 pub mod domain_socket;
+pub mod intra;
 
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;

--- a/basesandbox/src/ipc/domain_socket.rs
+++ b/basesandbox/src/ipc/domain_socket.rs
@@ -1,0 +1,162 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+use std::cell::RefCell;
+use std::os::unix::net::UnixDatagram;
+use std::sync::Arc;
+
+// TODO: Use stream instead of datagram.
+struct SocketInternal(UnixDatagram, String);
+
+impl Drop for SocketInternal {
+    fn drop(&mut self) {
+        std::fs::remove_file(&self.1).unwrap();
+    }
+}
+
+pub struct DomainSocketSend {
+    socket: Arc<SocketInternal>,
+}
+
+impl IpcSend for DomainSocketSend {
+    fn send(&self, data: &[u8]) {
+        assert_eq!(self.socket.0.send(data).unwrap(), data.len());
+    }
+}
+
+pub struct DomainSocketRecv {
+    socket: Arc<SocketInternal>,
+    buffer: RefCell<Vec<u8>>,
+}
+
+impl IpcRecv for DomainSocketRecv {
+    type Terminator = Terminator;
+
+    fn recv(&self, timeout: Option<std::time::Duration>) -> Result<Vec<u8>, RecvError> {
+        self.socket.0.set_read_timeout(timeout).unwrap();
+        let count = self.socket.0.recv(&mut self.buffer.borrow_mut()).unwrap();
+        assert!(count < self.buffer.borrow().len(), "Unix datagram got data larger than the buffer.");
+        if count == 0 {
+            return Err(RecvError::Termination)
+        }
+        Ok(self.buffer.borrow()[0..count].to_vec())
+    }
+
+    fn create_terminator(&self) -> Self::Terminator {
+        Terminator(self.socket.clone())
+    }
+}
+
+pub struct Terminator(Arc<SocketInternal>);
+
+impl Terminate for Terminator {
+    fn terminate(&self) {
+        if let Err(e) = (self.0).0.shutdown(std::net::Shutdown::Both) {
+            assert_eq!(e.kind(), std::io::ErrorKind::NotConnected);
+        }
+    }
+}
+
+pub struct DomainSocket {
+    send: DomainSocketSend,
+    recv: DomainSocketRecv,
+}
+
+impl IpcSend for DomainSocket {
+    fn send(&self, data: &[u8]) {
+        self.send.send(data)
+    }
+}
+
+impl IpcRecv for DomainSocket {
+    type Terminator = Terminator;
+
+    fn recv(&self, timeout: Option<std::time::Duration>) -> Result<Vec<u8>, RecvError> {
+        self.recv.recv(timeout)
+    }
+
+    fn create_terminator(&self) -> Self::Terminator {
+        self.recv.create_terminator()
+    }
+}
+
+impl Ipc for DomainSocket {
+    fn arguments_for_both_ends() -> (Vec<u8>, Vec<u8>) {
+        let address_server = format!("{}/{}", std::env::temp_dir().to_str().unwrap(), generate_random_name());
+        let address_client = format!("{}/{}", std::env::temp_dir().to_str().unwrap(), generate_random_name());
+        (
+            serde_cbor::to_vec(&(true, &address_server, &address_client)).unwrap(),
+            serde_cbor::to_vec(&(false, &address_client, &address_server)).unwrap(),
+        )
+    }
+
+    type SendHalf = DomainSocketSend;
+    type RecvHalf = DomainSocketRecv;
+
+    fn new(data: Vec<u8>) -> Self {
+        let (am_i_server, address_src, address_dst): (bool, String, String) = serde_cbor::from_slice(&data).unwrap();
+        let socket = UnixDatagram::bind(&address_src).unwrap();
+        let mut success = false;
+
+        for _ in 0..100 {
+            if socket.connect(&address_dst).is_ok() {
+                success = true;
+                break
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(success, "Failed to establish domain socket");
+        socket.set_write_timeout(None).unwrap();
+        socket.set_nonblocking(false).unwrap();
+
+        // Handshake
+        if am_i_server {
+            socket.set_read_timeout(Some(std::time::Duration::from_millis(100))).unwrap();
+            let mut buf = [0 as u8; 32];
+            let count = socket.recv(&mut buf).unwrap();
+            assert_eq!(count, 3);
+            assert_eq!(&buf[0..3], b"hey");
+            socket.send(b"hello").unwrap();
+            let count = socket.recv(&mut buf).unwrap();
+            assert_eq!(count, 2);
+            assert_eq!(&buf[0..2], b"hi");
+        } else {
+            socket.send(b"hey").unwrap();
+            socket.set_read_timeout(Some(std::time::Duration::from_millis(100))).unwrap();
+            let mut buf = [0 as u8; 32];
+            let count = socket.recv(&mut buf).unwrap();
+            assert_eq!(count, 5);
+            assert_eq!(&buf[0..5], b"hello");
+            socket.send(b"hi").unwrap();
+        }
+
+        let socket = Arc::new(SocketInternal(socket, address_src));
+        DomainSocket {
+            send: DomainSocketSend {
+                socket: socket.clone(),
+            },
+            recv: DomainSocketRecv {
+                socket,
+                buffer: RefCell::new(vec![0; 1024 * 8 + 1]),
+            },
+        }
+    }
+
+    fn split(self) -> (Self::SendHalf, Self::RecvHalf) {
+        (self.send, self.recv)
+    }
+}

--- a/basesandbox/src/ipc/intra.rs
+++ b/basesandbox/src/ipc/intra.rs
@@ -1,0 +1,175 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+use crossbeam::channel::{bounded, Receiver, RecvTimeoutError, Sender};
+use once_cell::sync::OnceCell;
+use parking_lot::Mutex;
+use std::collections::hash_map::HashMap;
+
+struct RegisteredIpcEnds {
+    is_server: bool,
+    send: Sender<Vec<u8>>,
+    recv: Receiver<Vec<u8>>,
+    /// One copy of Counterparty's Send end
+    send_for_termination: Sender<Vec<u8>>,
+}
+
+static POOL: OnceCell<Mutex<HashMap<String, RegisteredIpcEnds>>> = OnceCell::new();
+fn get_pool_raw() -> &'static Mutex<HashMap<String, RegisteredIpcEnds>> {
+    POOL.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn add_ends(key: String, ends: RegisteredIpcEnds) {
+    assert!(get_pool_raw().lock().insert(key, ends).is_none())
+}
+
+fn take_ends(key: &str) -> RegisteredIpcEnds {
+    get_pool_raw().lock().remove(key).unwrap()
+}
+
+pub struct IntraSend(Sender<Vec<u8>>);
+
+impl IpcSend for IntraSend {
+    fn send(&self, data: &[u8]) {
+        self.0.send(data.to_vec()).unwrap()
+    }
+}
+
+pub struct IntraRecv(Receiver<Vec<u8>>, Sender<Vec<u8>>);
+
+pub struct Terminator(Sender<Vec<u8>>);
+
+impl Terminate for Terminator {
+    fn terminate(&self) {
+        self.0.send([].to_vec()).unwrap();
+    }
+}
+
+impl IpcRecv for IntraRecv {
+    type Terminator = Terminator;
+
+    fn recv(&self, timeout: Option<std::time::Duration>) -> Result<Vec<u8>, RecvError> {
+        let x = if let Some(t) = timeout {
+            self.0.recv_timeout(t).map_err(|e| {
+                if e == RecvTimeoutError::Timeout {
+                    RecvError::TimeOut
+                } else {
+                    panic!()
+                }
+            })
+        } else {
+            Ok(self.0.recv().unwrap())
+        }?;
+
+        if x.is_empty() {
+            return Err(RecvError::Termination)
+        }
+        Ok(x)
+    }
+
+    fn create_terminator(&self) -> Self::Terminator {
+        Terminator(self.1.clone())
+    }
+}
+
+/// This acts like an IPC, but is actually an intra-process communication.
+/// It will be useful when you have to simulate IPC, but the two ends don't have
+/// to be actually in separated processes.
+pub struct Intra {
+    send: IntraSend,
+    recv: IntraRecv,
+}
+
+impl IpcSend for Intra {
+    fn send(&self, data: &[u8]) {
+        self.send.send(data)
+    }
+}
+
+impl IpcRecv for Intra {
+    type Terminator = Terminator;
+
+    fn recv(&self, timeout: Option<std::time::Duration>) -> Result<Vec<u8>, RecvError> {
+        self.recv.recv(timeout)
+    }
+
+    fn create_terminator(&self) -> Self::Terminator {
+        self.recv.create_terminator()
+    }
+}
+
+impl Ipc for Intra {
+    fn arguments_for_both_ends() -> (Vec<u8>, Vec<u8>) {
+        let key_server = generate_random_name();
+        let key_client = generate_random_name();
+
+        let (send_server, recv_client) = bounded(256);
+        let (send_client, recv_server) = bounded(256);
+
+        add_ends(key_server.clone(), RegisteredIpcEnds {
+            is_server: true,
+            send: send_server.clone(),
+            recv: recv_server,
+            send_for_termination: send_client.clone(),
+        });
+        add_ends(key_client.clone(), RegisteredIpcEnds {
+            is_server: false,
+            send: send_client,
+            recv: recv_client,
+            send_for_termination: send_server,
+        });
+
+        (serde_cbor::to_vec(&key_server).unwrap(), serde_cbor::to_vec(&key_client).unwrap())
+    }
+
+    type SendHalf = IntraSend;
+    type RecvHalf = IntraRecv;
+
+    fn new(data: Vec<u8>) -> Self {
+        let key: String = serde_cbor::from_slice(&data).unwrap();
+        let RegisteredIpcEnds {
+            is_server,
+            send,
+            recv,
+            send_for_termination,
+        } = take_ends(&key);
+
+        // Handshake
+        let timeout = std::time::Duration::from_millis(1000);
+        if is_server {
+            let x = recv.recv_timeout(timeout).unwrap();
+            assert_eq!(x, b"hey");
+            send.send(b"hello".to_vec()).unwrap();
+            let x = recv.recv_timeout(timeout).unwrap();
+            assert_eq!(x, b"hi");
+        } else {
+            send.send(b"hey".to_vec()).unwrap();
+            let x = recv.recv().unwrap();
+            assert_eq!(x, b"hello");
+            send.send(b"hi".to_vec()).unwrap();
+        }
+
+        Intra {
+            send: IntraSend(send),
+            recv: IntraRecv(recv, send_for_termination),
+        }
+    }
+
+    fn split(self) -> (Self::SendHalf, Self::RecvHalf) {
+        (self.send, self.recv)
+    }
+}

--- a/basesandbox/src/ipc/multiplex.rs
+++ b/basesandbox/src/ipc/multiplex.rs
@@ -1,0 +1,101 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::{IpcRecv, IpcSend, RecvError, Terminate};
+use crossbeam::channel::bounded;
+use parking_lot::Mutex;
+use std::thread;
+
+type Sender = crossbeam::channel::Sender<Vec<u8>>;
+type Receiver = crossbeam::channel::Receiver<Vec<u8>>;
+
+pub trait Forward {
+    fn forward(data: &[u8]) -> usize;
+}
+
+fn sender<S: IpcSend>(send: S, recv: Receiver) {
+    loop {
+        let data = recv.recv().unwrap();
+        // special exit flag
+        if data.is_empty() {
+            break
+        }
+        send.send(&data);
+    }
+}
+
+fn receiver<F: Forward, R: IpcRecv>(recv: R, send: Vec<Sender>) {
+    loop {
+        let data = match recv.recv(None) {
+            Err(RecvError::TimeOut) => panic!(),
+            Err(RecvError::Termination) => return,
+            Ok(x) => x,
+        };
+        send[F::forward(&data)].send(data).unwrap();
+    }
+}
+
+pub struct Multiplexer {
+    sender_thread: Option<thread::JoinHandle<()>>,
+    receiver_thread: Option<thread::JoinHandle<()>>,
+    /// Here Mutex is used to make the Multiplxer Sync, while dyn Terminate isn't.
+    termiantor: Option<Mutex<Box<dyn Terminate>>>,
+    sender_send: Sender, // will convey the flag of termination
+}
+
+impl Multiplexer {
+    pub fn create<F: Forward, S: IpcSend + 'static, R: IpcRecv + 'static>(
+        ipc_send: S,
+        ipc_recv: R,
+        multiplex: usize,
+        channel_capacity: usize,
+    ) -> (Vec<(Sender, Receiver)>, Self) {
+        let (sender_send, sender_recv) = bounded(channel_capacity);
+        let mut receiver_sends = Vec::<Sender>::new();
+        let mut channel_ends = Vec::<(Sender, Receiver)>::new();
+        let termiantor: Option<Mutex<Box<dyn Terminate>>> = Some(Mutex::new(Box::new(ipc_recv.create_terminator())));
+
+        for _ in 0..multiplex {
+            let (send, recv) = bounded(channel_capacity);
+            channel_ends.push((sender_send.clone(), recv));
+            receiver_sends.push(send);
+        }
+
+        let sender_thread = thread::spawn(move || {
+            sender(ipc_send, sender_recv);
+        });
+
+        let receiver_thread = thread::spawn(move || {
+            receiver::<F, R>(ipc_recv, receiver_sends);
+        });
+
+        (channel_ends, Multiplexer {
+            sender_thread: Some(sender_thread),
+            receiver_thread: Some(receiver_thread),
+            termiantor,
+            sender_send,
+        })
+    }
+}
+
+impl Drop for Multiplexer {
+    fn drop(&mut self) {
+        self.termiantor.take().unwrap().into_inner().terminate();
+        self.sender_send.send(Vec::new()).unwrap();
+        self.receiver_thread.take().unwrap().join().unwrap();
+        self.sender_thread.take().unwrap().join().unwrap();
+    }
+}

--- a/basesandbox/src/lib.rs
+++ b/basesandbox/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/basesandbox/src/lib.rs
+++ b/basesandbox/src/lib.rs
@@ -13,3 +13,5 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pub mod ipc;

--- a/basesandbox/tests/intergration_test.rs
+++ b/basesandbox/tests/intergration_test.rs
@@ -1,0 +1,263 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+extern crate codechain_basesandbox as cbsb;
+
+use cbsb::execution::executee;
+use cbsb::execution::executor;
+use cbsb::ipc::domain_socket::DomainSocket;
+use cbsb::ipc::intra::Intra;
+use cbsb::ipc::multiplex::{Forward, Multiplexer};
+use cbsb::ipc::Ipc;
+use cbsb::ipc::{IpcRecv, IpcSend, Terminate};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+// CI server is really slow for this. Usually 10 is ok.
+const TIMEOUT: std::time::Duration = std::time::Duration::from_millis(10000);
+
+fn simple_thread(args: Vec<String>) {
+    let ctx = executee::start::<Intra>(args);
+    let r = ctx.ipc.as_ref().unwrap().recv(Some(TIMEOUT)).unwrap();
+    assert_eq!(r, b"Hello?\0");
+    ctx.ipc.as_ref().unwrap().send(b"I'm here!\0");
+    ctx.terminate();
+}
+
+fn simple_executor<I: Ipc + 'static, E: executor::Executor>(path: &str) {
+    let ctx = executor::execute::<I, E>(path).unwrap();
+    ctx.ipc.send(b"Hello?\0");
+    let r = ctx.ipc.recv(Some(TIMEOUT)).unwrap();
+    assert_eq!(r, b"I'm here!\0");
+    ctx.terminate();
+}
+
+#[test]
+fn execute_simple_rust() {
+    simple_executor::<DomainSocket, executor::Executable>("./../target/debug/test_simple_rs");
+}
+
+#[test]
+fn execute_simple_intra() {
+    // Note that cargo unit tests might share global static variable.
+    // You must use unique name per execution
+    let name = cbsb::ipc::generate_random_name();
+    executor::add_function_pool(name.clone(), Arc::new(simple_thread));
+    simple_executor::<Intra, executor::PlainThread>(&name);
+}
+
+#[test]
+fn execute_simple_multiple() {
+    let name_source = cbsb::ipc::generate_random_name();
+    executor::add_function_pool(name_source.clone(), Arc::new(simple_thread));
+
+    let t1 =
+        thread::spawn(|| simple_executor::<DomainSocket, executor::Executable>("./../target/debug/test_simple_rs"));
+    let t2 =
+        thread::spawn(|| simple_executor::<DomainSocket, executor::Executable>("./../target/debug/test_simple_rs"));
+    let t3 =
+        thread::spawn(|| simple_executor::<DomainSocket, executor::Executable>("./../target/debug/test_simple_rs"));
+
+    let name = name_source.clone();
+    let t4 = thread::spawn(move || simple_executor::<Intra, executor::PlainThread>(&name));
+    let name = name_source.clone();
+    let t5 = thread::spawn(move || simple_executor::<Intra, executor::PlainThread>(&name));
+    let name = name_source;
+    let t6 = thread::spawn(move || simple_executor::<Intra, executor::PlainThread>(&name));
+
+    t1.join().unwrap();
+    t2.join().unwrap();
+    t3.join().unwrap();
+    t4.join().unwrap();
+    t5.join().unwrap();
+    t6.join().unwrap();
+}
+
+#[test]
+fn execute_simple_intra_complicated() {
+    let name = cbsb::ipc::generate_random_name();
+    executor::add_function_pool(name.clone(), Arc::new(simple_thread));
+    let ctx1 = executor::execute::<Intra, executor::PlainThread>(&name).unwrap();
+    let ctx2 = executor::execute::<Intra, executor::PlainThread>(&name).unwrap();
+
+    ctx2.ipc.send(b"Hello?\0");
+    ctx1.ipc.send(b"Hello?\0");
+
+    let r = ctx1.ipc.recv(Some(TIMEOUT)).unwrap();
+    assert_eq!(r, b"I'm here!\0");
+    let r = ctx2.ipc.recv(Some(TIMEOUT)).unwrap();
+    assert_eq!(r, b"I'm here!\0");
+
+    ctx1.terminate();
+    ctx2.terminate();
+}
+
+#[test]
+fn execute_simple_intra_massive() {
+    let name = cbsb::ipc::generate_random_name();
+    executor::add_function_pool(name.clone(), Arc::new(simple_thread));
+
+    let mut threads = Vec::new();
+    for _ in 0..32 {
+        let name = name.clone();
+        threads.push(thread::spawn(move || {
+            let mut ctxs = Vec::new();
+            for _ in 0..32 {
+                ctxs.push(executor::execute::<Intra, executor::PlainThread>(&name).unwrap());
+            }
+
+            for ctx in &ctxs {
+                ctx.ipc.send(b"Hello?\0");
+            }
+
+            for ctx in &ctxs {
+                let r = ctx.ipc.recv(Some(TIMEOUT)).unwrap();
+                assert_eq!(r, b"I'm here!\0");
+            }
+
+            while let Some(x) = ctxs.pop() {
+                x.terminate();
+            }
+        }))
+    }
+
+    while let Some(x) = threads.pop() {
+        x.join().unwrap();
+    }
+}
+
+fn setup_ipc<I: Ipc + 'static>() -> (I, I) {
+    let (c1, c2) = I::arguments_for_both_ends();
+    let d1 = thread::spawn(|| I::new(c1));
+    let d2 = I::new(c2);
+    let d1 = d1.join().unwrap();
+    (d1, d2)
+}
+
+#[test]
+fn terminator_socket() {
+    let (d1, d2) = setup_ipc::<DomainSocket>();
+    let terminator = d1.create_terminator();
+    let barrier = Arc::new(Barrier::new(2));
+    let barrier_ = barrier.clone();
+    let t = thread::spawn(move || {
+        assert_eq!(d1.recv(None).unwrap(), vec![1, 2, 3]);
+        barrier_.wait();
+        assert_eq!(d1.recv(None).unwrap_err(), cbsb::ipc::RecvError::Termination)
+    });
+    d2.send(&[1, 2, 3]);
+    barrier.wait();
+    terminator.terminate();
+    t.join().unwrap();
+}
+
+#[test]
+fn terminator_intra() {
+    let (d1, d2) = setup_ipc::<Intra>();
+    let terminator = d1.create_terminator();
+    let barrier = Arc::new(Barrier::new(2));
+    let barrier_ = barrier.clone();
+    let t = thread::spawn(move || {
+        assert_eq!(d1.recv(None).unwrap(), vec![1, 2, 3]);
+        barrier_.wait();
+        assert_eq!(d1.recv(None).unwrap_err(), cbsb::ipc::RecvError::Termination)
+    });
+    d2.send(&[1, 2, 3]);
+    barrier.wait();
+    terminator.terminate();
+    t.join().unwrap();
+}
+
+/// DomainSocket send must be a blocking operation; if not then this bursting traffic
+/// will make the send() cause the "Resource temporarily unavailable" error.
+#[test]
+fn socket_must_block() {
+    let n = 200;
+    let packet_size = 3000;
+    let (d1, d2) = setup_ipc::<DomainSocket>();
+    let terminator = d1.create_terminator();
+    let barrier = Arc::new(Barrier::new(2));
+    let barrier_ = barrier.clone();
+    let t = thread::spawn(move || {
+        for i in 0..n {
+            let r = d1.recv(None).unwrap();
+            assert!(r.iter().all(|&x| x == (i % 256) as u8));
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        barrier_.wait();
+        assert_eq!(d1.recv(None).unwrap_err(), cbsb::ipc::RecvError::Termination);
+    });
+    for i in 0..n {
+        let mut data = Vec::<u8>::with_capacity(packet_size);
+        for _ in 0..packet_size {
+            data.push((i % 256) as u8);
+        }
+        d2.send(&data);
+    }
+    barrier.wait();
+    terminator.terminate();
+    t.join().unwrap();
+}
+
+struct TestForward;
+
+impl Forward for TestForward {
+    fn forward(data: &[u8]) -> usize {
+        if data[0] == b'0' {
+            0
+        } else {
+            1
+        }
+    }
+}
+
+#[test]
+fn multiplexer() {
+    let (c1, c2) = DomainSocket::arguments_for_both_ends();
+    let d1 = thread::spawn(|| DomainSocket::new(c1));
+    let d2 = DomainSocket::new(c2);
+    let d1 = d1.join().unwrap();
+
+    let (s1, r1) = d1.split();
+    let (s2, r2) = d2.split();
+
+    let (mut multiplexed1, multiplxer1) = Multiplexer::create::<TestForward, _, _>(s1, r1, 2, 100);
+    let (mut multiplexed2, multiplxer2) = Multiplexer::create::<TestForward, _, _>(s2, r2, 2, 100);
+
+    // multiplxed channel 1
+    let (s1_1, r1_1) = multiplexed1.pop().unwrap();
+    let (s2_1, r2_1) = multiplexed2.pop().unwrap();
+
+    // multiplxed channel 0
+    let (s1_2, r1_2) = multiplexed1.pop().unwrap();
+    let (s2_2, r2_2) = multiplexed2.pop().unwrap();
+
+    s1_1.send(b"11".to_vec()).unwrap();
+    assert_eq!(r2_1.recv().unwrap(), b"11");
+
+    s2_1.send(b"12".to_vec()).unwrap();
+    assert_eq!(r1_1.recv().unwrap(), b"12");
+
+    s2_2.send(b"03".to_vec()).unwrap();
+    assert_eq!(r1_2.recv().unwrap(), b"03");
+
+    s1_2.send(b"04".to_vec()).unwrap();
+    assert_eq!(r2_2.recv().unwrap(), b"04");
+
+    // we have to drop the multiplexer itself first
+    drop(multiplxer1);
+    drop(multiplxer2);
+}

--- a/basesandbox/tests/simple/simple.rs
+++ b/basesandbox/tests/simple/simple.rs
@@ -14,5 +14,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pub mod execution;
-pub mod ipc;
+extern crate codechain_basesandbox as cbsb;
+use cbsb::execution::executee;
+use cbsb::ipc::domain_socket::DomainSocket;
+use cbsb::ipc::{IpcRecv, IpcSend};
+use std::time::Duration;
+
+#[cfg(all(unix, target_arch = "x86_64"))]
+fn main() -> Result<(), String> {
+    let args = std::env::args().collect();
+    let ctx = executee::start::<DomainSocket>(args);
+    let r = ctx.ipc.as_ref().unwrap().recv(Some(Duration::from_millis(100))).unwrap();
+    assert_eq!(r, b"Hello?\0");
+    ctx.ipc.as_ref().unwrap().send(b"I'm here!\0");
+    ctx.terminate();
+    Ok(())
+}


### PR DESCRIPTION
This PR includes
- 08dcaed34 Assure domain socket's blocking send()
- 08c1c30b6 Refactor common ipc setup
- 081effa42 Allow NotConnected error in socket shutdown
- 815be21c4 Make Executor Send
- 3e54d0f1b Add test for multiplexer
- b44874a0a Implement IPC multiplexer
- 1440f5502 Do not allow duplicated registeration for add_function_pool()
- 64826efd8 Delete explicit socket shutdown
- 13d288875 Make timeouts generous
- 6c151899e Enhance termination protocol of basesandbox execution
- a15abae1a Fix intra to use right terminator
- 4867497e3 Add tests for IPC termination
- 5d75699a2 Add handshake for Intra
- 18152c71e Make executor establish IPC concurrently
- ac5c9c8b2 Add handshake for domain socket constructor
- f93dcdd79 Make domain socket use connect()
- 7a3650943 Change IPC establishment condition
- 6bbac9b85 Move simple.rs from /tests to /tests/simple
- fa38e864e Add a threaded test for Intra
- c0e168b37 Fix the random name generator for IPC
- 120c4ea05 Implement tests for IPC
- a8994ae36 Implement execution of process
- 1df3f4920 Implement intra-process communication that complies IPC interface
- 784b57c18 Implement domain socket
- bc31aa53b Implement abstracted interface of IPC

I reordered and squashed them.