### PR TITLE
Fetch consistent state in mempool functions

### DIFF
--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -366,6 +366,9 @@ impl AccountData for TestBlockChainClient {
     fn seq(&self, pubkey: &Public, id: BlockId) -> Option<u64> {
         match id {
             BlockId::Latest => Some(self.seqs.read().get(pubkey).cloned().unwrap_or(0)),
+            BlockId::Hash(hash) if hash == *self.last_hash.read() => {
+                Some(self.seqs.read().get(pubkey).cloned().unwrap_or(0))
+            }
             _ => None,
         }
     }
@@ -373,6 +376,9 @@ impl AccountData for TestBlockChainClient {
     fn balance(&self, pubkey: &Public, state: StateOrBlock) -> Option<u64> {
         match state {
             StateOrBlock::Block(BlockId::Latest) | StateOrBlock::State(_) => {
+                Some(self.balances.read().get(pubkey).cloned().unwrap_or(0))
+            }
+            StateOrBlock::Block(BlockId::Hash(hash)) if hash == *self.last_hash.read() => {
                 Some(self.balances.read().get(pubkey).cloned().unwrap_or(0))
             }
             _ => None,

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -292,7 +292,8 @@ impl Miner {
             })
             .collect();
 
-        let fetch_account = fetch_account_creator(client);
+        let block_id = BlockId::Hash(best_header.hash());
+        let fetch_account = fetch_account_creator(client, block_id);
 
         let insertion_results = mem_pool.add(to_insert, current_block_number, current_timestamp, &fetch_account);
 
@@ -469,8 +470,11 @@ impl Miner {
         }
         let block = open_block.close()?;
 
-        let fetch_seq = |p: &Public| chain.latest_seq(p);
-
+        let block_id = {
+            let best_block_hash = chain.chain_info().best_block_hash;
+            BlockId::Hash(best_block_hash)
+        };
+        let fetch_seq = |p: &Public| chain.seq(p, block_id).expect("Read from best block");
         {
             let mut mem_pool = self.mem_pool.write();
             mem_pool.remove(
@@ -551,7 +555,11 @@ impl MinerService for Miner {
         ctrace!(MINER, "chain_new_blocks");
 
         {
-            let fetch_account = fetch_account_creator(chain);
+            let block_id = {
+                let current_block_hash = chain.chain_info().best_block_hash;
+                BlockId::Hash(current_block_hash)
+            };
+            let fetch_account = fetch_account_creator(chain, block_id);
             let current_block_number = chain.chain_info().best_block_number;
             let current_timestamp = chain.chain_info().best_block_timestamp;
             let mut mem_pool = self.mem_pool.write();

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -156,9 +156,12 @@ pub enum TransactionImportResult {
     Future,
 }
 
-fn fetch_account_creator<'c>(client: &'c dyn AccountData) -> impl Fn(&Public) -> AccountDetails + 'c {
+fn fetch_account_creator<'c>(
+    client: &'c dyn AccountData,
+    block_id: BlockId,
+) -> impl Fn(&Public) -> AccountDetails + 'c {
     move |pubkey: &Public| AccountDetails {
-        seq: client.latest_seq(&pubkey),
-        balance: client.latest_balance(&pubkey),
+        seq: client.seq(&pubkey, block_id).expect("We are querying sequence using trusted block id"),
+        balance: client.balance(&pubkey, block_id.into()).expect("We are querying balance using trusted block id"),
     }
 }


### PR DESCRIPTION
We found that mempool mis-calculates sequence in the TPS test. After
fixing the mempool to read consistent state, mempool calculates
sequence well.

Copied from https://github.com/CodeChain-io/codechain/pull/1976