### PR TITLE
Rename 'address' to 'account_id'

### DIFF
--- a/basic_module/account/src/core.rs
+++ b/basic_module/account/src/core.rs
@@ -29,19 +29,19 @@ pub trait TransactionExecutor {
 }
 
 pub trait AccountManager {
-    fn add_balance(&self, address: &Public, val: u64);
+    fn add_balance(&self, account_id: &Public, val: u64);
 
-    fn sub_balance(&self, address: &Public, val: u64) -> Result<(), Error>;
+    fn sub_balance(&self, account_id: &Public, val: u64) -> Result<(), Error>;
 
-    fn set_balance(&self, address: &Public, val: u64);
+    fn set_balance(&self, account_id: &Public, val: u64);
 
-    fn increment_sequence(&self, address: &Public);
+    fn increment_sequence(&self, account_id: &Public);
 }
 
 pub trait AccountView {
-    fn is_active(&self, address: &Public) -> bool;
+    fn is_active(&self, account_id: &Public) -> bool;
 
-    fn get_balance(&self, address: &Public) -> u64;
+    fn get_balance(&self, account_id: &Public) -> u64;
 
-    fn get_sequence(&self, address: &Public) -> u64;
+    fn get_sequence(&self, account_id: &Public) -> u64;
 }

--- a/basic_module/account/src/impls.rs
+++ b/basic_module/account/src/impls.rs
@@ -80,28 +80,28 @@ impl TransactionExecutor for Executor {
 pub struct Manager {}
 
 impl AccountManager for Manager {
-    fn add_balance(&self, address: &Public, val: u64) {
-        add_balance_internalliy(address, val)
+    fn add_balance(&self, account_id: &Public, val: u64) {
+        add_balance_internalliy(account_id, val)
     }
 
-    fn sub_balance(&self, address: &Public, val: u64) -> Result<(), Error> {
-        sub_balance_internalliy(address, val)
+    fn sub_balance(&self, account_id: &Public, val: u64) -> Result<(), Error> {
+        sub_balance_internalliy(account_id, val)
     }
 
-    fn set_balance(&self, address: &Public, val: u64) {
+    fn set_balance(&self, account_id: &Public, val: u64) {
         let context = get_context();
-        let mut account = get_account(address);
+        let mut account = get_account(account_id);
 
         account.balance = val;
-        context.set(address, account.to_vec());
+        context.set(account_id, account.to_vec());
     }
 
-    fn increment_sequence(&self, address: &Public) {
+    fn increment_sequence(&self, account_id: &Public) {
         let context = get_context();
-        let mut account = get_account(address);
+        let mut account = get_account(account_id);
 
         account.sequence += 1;
-        context.set(address, account.to_vec());
+        context.set(account_id, account.to_vec());
     }
 }
 
@@ -109,15 +109,15 @@ impl AccountManager for Manager {
 pub struct View {}
 
 impl AccountView for View {
-    fn is_active(&self, address: &Public) -> bool {
-        get_balance_internally(address) != 0 || get_sequence_internally(address) != 0
+    fn is_active(&self, account_id: &Public) -> bool {
+        get_balance_internally(account_id) != 0 || get_sequence_internally(account_id) != 0
     }
 
-    fn get_balance(&self, address: &Public) -> u64 {
-        get_balance_internally(address)
+    fn get_balance(&self, account_id: &Public) -> u64 {
+        get_balance_internally(account_id)
     }
 
-    fn get_sequence(&self, address: &Public) -> u64 {
-        get_sequence_internally(address)
+    fn get_sequence(&self, account_id: &Public) -> u64 {
+        get_sequence_internally(account_id)
     }
 }

--- a/basic_module/account/src/internal.rs
+++ b/basic_module/account/src/internal.rs
@@ -20,42 +20,42 @@ use crate::types::Account;
 use ckey::Ed25519Public as Public;
 
 #[allow(dead_code)]
-pub fn add_balance(address: &Public, val: u64) {
+pub fn add_balance(account_id: &Public, val: u64) {
     if val == 0 {
         return
     }
 
     let context = get_context();
-    let mut account: Account = get_account(address);
+    let mut account: Account = get_account(account_id);
 
     account.balance += val;
-    context.set(address, account.to_vec());
+    context.set(account_id, account.to_vec());
 }
 
 #[allow(dead_code)]
-pub fn sub_balance(address: &Public, val: u64) -> Result<(), Error> {
+pub fn sub_balance(account_id: &Public, val: u64) -> Result<(), Error> {
     let context = get_context();
-    let mut account: Account = get_account(address);
+    let mut account: Account = get_account(account_id);
 
     if account.balance < val {
         return Err(Error::InvalidValue(account.balance, val))
     }
 
     account.balance -= val;
-    context.set(address, account.to_vec());
+    context.set(account_id, account.to_vec());
     Ok(())
 }
 
 #[allow(dead_code)]
-pub fn get_sequence(address: &Public) -> u64 {
-    get_account(address).sequence
+pub fn get_sequence(account_id: &Public) -> u64 {
+    get_account(account_id).sequence
 }
 
 #[allow(dead_code)]
-pub fn get_balance(address: &Public) -> u64 {
-    get_account(address).balance
+pub fn get_balance(account_id: &Public) -> u64 {
+    get_account(account_id).balance
 }
 
-pub fn get_account(address: &Public) -> Account {
-    get_context().get(address).map(|account| account.into()).unwrap_or_default()
+pub fn get_account(account_id: &Public) -> Account {
+    get_context().get(account_id).map(|account| account.into()).unwrap_or_default()
 }


### PR DESCRIPTION
The variables named 'account' had public key as its value. We judged
that the name was inappropriate to have the value, so I renamed the name
`address` to `account_id`.