### PR TITLE
Change the mutability of SubStorageAccess

### DIFF
--- a/basic_module/staking/src/execute.rs
+++ b/basic_module/staking/src/execute.rs
@@ -60,7 +60,7 @@ pub fn apply_internal(
     check_before_fee_imposition(sender_public, fee, seq, min_fee)?;
 
     // Does not impose fee and increase sequence for a failed transaction
-    let substorage = substorage();
+    let mut substorage = substorage();
     substorage.create_checkpoint();
 
     let account_manager = account_manager();

--- a/coordinator/src/context/sub_storage_access.rs
+++ b/coordinator/src/context/sub_storage_access.rs
@@ -20,14 +20,14 @@ pub type Value = Vec<u8>;
 // Interface between each module and the coordinator
 pub trait SubStorageAccess {
     fn get(&self, key: &Key) -> Option<Value>;
-    fn set(&self, key: &Key, value: Value);
+    fn set(&mut self, key: &Key, value: Value);
     fn has(&self, key: &Key) -> bool;
-    fn remove(&self, key: &Key);
+    fn remove(&mut self, key: &Key);
 
     /// Create a recoverable checkpoint of this state
-    fn create_checkpoint(&self);
+    fn create_checkpoint(&mut self);
     /// Revert to the last checkpoint and discard it
-    fn revert_to_the_checkpoint(&self);
+    fn revert_to_the_checkpoint(&mut self);
     /// Merge last checkpoint with the previous
-    fn discard_checkpoint(&self);
+    fn discard_checkpoint(&mut self);
 }


### PR DESCRIPTION
I found the SubStorageAccess takes the immutable references. But, it's safer to take the mutable reference when it changes the internal value because it makes only one thread be able to mutate the values.