### PR TITLE
Clean unnecessary interfaces

### DIFF
--- a/basic_module/account/src/import.rs
+++ b/basic_module/account/src/import.rs
@@ -1,8 +1,0 @@
-pub trait FeeManager {
-    fn accumulate_block_fee(&self, total_additional_fee: u64, total_min_fee: u64);
-}
-
-#[allow(dead_code)]
-pub fn fee_manager() -> Box<dyn FeeManager> {
-    unimplemented!()
-}

--- a/basic_module/account/src/lib.rs
+++ b/basic_module/account/src/lib.rs
@@ -25,7 +25,6 @@ extern crate codechain_key as ckey;
 mod core;
 mod error;
 mod impls;
-mod import;
 mod internal;
 mod types;
 

--- a/basic_module/staking/src/execute.rs
+++ b/basic_module/staking/src/execute.rs
@@ -19,7 +19,7 @@ use crate::error::{Insufficient, Mismatch};
 use crate::runtime_error::Error;
 use crate::state::*;
 use crate::transactions::{AutoAction, UserAction, UserTransaction};
-use crate::types::{Approval, Bytes, Public, ReleaseResult, ResultantFee, StakeQuantity, Tiebreaker};
+use crate::types::{Approval, Bytes, Public, ReleaseResult, StakeQuantity, Tiebreaker};
 use crate::{account_manager, account_viewer, substorage};
 
 fn check_before_fee_imposition(sender_public: &Public, fee: u64, seq: u64, min_fee: u64) -> Result<(), Error> {
@@ -43,7 +43,7 @@ pub fn apply_internal(
     tx: UserTransaction,
     sender_public: &Public,
     tiebreaker: Tiebreaker,
-) -> Result<(TransactionExecutionOutcome, ResultantFee), Error> {
+) -> Result<TransactionExecutionOutcome, Error> {
     let UserTransaction {
         action,
         fee,
@@ -73,12 +73,7 @@ pub fn apply_internal(
         Err(_) => substorage.revert_to_the_checkpoint(),
     };
 
-    result.map(|outcome| {
-        (outcome, ResultantFee {
-            additional_fee: fee - min_fee,
-            min_fee,
-        })
-    })
+    result
 }
 
 fn execute_user_action(

--- a/basic_module/staking/src/imported.rs
+++ b/basic_module/staking/src/imported.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::types::{Public, Signature};
+use crate::types::Public;
 
 pub trait AccountManager {
     fn add_balance(&self, public: &Public, val: u64);
@@ -27,8 +27,4 @@ pub trait AccountView {
     fn is_active(&self, public: &Public) -> bool;
     fn get_balance(&self, public: &Public) -> u64;
     fn get_sequence(&self, public: &Public) -> u64;
-}
-
-pub trait SignatureManager {
-    fn verify(&self, signature: &Signature, message: &[u8], public: &Public) -> bool;
 }

--- a/basic_module/staking/src/imported.rs
+++ b/basic_module/staking/src/imported.rs
@@ -32,7 +32,3 @@ pub trait AccountView {
 pub trait SignatureManager {
     fn verify(&self, signature: &Signature, message: &[u8], public: &Public) -> bool;
 }
-
-pub trait FeeManager {
-    fn accumulate_block_fee(&self, total_additional_fee: u64, total_min_fee: u64);
-}

--- a/basic_module/staking/src/lib.rs
+++ b/basic_module/staking/src/lib.rs
@@ -20,7 +20,7 @@ extern crate serde_derive;
 extern crate lazy_static;
 
 use coordinator::context::{ChainHistoryAccess, SubStateHistoryAccess, SubStorageAccess};
-use imported::{AccountManager, AccountView, FeeManager};
+use imported::{AccountManager, AccountView};
 
 mod check;
 mod core;
@@ -60,10 +60,6 @@ pub fn account_manager() -> Box<dyn AccountManager> {
 }
 
 pub fn account_viewer() -> Box<dyn AccountView> {
-    unimplemented!()
-}
-
-pub fn fee_manager() -> Box<dyn FeeManager> {
     unimplemented!()
 }
 

--- a/basic_module/staking/src/types.rs
+++ b/basic_module/staking/src/types.rs
@@ -17,7 +17,6 @@
 pub use fkey::{sign, verify, Ed25519Private as Private, Ed25519Public as Public, Signature};
 pub use ftypes::{BlockNumber, Header};
 use std::fmt;
-use std::ops::Add;
 use std::str;
 
 pub type Bytes = Vec<u8>;
@@ -108,21 +107,4 @@ pub enum ReleaseResult {
 pub struct Approval {
     pub signature: Signature,
     pub signer_public: Public,
-}
-
-#[derive(Default, Serialize, Clone, Copy)]
-pub struct ResultantFee {
-    pub additional_fee: u64,
-    pub min_fee: u64,
-}
-
-impl Add for ResultantFee {
-    type Output = Self;
-
-    fn add(self, other: Self) -> Self {
-        Self {
-            additional_fee: self.additional_fee + other.additional_fee,
-            min_fee: self.min_fee + other.min_fee,
-        }
-    }
 }


### PR DESCRIPTION
This pr removes two interfaces: `FeeManager`; `SignatureManager`.
For the former, we do not have to consider the unimplemented module `Distribution`. For the latter, each module can verify signature with help of the `foundry/key` crate.