### PR TITLE
Add Coordinator to the master branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "backtrace"
@@ -687,6 +687,10 @@ dependencies = [
  "time",
  "url 1.7.2",
 ]
+
+[[package]]
+name = "coordinator"
+version = "0.1.0"
 
 [[package]]
 name = "core-foundation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,7 @@ dependencies = [
 name = "coordinator"
 version = "0.1.0"
 dependencies = [
+ "codechain-crypto",
  "codechain-types",
  "primitives",
  "rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,11 @@ dependencies = [
 [[package]]
 name = "coordinator"
 version = "0.1.0"
+dependencies = [
+ "codechain-types",
+ "primitives",
+ "rlp",
+]
 
 [[package]]
 name = "core-foundation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,7 @@ name = "coordinator"
 version = "0.1.0"
 dependencies = [
  "codechain-crypto",
+ "codechain-key",
  "codechain-types",
  "primitives",
  "rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,5 @@ members = [
     "informer_courier",
     "sync",
     "types",
+    "coordinator"
 ]

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "coordinator"
+version = "0.1.0"
+authors = ["CodeChain Team <hi@codechain.io>"]
+edition = "2018"
+
+[dependencies]

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["CodeChain Team <hi@codechain.io>"]
 edition = "2018"
 
 [dependencies]
+ccrypto = { package = "codechain-crypto", git = "https://github.com/CodeChain-io/rust-codechain-crypto.git", version = "0.2" }
 ctypes = { package = "codechain-types", path = "../types" }
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
 rlp = { git = "https://github.com/CodeChain-io/rlp.git", version = "0.4" }

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 ccrypto = { package = "codechain-crypto", git = "https://github.com/CodeChain-io/rust-codechain-crypto.git", version = "0.2" }
+ckey = {package = "codechain-key", path = "../key" }
 ctypes = { package = "codechain-types", path = "../types" }
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
 rlp = { git = "https://github.com/CodeChain-io/rlp.git", version = "0.4" }

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -5,3 +5,6 @@ authors = ["CodeChain Team <hi@codechain.io>"]
 edition = "2018"
 
 [dependencies]
+ctypes = { package = "codechain-types", path = "../types" }
+primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
+rlp = { git = "https://github.com/CodeChain-io/rlp.git", version = "0.4" }

--- a/coordinator/src/context.rs
+++ b/coordinator/src/context.rs
@@ -1,0 +1,18 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/// A `Context` provides the interface against the system services such as
+pub trait Context {}

--- a/coordinator/src/context/chain_history_access.rs
+++ b/coordinator/src/context/chain_history_access.rs
@@ -14,16 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-mod chain_history_access;
-mod mem_pool_access;
-mod storage_access;
-mod sub_storage_access;
+use crate::header::Header;
+use ctypes::BlockId;
 
-pub use chain_history_access::ChainHistoryAccess;
-pub use mem_pool_access::MemPoolAccess;
-pub use storage_access::StorageAccess;
-pub use sub_storage_access::SubStorageAccess;
-
-/// A `Context` provides the interface against the system services such as moulde substorage access,
-/// mempool access
-pub trait Context: SubStorageAccess + MemPoolAccess {}
+pub trait ChainHistoryAccess {
+    fn get_block_header(&self, block_id: BlockId) -> Option<Header>;
+}

--- a/coordinator/src/context/mem_pool_access.rs
+++ b/coordinator/src/context/mem_pool_access.rs
@@ -14,14 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-mod mem_pool_access;
-mod storage_access;
-mod sub_storage_access;
+use crate::transaction::Transaction;
+use ctypes::TxHash;
 
-pub use mem_pool_access::MemPoolAccess;
-pub use storage_access::StorageAccess;
-pub use sub_storage_access::SubStorageAccess;
-
-/// A `Context` provides the interface against the system services such as moulde substorage access,
-/// mempool access
-pub trait Context: SubStorageAccess + MemPoolAccess {}
+pub trait MemPoolAccess {
+    fn inject_transactions(&self, txs: Vec<Transaction>) -> Vec<Result<TxHash, String>>;
+}

--- a/coordinator/src/context/storage_access.rs
+++ b/coordinator/src/context/storage_access.rs
@@ -14,10 +14,22 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-mod storage_access;
-mod sub_storage_access;
+pub use ctypes::StorageId;
 
-pub use storage_access::StorageAccess;
-pub use sub_storage_access::SubStorageAccess;
+pub type Key = dyn AsRef<[u8]>;
+pub type Value = Vec<u8>;
 
-pub trait Context: SubStorageAccess {}
+// Interface between host and the coordinator
+pub trait StorageAccess {
+    fn get(&self, storage_id: StorageId, key: &Key) -> Option<Value>;
+    fn set(&mut self, storage_id: StorageId, key: &Key, value: Value);
+    fn has(&self, storage_id: StorageId, key: &Key) -> bool;
+    fn remove(&mut self, storage_id: StorageId, key: &Key);
+
+    /// Create a recoverable checkpoint of this state
+    fn create_checkpoint(&mut self);
+    /// Revert to the last checkpoint and discard it
+    fn revert_to_the_checkpoint(&mut self);
+    /// Merge last checkpoint with the previous
+    fn discard_checkpoint(&mut self);
+}

--- a/coordinator/src/context/sub_storage_access.rs
+++ b/coordinator/src/context/sub_storage_access.rs
@@ -14,10 +14,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-mod storage_access;
-mod sub_storage_access;
+pub type Key = dyn AsRef<[u8]>;
+pub type Value = Vec<u8>;
 
-pub use storage_access::StorageAccess;
-pub use sub_storage_access::SubStorageAccess;
+// Interface between each module and the coordinator
+pub trait SubStorageAccess {
+    fn get(&self, key: &Key) -> Option<Value>;
+    fn set(&self, key: &Key, value: Value);
+    fn has(&self, key: &Key) -> bool;
+    fn remove(&self, key: &Key);
 
-pub trait Context: SubStorageAccess {}
+    /// Create a recoverable checkpoint of this state
+    fn create_checkpoint(&self);
+    /// Revert to the last checkpoint and discard it
+    fn revert_to_the_checkpoint(&self);
+    /// Merge last checkpoint with the previous
+    fn discard_checkpoint(&self);
+}

--- a/coordinator/src/header.rs
+++ b/coordinator/src/header.rs
@@ -14,33 +14,29 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pub mod context;
-mod header;
-mod transaction;
-mod types;
+use ckey::Ed25519Public as Public;
+use primitives::Bytes;
 
-use self::context::Context;
-
-/// The `Coordinator` encapsulates all the logic for a Foundry application.
-///
-/// It assembles modules and feeds them various events from the underlying
-/// consensus engine.
-pub struct Coordinator {}
-
-pub struct Builder<C: Context> {
-    _context: C,
+#[derive(Debug, Clone, PartialEq)]
+pub struct Header {
+    /// Block timestamp.
+    timestamp: u64,
+    /// Block number.
+    number: u64,
+    /// Block author.
+    author: Public,
+    /// Block extra data.
+    extra_data: Bytes,
 }
 
-impl<C: Context> Builder<C> {
+impl Header {
     #[allow(dead_code)]
-    fn new(context: C) -> Self {
-        Builder {
-            _context: context,
+    pub fn new(timestamp: u64, number: u64, author: Public, extra_data: Bytes) -> Self {
+        Self {
+            timestamp,
+            number,
+            author,
+            extra_data,
         }
-    }
-
-    #[allow(dead_code)]
-    fn build(self) -> Coordinator {
-        Coordinator {}
     }
 }

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 pub mod context;
+mod transaction;
 mod types;
 
 use self::context::Context;

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -1,0 +1,43 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pub mod context;
+
+use self::context::Context;
+
+/// The `Coordinator` encapsulates all the logic for a Foundry application.
+///
+/// It assembles modules and feeds them various events from the underlying
+/// consensus engine.
+pub struct Coordinator {}
+
+pub struct Builder<C: Context> {
+    _context: C,
+}
+
+impl<C: Context> Builder<C> {
+    #[allow(dead_code)]
+    fn new(context: C) -> Self {
+        Builder {
+            _context: context,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn build(self) -> Coordinator {
+        Coordinator {}
+    }
+}

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod context;
 mod header;
+pub mod test_coordinator;
 mod traits;
 mod transaction;
 mod types;

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -16,16 +16,76 @@
 
 pub mod context;
 mod header;
+mod traits;
 mod transaction;
 mod types;
 
-use self::context::Context;
+use self::context::{Context, StorageAccess};
+use self::header::Header;
+use self::traits::{BlockExecutor, Initializer, TxFilter};
+use self::transaction::{Transaction, TransactionWithMetadata};
+use self::types::{BlockOutcome, ErrorCode, VerifiedCrime};
+use crate::types::{CloseBlockError, ExecuteTransactionError, HeaderError, TransactionExecutionOutcome};
+use ctypes::{CompactValidatorSet, ConsensusParams};
 
 /// The `Coordinator` encapsulates all the logic for a Foundry application.
 ///
 /// It assembles modules and feeds them various events from the underlying
 /// consensus engine.
+#[derive(Default)]
 pub struct Coordinator {}
+
+impl Initializer for Coordinator {
+    fn initialize_chain(&self, _app_state: String) -> (CompactValidatorSet, ConsensusParams) {
+        unimplemented!()
+    }
+}
+
+impl BlockExecutor for Coordinator {
+    fn open_block(
+        &self,
+        _storage: &mut dyn StorageAccess,
+        _header: &Header,
+        _verified_crimes: &[VerifiedCrime],
+    ) -> Result<(), HeaderError> {
+        unimplemented!()
+    }
+
+    fn execute_transactions(
+        &self,
+        _storage: &mut dyn StorageAccess,
+        _transactions: &[Transaction],
+    ) -> Result<Vec<TransactionExecutionOutcome>, ExecuteTransactionError> {
+        unimplemented!()
+    }
+
+    fn prepare_block<'a>(
+        &self,
+        _storage: &mut dyn StorageAccess,
+        _transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
+    ) -> Vec<&'a Transaction> {
+        unimplemented!()
+    }
+
+    fn close_block(&self, _storage: &mut dyn StorageAccess) -> Result<BlockOutcome, CloseBlockError> {
+        unimplemented!()
+    }
+}
+
+impl TxFilter for Coordinator {
+    fn check_transaction(&self, _transaction: &Transaction) -> Result<(), ErrorCode> {
+        unimplemented!()
+    }
+
+    fn filter_transactions<'a>(
+        &self,
+        _transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
+        _memory_limit: Option<usize>,
+        _size_limit: Option<usize>,
+    ) -> (Vec<&'a TransactionWithMetadata>, Vec<&'a TransactionWithMetadata>) {
+        unimplemented!()
+    }
+}
 
 pub struct Builder<C: Context> {
     _context: C,

--- a/coordinator/src/test_coordinator.rs
+++ b/coordinator/src/test_coordinator.rs
@@ -1,0 +1,129 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::context::StorageAccess;
+use crate::header::Header;
+use crate::traits::{BlockExecutor, Initializer, TxFilter};
+use crate::transaction::{Transaction, TransactionWithMetadata};
+use crate::types::{
+    BlockOutcome, CloseBlockError, ErrorCode, ExecuteTransactionError, HeaderError, TransactionExecutionOutcome,
+    VerifiedCrime,
+};
+use ctypes::{CompactValidatorSet, ConsensusParams};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+// Coordinator dedicated for mempool and miner testing
+pub struct TestCoordinator {
+    validator_set: CompactValidatorSet,
+    consensus_params: ConsensusParams,
+    body_count: AtomicUsize,
+    body_size: AtomicUsize,
+}
+
+impl Default for TestCoordinator {
+    fn default() -> Self {
+        Self {
+            validator_set: Default::default(),
+            consensus_params: ConsensusParams::default_for_test(),
+            body_count: AtomicUsize::new(0),
+            body_size: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl Initializer for TestCoordinator {
+    fn initialize_chain(&self, _app_state: String) -> (CompactValidatorSet, ConsensusParams) {
+        (self.validator_set.clone(), self.consensus_params)
+    }
+}
+
+impl BlockExecutor for TestCoordinator {
+    fn open_block(
+        &self,
+        _storage: &mut dyn StorageAccess,
+        _header: &Header,
+        _verified_crime: &[VerifiedCrime],
+    ) -> Result<(), HeaderError> {
+        self.body_count.store(0, Ordering::SeqCst);
+        self.body_size.store(0, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn execute_transactions(
+        &self,
+        _storage: &mut dyn StorageAccess,
+        transactions: &[Transaction],
+    ) -> Result<Vec<TransactionExecutionOutcome>, ExecuteTransactionError> {
+        self.body_count.fetch_add(transactions.len(), Ordering::SeqCst);
+        let body_size: usize = transactions.iter().map(|tx| tx.size()).sum();
+        self.body_size.fetch_add(body_size, Ordering::SeqCst);
+        Ok((0..self.body_count.load(Ordering::SeqCst))
+            .map(|_| TransactionExecutionOutcome {
+                events: Vec::new(),
+            })
+            .collect())
+    }
+
+    fn prepare_block<'a>(
+        &self,
+        _storage: &mut dyn StorageAccess,
+        transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
+    ) -> Vec<&'a Transaction> {
+        transactions.map(|tx_with_metadata| &tx_with_metadata.tx).collect()
+    }
+
+    fn close_block(&self, _storage: &mut dyn StorageAccess) -> Result<BlockOutcome, CloseBlockError> {
+        if self.body_size.load(Ordering::SeqCst) > self.consensus_params.max_body_size() as usize {
+            Ok(BlockOutcome {
+                updated_validator_set: Some(self.validator_set.clone()),
+                updated_consensus_params: Some(self.consensus_params),
+
+                events: Vec::new(),
+            })
+        } else {
+            Err(String::from("Block size exceeds the maximum value"))
+        }
+    }
+}
+
+impl TxFilter for TestCoordinator {
+    fn check_transaction(&self, transaction: &Transaction) -> Result<(), ErrorCode> {
+        if transaction.size() > self.consensus_params.max_body_size() as usize {
+            Err(1)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn filter_transactions<'a>(
+        &self,
+        transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
+        memory_limit: Option<usize>,
+        size_limit: Option<usize>,
+    ) -> (Vec<&'a TransactionWithMetadata>, Vec<&'a TransactionWithMetadata>) {
+        let invalid = Vec::new();
+        let mut memory = 0;
+        let mut size = 0;
+        let low_priority = transactions
+            .skip_while(|tx| {
+                memory += (*tx).size();
+                size += 1;
+                memory <= memory_limit.unwrap_or(usize::max_value()) && size <= size_limit.unwrap_or(usize::max_value())
+            })
+            .collect();
+        (invalid, low_priority)
+    }
+}

--- a/coordinator/src/traits.rs
+++ b/coordinator/src/traits.rs
@@ -1,0 +1,55 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::context::StorageAccess;
+use crate::header::Header;
+use crate::transaction::{Transaction, TransactionWithMetadata};
+use crate::types::{BlockOutcome, CloseBlockError, ErrorCode, HeaderError, TransactionExecutionOutcome, VerifiedCrime};
+use ctypes::{CompactValidatorSet, ConsensusParams};
+
+pub trait Initializer: Send + Sync {
+    fn initialize_chain(&self, app_state: String) -> (CompactValidatorSet, ConsensusParams);
+}
+
+pub trait BlockExecutor: Send + Sync {
+    fn open_block(
+        &self,
+        storage: &mut dyn StorageAccess,
+        header: &Header,
+        verified_crimes: &[VerifiedCrime],
+    ) -> Result<(), HeaderError>;
+    fn execute_transactions(
+        &self,
+        storage: &mut dyn StorageAccess,
+        transactions: &[Transaction],
+    ) -> Result<Vec<TransactionExecutionOutcome>, ()>;
+    fn prepare_block<'a>(
+        &self,
+        storage: &mut dyn StorageAccess,
+        transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
+    ) -> Vec<&'a Transaction>;
+    fn close_block(&self, storage: &mut dyn StorageAccess) -> Result<BlockOutcome, CloseBlockError>;
+}
+
+pub trait TxFilter: Send + Sync {
+    fn check_transaction(&self, transaction: &Transaction) -> Result<(), ErrorCode>;
+    fn filter_transactions<'a>(
+        &self,
+        transactions: Box<dyn Iterator<Item = &'a TransactionWithMetadata> + 'a>,
+        memory_limit: Option<usize>,
+        size_limit: Option<usize>,
+    ) -> (Vec<&'a TransactionWithMetadata>, Vec<&'a TransactionWithMetadata>);
+}

--- a/coordinator/src/transaction.rs
+++ b/coordinator/src/transaction.rs
@@ -1,0 +1,183 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use ccrypto::blake256;
+use ctypes::TxHash;
+use primitives::Bytes;
+use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+
+/// An encoded transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Transaction {
+    tx_type: String,
+    body: Bytes,
+}
+
+impl Transaction {
+    #[allow(dead_code)]
+    fn tx_type(&self) -> &str {
+        &self.tx_type
+    }
+
+    pub fn body(&self) -> &Bytes {
+        &self.body
+    }
+
+    pub fn size(&self) -> usize {
+        self.rlp_bytes().len()
+    }
+
+    pub fn hash(&self) -> TxHash {
+        blake256(self.rlp_bytes()).into()
+    }
+}
+
+impl Encodable for Transaction {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.begin_list(2).append(&self.tx_type).append(self.body());
+    }
+}
+
+impl Decodable for Transaction {
+    fn decode(rlp: &Rlp) -> Result<Self, rlp::DecoderError> {
+        let item_count = rlp.item_count()?;
+        if item_count != 2 {
+            return Err(DecoderError::RlpIncorrectListLen {
+                expected: 2,
+                got: item_count,
+            })
+        }
+        Ok(Self {
+            tx_type: rlp.val_at(0)?,
+            body: rlp.val_at(1)?,
+        })
+    }
+}
+
+/// Transaction origin
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TxOrigin {
+    /// Transaction coming from local RPC
+    Local,
+    /// External transaction received from network
+    External,
+}
+
+type TxOriginType = u8;
+const LOCAL: TxOriginType = 0x01;
+const EXTERNAL: TxOriginType = 0x02;
+
+impl Encodable for TxOrigin {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        match self {
+            TxOrigin::Local => LOCAL.rlp_append(s),
+            TxOrigin::External => EXTERNAL.rlp_append(s),
+        };
+    }
+}
+
+impl Decodable for TxOrigin {
+    fn decode(d: &Rlp<'_>) -> Result<Self, DecoderError> {
+        match d.as_val().expect("rlp decode Error") {
+            LOCAL => Ok(TxOrigin::Local),
+            EXTERNAL => Ok(TxOrigin::External),
+            _ => Err(DecoderError::Custom("Unexpected Txorigin type")),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransactionWithMetadata {
+    pub tx: Transaction,
+    pub origin: TxOrigin,
+    pub inserted_block_number: u64,
+    pub inserted_timestamp: u64,
+    /// ID assigned upon insertion, should be unique
+    pub insertion_id: u64,
+}
+
+impl<'a> TransactionWithMetadata {
+    #[allow(dead_code)]
+    pub fn new(
+        tx: Transaction,
+        origin: TxOrigin,
+        inserted_block_number: u64,
+        inserted_timestamp: u64,
+        insertion_id: u64,
+    ) -> Self {
+        Self {
+            tx,
+            origin,
+            inserted_block_number,
+            inserted_timestamp,
+            insertion_id,
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        self.tx.size()
+    }
+
+    #[allow(dead_code)]
+    pub fn hash(&self) -> TxHash {
+        self.tx.hash()
+    }
+}
+
+impl Encodable for TransactionWithMetadata {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.begin_list(5)
+            .append(&self.tx)
+            .append(&self.origin)
+            .append(&self.inserted_block_number)
+            .append(&self.inserted_timestamp)
+            .append(&self.insertion_id);
+    }
+}
+
+impl Decodable for TransactionWithMetadata {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let item_count = rlp.item_count()?;
+        if item_count != 5 {
+            return Err(DecoderError::RlpIncorrectListLen {
+                expected: 5,
+                got: item_count,
+            })
+        }
+        Ok(Self {
+            tx: rlp.val_at(0)?,
+            origin: rlp.val_at(1)?,
+            inserted_block_number: rlp.val_at(2)?,
+            inserted_timestamp: rlp.val_at(3)?,
+            insertion_id: rlp.val_at(4)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rlp::rlp_encode_and_decode_test;
+
+    #[test]
+    fn encode_and_decode_transaction() {
+        let transaction = Transaction {
+            tx_type: "test".to_string(),
+            body: vec![0, 1, 2, 3, 4],
+        };
+        rlp_encode_and_decode_test!(transaction);
+    }
+}

--- a/coordinator/src/types.rs
+++ b/coordinator/src/types.rs
@@ -14,31 +14,32 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pub mod context;
-mod types;
+mod event;
 
-use self::context::Context;
+use self::event::Event;
+use ctypes::{CompactValidatorSet, ConsensusParams};
 
-/// The `Coordinator` encapsulates all the logic for a Foundry application.
-///
-/// It assembles modules and feeds them various events from the underlying
-/// consensus engine.
-pub struct Coordinator {}
-
-pub struct Builder<C: Context> {
-    _context: C,
+pub enum VerifiedCrime {
+    #[allow(dead_code)]
+    DoubleVote {
+        height: u64,
+        author_index: usize,
+        criminal_index: usize,
+    },
 }
 
-impl<C: Context> Builder<C> {
-    #[allow(dead_code)]
-    fn new(context: C) -> Self {
-        Builder {
-            _context: context,
-        }
-    }
-
-    #[allow(dead_code)]
-    fn build(self) -> Coordinator {
-        Coordinator {}
-    }
+pub struct TransactionExecutionOutcome {
+    pub events: Vec<Event>,
 }
+
+pub type HeaderError = String;
+pub type ExecuteTransactionError = ();
+pub type CloseBlockError = String;
+
+pub struct BlockOutcome {
+    pub updated_validator_set: Option<CompactValidatorSet>,
+    pub updated_consensus_params: Option<ConsensusParams>,
+    pub events: Vec<Event>,
+}
+
+pub type ErrorCode = u32;

--- a/coordinator/src/types/event.rs
+++ b/coordinator/src/types/event.rs
@@ -1,0 +1,61 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use primitives::Bytes;
+use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Event {
+    pub key: String,
+    pub value: Bytes,
+}
+
+impl Encodable for Event {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.begin_list(2).append(&self.key).append(&self.value);
+    }
+}
+
+impl Decodable for Event {
+    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+        let item_count = rlp.item_count()?;
+        if item_count != 2 {
+            return Err(DecoderError::RlpIncorrectListLen {
+                expected: 2,
+                got: item_count,
+            })
+        }
+        Ok(Self {
+            key: rlp.val_at(0)?,
+            value: rlp.val_at(1)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rlp::rlp_encode_and_decode_test;
+
+    #[test]
+    fn encode_and_decode_events() {
+        let event = Event {
+            key: "test key".to_string(),
+            value: vec![0, 1, 2, 3, 4, 5],
+        };
+        rlp_encode_and_decode_test!(event);
+    }
+}

--- a/types/src/consensus_params.rs
+++ b/types/src/consensus_params.rs
@@ -1,0 +1,130 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use cjson::scheme::Params;
+use ckey::NetworkId;
+use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
+use std::str::FromStr;
+
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct ConsensusParams {
+    /// Maximum size of extra data.
+    max_extra_data_size: u64,
+    /// Network id.
+    network_id: NetworkId,
+    /// Maximum size of block body.
+    max_body_size: u64,
+    /// Snapshot creation period in unit of block numbers.
+    snapshot_period: u64,
+
+    term_seconds: u64,
+}
+
+impl ConsensusParams {
+    pub fn max_extra_data_size(&self) -> u64 {
+        self.max_extra_data_size
+    }
+    pub fn network_id(&self) -> NetworkId {
+        self.network_id
+    }
+    pub fn max_body_size(&self) -> u64 {
+        self.max_body_size
+    }
+    pub fn snapshot_period(&self) -> u64 {
+        self.snapshot_period
+    }
+    pub fn term_seconds(&self) -> u64 {
+        self.term_seconds
+    }
+
+    pub fn default_for_test() -> Self {
+        Self {
+            max_extra_data_size: 1000,
+            network_id: NetworkId::from_str("dt").unwrap(),
+            max_body_size: 1000,
+            snapshot_period: 1000,
+            term_seconds: 1000,
+        }
+    }
+}
+
+impl Encodable for ConsensusParams {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        s.begin_list(5)
+            .append(&self.max_extra_data_size)
+            .append(&self.network_id)
+            .append(&self.max_body_size)
+            .append(&self.snapshot_period)
+            .append(&self.term_seconds);
+    }
+}
+
+impl Decodable for ConsensusParams {
+    fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
+        let size = rlp.item_count()?;
+        if size != 5 {
+            return Err(DecoderError::RlpIncorrectListLen {
+                expected: 5,
+                got: size,
+            })
+        }
+
+        let max_extra_data_size = rlp.val_at(0)?;
+        let network_id = rlp.val_at(1)?;
+        let max_body_size = rlp.val_at(2)?;
+        let snapshot_period = rlp.val_at(3)?;
+        let term_seconds = rlp.val_at(4)?;
+
+        Ok(Self {
+            max_extra_data_size,
+            network_id,
+            max_body_size,
+            snapshot_period,
+            term_seconds,
+        })
+    }
+}
+
+impl From<Params> for ConsensusParams {
+    fn from(p: Params) -> Self {
+        Self {
+            max_extra_data_size: p.max_extra_data_size.into(),
+            network_id: p.network_id,
+            max_body_size: p.max_body_size.into(),
+            snapshot_period: p.snapshot_period.into(),
+            term_seconds: p.term_seconds.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rlp::rlp_encode_and_decode_test;
+
+    #[test]
+    fn encode_and_decode_default() {
+        rlp_encode_and_decode_test!(ConsensusParams::default_for_test());
+    }
+
+    #[test]
+    fn rlp_with_extra_fields() {
+        let mut params = ConsensusParams::default_for_test();
+        params.max_extra_data_size = 100;
+        params.max_body_size = 123;
+        rlp_encode_and_decode_test!(params);
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -22,6 +22,7 @@ extern crate rlp_derive;
 mod block_hash;
 mod block_id;
 mod common_params;
+mod consensus_params;
 mod deposit;
 mod sync_header;
 mod tx_hash;
@@ -46,6 +47,7 @@ pub struct TransactionLocation {
 pub use block_hash::BlockHash;
 pub use block_id::BlockId;
 pub use common_params::CommonParams;
+pub use consensus_params::ConsensusParams;
 pub use deposit::Deposit;
 pub use header::Header;
 pub use sync_header::SyncHeader;

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -26,7 +26,7 @@ pub struct CompactValidatorEntry {
 }
 
 // It will be hashed in the header.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct CompactValidatorSet(Vec<CompactValidatorEntry>);
 impl CompactValidatorSet {
     pub fn new(x: Vec<CompactValidatorEntry>) -> Self {


### PR DESCRIPTION
This PR reorders, re-structs, and squshes the commits in the mold branch.
The commits are
* 632ede45d (mold) Implement StateHistoryAccess for Client
* a383e0322 Add a method to the host side to transfer Header
* 9634e7a43 Use boxed iterator instead of slice of references in filter_transactions
* 02ad51fd9 Change fetch_transactions_for_block into prepare_transactions_with_result
* b263c6aad Deliver transaction hashes when injection
* 9b41137e1 Change the return type of open_block to Result
* d77d21c8a Change return the type of execute_transactions to Result
* 1cff4c388 Change the return type of close_block to Result
* 7db3a183b Make updated entries in BlockOutcome optional
* 2336b11bc Remove storage_id from methods in SubStorageAccess
* 21189f790 Implement MemPoolAccess trait
* b20ecc0f5 Add missing license preamble in coordinator crate
* 2f5d54191 Rename remove_transactions with filter_transactions
* b7c0f729a Separate validator.rs into traits.rs and types.rs
* bba8ff9b7 Separate Validator trait into Initializer, BlockExecutor, and TxFilter.
* 02a98a2aa Implement TestCoordinator for miner/mempool testing
* e5731f48f Use dyn Validator instead of Coordinator
* 3c06e014c Use reference in TransactionWithGas
* 63d7f2015 Use validator set and consensus params given by initialize_chain
* cc8c19bcc Refine consensus parameters in validator interface
* 5c3b8c55e Add basic information to double vote evidence
* 71ac1d2ef Implement Encodable trait to Event type
* 76eda18cd Rename Evidence with VerifiedCrime
* 5dabbb8c9 Make transaction types encodable
* ea8811d6f Add error code to check_transaction
* 110834fc3 Revert author type from Pubilc to Address
* 29de7563c Fix and refine transaction handling interface and types
* d25dcd251 Rename Builder::create to Builder::new
* 053c75dee Change the fields of ConsensusParams to non optional
* 4fdb1f468 Remove the unnecessary macro import statement
* 3d20a304e Replace Context argument with SubStorageAccess
* e5c8d1885 Remove context from Coordinator
* 2930389c7 Construct the SubStorageAccess interface
* 27819e330 Remove state root from block outcome
* 5b8ac282e Refine execute_block interface
* 607333a38 Remove commit and revert interface from Validator
* 026a9c6b2 Use CompactValidatorSet in validator interface
* 162cff983 Replace BlockHash in BlockOutcome into state_root
* b961fbb49 Add is_success field to BlockOutcome
* c133fffaf Remove is_success from TransactionExecutionOutcome
* 9d93aa2b2 Add commit and revert interface
* 56d00ef22 Rename new() to create() for the Builder
* 3701c320b Revert BlockHash type
* b985266b5 Fix Public into Ed25519Public
* 5786e04ca Refine validator interface
* 06a9a482e Use reference types in inputs of validator interfaces
* 9172ba738 Allow public access to transaction size and hash
* 8a1cfcdab Suppress Clippy warning
* b55179bcd Use Bytes instead of Box in transaction types
* 977911b74 Use more concrete types in transaction structs
* 2b8686ae1 Refine BlockHash in BlockOutcome
* ee55ca391 Introduce transaction fetching and removing interface
* 3b821105c Simplify header field in execute_block method
* c40840652 Add more transaction check types for flexibility
* 0998647f9 Polish up check_transaction return
* d7721faca use usize instead of u64 for gas and priority
* c84819163 Add priority and gas to TransactionCheckOutcome
* a7a8c5b24 Subdivide the return of check_transaction
* b130830eb Add recheck option to check_transaction
* 797c169ad Change Header type to BlockHash
* 3f1de3ec9 Add draft design of validator module
* 30e7d2b44 Add the draft design

This PR extracts the implementation of the coordinator module only. It doesn't change the host to use the coordinator yet.