### PR TITLE
Change block generation event parameter name

### DIFF
--- a/informer/src/handler/subscription.rs
+++ b/informer/src/handler/subscription.rs
@@ -50,7 +50,7 @@ impl Subscription {
                 cinfo!(INFORMER, "The event is successfully added to user's interested events");
                 self.interested_events.push(event);
             }
-            "BlockGeneration_by_number" => {
+            "BlockGenerationByNumber" => {
                 let cold_event = EventTags::ColdBlockGenerationNumerical(
                     // FIXME: Handle Unvalid block number
                     params[1].as_str().parse().unwrap(),
@@ -58,7 +58,7 @@ impl Subscription {
                 cinfo!(INFORMER, "The event is successfully added to user's interested events");
                 self.interested_events.push(cold_event);
             }
-            "BlockGeneration_by_hash" => {
+            "BlockGenerationByHash" => {
                 let cold_event = EventTags::ColdBlockGenerationHash(params[1].clone());
                 cinfo!(INFORMER, "The event is successfully added to user's interested events");
                 self.interested_events.push(cold_event);


### PR DESCRIPTION
In this commit, we change the name of the block generation event on informer API. 