### PR TITLE
Make the client hold the miner directly

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -70,6 +70,9 @@ pub struct Client {
 
     importer: Importer,
 
+    /// Handles block sealing
+    miner: Arc<Miner>,
+
     /// Timer for reseal_min_period on miner client
     reseal_timer: TimerApi,
 }
@@ -101,7 +104,7 @@ impl Client {
 
         let engine = scheme.engine.clone();
 
-        let importer = Importer::try_new(config, engine.clone(), message_channel.clone(), miner)?;
+        let importer = Importer::try_new(config, engine.clone(), message_channel.clone(), Arc::clone(&miner))?;
 
         let client = Arc::new(Client {
             engine,
@@ -112,6 +115,7 @@ impl Client {
             notify: RwLock::new(Vec::new()),
             queue_transactions: AtomicUsize::new(0),
             importer,
+            miner,
             reseal_timer,
         });
 
@@ -162,7 +166,7 @@ impl Client {
 
     /// This is triggered by a message coming from a engine when a new block should be created
     pub fn update_sealing(&self, parent_block: BlockId, allow_empty_block: bool) {
-        self.importer.miner.update_sealing(self, parent_block, allow_empty_block);
+        self.miner.update_sealing(self, parent_block, allow_empty_block);
     }
 
     fn block_hash(chain: &BlockChain, id: &BlockId) -> Option<BlockHash> {
@@ -193,7 +197,7 @@ impl Client {
         self.queue_transactions.fetch_sub(transactions.len(), AtomicOrdering::SeqCst);
         let transactions: Vec<UnverifiedTransaction> =
             transactions.iter().filter_map(|bytes| Rlp::new(bytes).as_val().ok()).collect();
-        let results = self.importer.miner.import_external_transactions(self, transactions);
+        let results = self.miner.import_external_transactions(self, transactions);
         results.len()
     }
 
@@ -223,7 +227,7 @@ impl Client {
         }
 
         let enacted = self.importer.extract_enacted(vec![update_result]);
-        self.importer.miner.chain_new_blocks(self, &[], &[], &enacted);
+        self.miner.chain_new_blocks(self, &[], &[], &enacted);
         self.new_blocks(&[], &[], &enacted);
     }
 
@@ -465,7 +469,7 @@ impl ImportBlock for Client {
             update_result
         };
         let enacted = self.importer.extract_enacted(vec![update_result]);
-        self.importer.miner.chain_new_blocks(self, &[h], &[], &enacted);
+        self.miner.chain_new_blocks(self, &[h], &[], &enacted);
         self.new_blocks(&[h], &[], &enacted);
         self.db().flush().expect("DB flush failed.");
         Ok(h)
@@ -473,10 +477,7 @@ impl ImportBlock for Client {
 
     fn set_min_timer(&self) {
         self.reseal_timer.cancel(RESEAL_MIN_TIMER_TOKEN).expect("Reseal min timer clear succeeds");
-        match self
-            .reseal_timer
-            .schedule_once(self.importer.miner.get_options().reseal_min_period, RESEAL_MIN_TIMER_TOKEN)
-        {
+        match self.reseal_timer.schedule_once(self.miner.get_options().reseal_min_period, RESEAL_MIN_TIMER_TOKEN) {
             Ok(_) => {}
             Err(TimerScheduleError::TokenAlreadyScheduled) => {
                 // Since set_min_timer could be called in multi thread, ignore the TokenAlreadyScheduled error
@@ -493,7 +494,7 @@ impl BlockChainClient for Client {
 
     /// Import own transaction
     fn queue_own_transaction(&self, transaction: VerifiedTransaction) -> Result<(), Error> {
-        self.importer.miner.import_own_transaction(self, transaction)?;
+        self.miner.import_own_transaction(self, transaction)?;
         Ok(())
     }
 
@@ -516,7 +517,7 @@ impl BlockChainClient for Client {
     }
 
     fn delete_all_pending_transactions(&self) {
-        self.importer.miner.delete_all_pending_transactions();
+        self.miner.delete_all_pending_transactions();
     }
 
     fn ready_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions {
@@ -524,23 +525,23 @@ impl BlockChainClient for Client {
             .common_params(BlockId::Latest)
             .expect("Common params of the latest block always exists")
             .max_body_size();
-        self.importer.miner.ready_transactions(size_limit, range)
+        self.miner.ready_transactions(size_limit, range)
     }
 
     fn count_pending_transactions(&self, range: Range<u64>) -> usize {
-        self.importer.miner.count_pending_transactions(range)
+        self.miner.count_pending_transactions(range)
     }
 
     fn future_pending_transactions(&self, range: Range<u64>) -> PendingVerifiedTransactions {
-        self.importer.miner.future_pending_transactions(range)
+        self.miner.future_pending_transactions(range)
     }
 
     fn future_included_count_pending_transactions(&self, range: Range<u64>) -> usize {
-        self.importer.miner.future_included_count_pending_transactions(range)
+        self.miner.future_included_count_pending_transactions(range)
     }
 
     fn is_pending_queue_empty(&self) -> bool {
-        self.importer.miner.status().transactions_in_pending_queue == 0
+        self.miner.status().transactions_in_pending_queue == 0
     }
 
     fn block_number(&self, id: &BlockId) -> Option<BlockNumber> {
@@ -641,23 +642,23 @@ impl BlockProducer for Client {
 
 impl MiningBlockChainClient for Client {
     fn get_malicious_users(&self) -> Vec<Public> {
-        self.importer.miner.get_malicious_users()
+        self.miner.get_malicious_users()
     }
 
     fn release_malicious_users(&self, prisoner_vec: Vec<Public>) {
-        self.importer.miner.release_malicious_users(prisoner_vec)
+        self.miner.release_malicious_users(prisoner_vec)
     }
 
     fn imprison_malicious_users(&self, prisoner_vec: Vec<Public>) {
-        self.importer.miner.imprison_malicious_users(prisoner_vec)
+        self.miner.imprison_malicious_users(prisoner_vec)
     }
 
     fn get_immune_users(&self) -> Vec<Public> {
-        self.importer.miner.get_immune_users()
+        self.miner.get_immune_users()
     }
 
     fn register_immune_users(&self, immune_user_vec: Vec<Public>) {
-        self.importer.miner.register_immune_users(immune_user_vec)
+        self.miner.register_immune_users(immune_user_vec)
     }
 }
 

--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -50,7 +50,7 @@ pub struct Importer {
     pub header_queue: HeaderQueue,
 
     /// Handles block sealing
-    pub miner: Arc<Miner>,
+    miner: Arc<Miner>,
 
     /// CodeChain engine to be used during import
     pub engine: Arc<dyn CodeChainEngine>,


### PR DESCRIPTION
Currently, the client access the miner through the importer. It's better to give a method to access the miner directly.

It closes #44. The issue suggests moving the miner to the client. However, because the importer holds the arc of the miner, we can make both of the importer and the client hold the miner. I think it's better than moving because the importer also needs the miner.