### PR TITLE
Port the account module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "module_account"
+version = "0.1.0"
+
+[[package]]
 name = "my_internet_ip"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,6 +1853,9 @@ version = "0.1.0"
 dependencies = [
  "codechain-crypto",
  "codechain-key",
+ "coordinator",
+ "lazy_static 1.4.0",
+ "parking_lot 0.6.4",
  "primitives",
  "serde",
  "serde_cbor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+
+[[package]]
 name = "heapsize"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,6 +1850,14 @@ dependencies = [
 [[package]]
 name = "module_account"
 version = "0.1.0"
+dependencies = [
+ "codechain-crypto",
+ "codechain-key",
+ "primitives",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+]
 
 [[package]]
 name = "my_internet_ip"
@@ -2717,6 +2731,16 @@ name = "serde"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,5 +74,6 @@ members = [
     "informer_courier",
     "sync",
     "types",
-    "coordinator"
+    "coordinator",
+    "basic_module/account"
 ]

--- a/basic_module/account/Cargo.toml
+++ b/basic_module/account/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2018"
 [dependencies]
 ccrypto = { package = "codechain-crypto", git = "https://github.com/CodeChain-io/rust-codechain-crypto.git", version = "0.2" }
 ckey = {package = "codechain-key", path = "../../key" }
+coordinator = {package = "coordinator", path = "../../coordinator" }
+lazy_static = "1.2"
+parking_lot = "0.6.0"
 primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
 serde = "1.0"
 serde_cbor = "0.11.1"

--- a/basic_module/account/Cargo.toml
+++ b/basic_module/account/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "module_account"
+version = "0.1.0"
+authors = ["CodeChain Team <hi@codechain.io>"]
+edition = "2018"
+
+[dependencies]
+
+[dev-dependencies]

--- a/basic_module/account/Cargo.toml
+++ b/basic_module/account/Cargo.toml
@@ -5,5 +5,11 @@ authors = ["CodeChain Team <hi@codechain.io>"]
 edition = "2018"
 
 [dependencies]
+ccrypto = { package = "codechain-crypto", git = "https://github.com/CodeChain-io/rust-codechain-crypto.git", version = "0.2" }
+ckey = {package = "codechain-key", path = "../../key" }
+primitives = { git = "https://github.com/CodeChain-io/rust-codechain-primitives.git", version = "0.4" }
+serde = "1.0"
+serde_cbor = "0.11.1"
+serde_derive = "1.0"
 
 [dev-dependencies]

--- a/basic_module/account/src/core.rs
+++ b/basic_module/account/src/core.rs
@@ -37,3 +37,11 @@ pub trait AccountManager {
 
     fn increment_sequence(&self, account_id: &Public);
 }
+
+pub trait AccountView {
+    fn is_active(&self, account_id: &Public) -> bool;
+
+    fn get_balance(&self, account_id: &Public) -> u64;
+
+    fn get_sequence(&self, account_id: &Public) -> u64;
+}

--- a/basic_module/account/src/core.rs
+++ b/basic_module/account/src/core.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use crate::error::Error;
 use crate::types::SignedTransaction;
 pub use ckey::{Ed25519Private as Private, Ed25519Public as Public, Error as KeyError, Password, Signature};
 pub use coordinator::context::SubStorageAccess;
@@ -25,4 +26,14 @@ pub trait CheckTxHandler {
 
 pub trait TransactionExecutor {
     fn execute_transactions(&self, transactions: &[SignedTransaction]) -> Result<Vec<TransactionExecutionOutcome>, ()>;
+}
+
+pub trait AccountManager {
+    fn add_balance(&self, account_id: &Public, val: u64);
+
+    fn sub_balance(&self, account_id: &Public, val: u64) -> Result<(), Error>;
+
+    fn set_balance(&self, account_id: &Public, val: u64);
+
+    fn increment_sequence(&self, account_id: &Public);
 }

--- a/basic_module/account/src/core.rs
+++ b/basic_module/account/src/core.rs
@@ -22,3 +22,7 @@ pub use coordinator::types::{ErrorCode, TransactionExecutionOutcome};
 pub trait CheckTxHandler {
     fn check_transaction(&self, tx: &SignedTransaction) -> Result<(), ErrorCode>;
 }
+
+pub trait TransactionExecutor {
+    fn execute_transactions(&self, transactions: &[SignedTransaction]) -> Result<Vec<TransactionExecutionOutcome>, ()>;
+}

--- a/basic_module/account/src/core.rs
+++ b/basic_module/account/src/core.rs
@@ -1,0 +1,24 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::types::SignedTransaction;
+pub use ckey::{Ed25519Private as Private, Ed25519Public as Public, Error as KeyError, Password, Signature};
+pub use coordinator::context::SubStorageAccess;
+pub use coordinator::types::{ErrorCode, TransactionExecutionOutcome};
+
+pub trait CheckTxHandler {
+    fn check_transaction(&self, tx: &SignedTransaction) -> Result<(), ErrorCode>;
+}

--- a/basic_module/account/src/error.rs
+++ b/basic_module/account/src/error.rs
@@ -14,8 +14,27 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#[macro_use]
-extern crate serde_derive;
+use ckey::{NetworkId, Signature};
+use std::fmt;
 
-mod error;
-mod types;
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum Error {
+    InvalidValue(u64, u64),
+    InvalidSignature(Signature),
+    InvalidNetworkId(NetworkId),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let msg: String = match *self {
+            Error::InvalidValue(balance, value) => {
+                format!("Invalid Value. The balance {} is smaller than this value {}", balance, value)
+            }
+            Error::InvalidNetworkId(network_id) => format!("{} is an invalid network id", network_id),
+            Error::InvalidSignature(sig) => format!("Signature {:?} is invalid", sig),
+        };
+
+        msg.fmt(f)
+    }
+}

--- a/basic_module/account/src/impls.rs
+++ b/basic_module/account/src/impls.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::core::{AccountManager, CheckTxHandler, TransactionExecutor};
+use crate::core::{AccountManager, AccountView, CheckTxHandler, TransactionExecutor};
 use crate::error::Error;
-use crate::internal::{add_balance, get_account, get_sequence, sub_balance};
+use crate::internal::{add_balance, get_account, get_balance, get_sequence, sub_balance};
 use crate::types::{Action, SignedTransaction};
 use crate::{check, get_context};
 use ckey::Ed25519Public as Public;
@@ -90,5 +90,22 @@ impl AccountManager for Manager {
 
         account.sequence += 1;
         context.set(account_id, account.to_vec());
+    }
+}
+
+#[allow(dead_code)]
+pub struct View {}
+
+impl AccountView for View {
+    fn is_active(&self, account_id: &Public) -> bool {
+        get_balance(account_id) != 0 || get_sequence(account_id) != 0
+    }
+
+    fn get_balance(&self, account_id: &Public) -> u64 {
+        get_balance(account_id)
+    }
+
+    fn get_sequence(&self, account_id: &Public) -> u64 {
+        get_sequence(account_id)
     }
 }

--- a/basic_module/account/src/impls.rs
+++ b/basic_module/account/src/impls.rs
@@ -1,0 +1,41 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::check;
+use crate::core::CheckTxHandler;
+use crate::internal::get_sequence;
+use crate::types::{Action, SignedTransaction};
+pub use coordinator::types::ErrorCode;
+
+#[allow(dead_code)]
+pub struct Handler {}
+
+impl CheckTxHandler for Handler {
+    fn check_transaction(&self, signed_tx: &SignedTransaction) -> Result<(), ErrorCode> {
+        check(signed_tx);
+
+        let Action::Pay {
+            sender,
+            receiver: _,
+            quantity: _,
+        } = signed_tx.tx.action;
+        if get_sequence(&sender) > signed_tx.tx.seq {
+            return Err(0xFFFF_FFFF)
+        }
+
+        Ok(())
+    }
+}

--- a/basic_module/account/src/internal.rs
+++ b/basic_module/account/src/internal.rs
@@ -14,9 +14,35 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use crate::error::Error;
 use crate::get_context;
 use crate::types::Account;
 use ckey::Ed25519Public as Public;
+
+pub fn add_balance(account_id: &Public, val: u64) {
+    if val == 0 {
+        return
+    }
+
+    let context = get_context();
+    let mut account: Account = get_account(account_id);
+
+    account.balance += val;
+    context.set(account_id, account.to_vec());
+}
+
+pub fn sub_balance(account_id: &Public, val: u64) -> Result<(), Error> {
+    let context = get_context();
+    let mut account: Account = get_account(account_id);
+
+    if account.balance < val {
+        return Err(Error::InvalidValue(account.balance, val))
+    }
+
+    account.balance -= val;
+    context.set(account_id, account.to_vec());
+    Ok(())
+}
 
 pub fn get_sequence(account_id: &Public) -> u64 {
     get_account(account_id).sequence

--- a/basic_module/account/src/internal.rs
+++ b/basic_module/account/src/internal.rs
@@ -1,0 +1,27 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::get_context;
+use crate::types::Account;
+use ckey::Ed25519Public as Public;
+
+pub fn get_sequence(account_id: &Public) -> u64 {
+    get_account(account_id).sequence
+}
+
+pub fn get_account(account_id: &Public) -> Account {
+    get_context().get(account_id).map(|account| account.into()).unwrap_or_default()
+}

--- a/basic_module/account/src/internal.rs
+++ b/basic_module/account/src/internal.rs
@@ -48,6 +48,10 @@ pub fn get_sequence(account_id: &Public) -> u64 {
     get_account(account_id).sequence
 }
 
+pub fn get_balance(account_id: &Public) -> u64 {
+    get_account(account_id).balance
+}
+
 pub fn get_account(account_id: &Public) -> Account {
     get_context().get(account_id).map(|account| account.into()).unwrap_or_default()
 }

--- a/basic_module/account/src/lib.rs
+++ b/basic_module/account/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/basic_module/account/src/types.rs
+++ b/basic_module/account/src/types.rs
@@ -1,0 +1,99 @@
+// Copyright 2020 Kodebox, Inc.
+// This file is part of CodeChain.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use ccrypto::blake256;
+use ckey::{Ed25519Public as Public, NetworkId, Signature};
+use primitives::H256;
+
+#[allow(dead_code)]
+pub type ErroneousTransactions = Vec<SignedTransaction>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Account {
+    pub balance: u64,
+    pub sequence: u64,
+}
+
+impl From<Vec<u8>> for Account {
+    fn from(vec: Vec<u8>) -> Account {
+        serde_cbor::from_slice(&vec).unwrap()
+    }
+}
+
+impl Default for Account {
+    fn default() -> Self {
+        Account {
+            balance: 0,
+            sequence: 0,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl Account {
+    pub fn new(balance: u64, sequence: u64) -> Account {
+        Account {
+            balance,
+            sequence,
+        }
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        serde_cbor::to_vec(&self).unwrap()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Transaction {
+    pub seq: u64,
+    pub fee: u64,
+    pub network_id: NetworkId,
+    pub action: Action,
+}
+
+impl Transaction {
+    #[allow(dead_code)]
+    pub fn hash(&self) -> H256 {
+        let serialized = serde_cbor::to_vec(&self).unwrap();
+        blake256(serialized)
+    }
+}
+
+#[derive(Clone)]
+pub struct SignedTransaction {
+    pub signature: Signature,
+    pub signer_public: Public,
+    pub tx: Transaction,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum Action {
+    Pay {
+        sender: Public,
+        receiver: Public,
+        quantity: u64,
+    },
+}
+
+impl Action {
+    #[allow(dead_code)]
+    pub fn min_fee(&self) -> u64 {
+        // Where can we initialize the min fee
+        // We need both consensus-defined minimum fee and machine-defined minimum fee
+        unimplemented!()
+    }
+}

--- a/basic_module/account/src/types.rs
+++ b/basic_module/account/src/types.rs
@@ -65,7 +65,6 @@ pub struct Transaction {
 }
 
 impl Transaction {
-    #[allow(dead_code)]
     pub fn hash(&self) -> H256 {
         let serialized = serde_cbor::to_vec(&self).unwrap();
         blake256(serialized)
@@ -79,7 +78,6 @@ pub struct SignedTransaction {
     pub tx: Transaction,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum Action {
     Pay {
@@ -90,7 +88,6 @@ pub enum Action {
 }
 
 impl Action {
-    #[allow(dead_code)]
     pub fn min_fee(&self) -> u64 {
         // Where can we initialize the min fee
         // We need both consensus-defined minimum fee and machine-defined minimum fee

--- a/coordinator/src/lib.rs
+++ b/coordinator/src/lib.rs
@@ -19,7 +19,7 @@ mod header;
 pub mod test_coordinator;
 mod traits;
 mod transaction;
-mod types;
+pub mod types;
 
 use self::context::{Context, StorageAccess};
 use self::header::Header;


### PR DESCRIPTION
This PR reorganized the commits below.

* 586dc887 Do not consider the distribution module
* 72ecd89f Modify the implementation of Account module
* b07edc1e Use parking_lot instead of the standard sync primitives
* 416750d8 Implement the trait SignatureManager
* c6db9f0e Implement the trait AccountView
* 3f21b974 Implement the trait AccountManager
* d12b403c Impelment the trait TransactionExecutor
* 46948065 Impelment the trait CheckTxHandler
* f4a62412 Implement internal functions
* fdd8322e Declare methods imported from external
* 8e5c16e2 Declare error handling and types for the module
* 81ebff60 Initialize for implementing the module Account

This commit depends on https://github.com/CodeChain-io/foundry/pull/396. I'll remove `do-not-merge` after the PR merged.