### PR TITLE
Remove unnecessary MinerStatus and MemPoolStatus

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -555,7 +555,7 @@ impl BlockChainClient for Client {
     }
 
     fn is_pending_queue_empty(&self) -> bool {
-        self.miner.status().transactions_in_pending_queue == 0
+        self.miner.num_pending_transactions() == 0
     }
 
     fn block_number(&self, id: &BlockId) -> Option<BlockNumber> {

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -513,7 +513,7 @@ impl BlockChainClient for TestBlockChainClient {
     }
 
     fn is_pending_queue_empty(&self) -> bool {
-        self.miner.status().transactions_in_pending_queue == 0
+        self.miner.num_pending_transactions() == 0
     }
 
     fn block_number(&self, _id: &BlockId) -> Option<BlockNumber> {

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -16,8 +16,8 @@
 
 use super::backup;
 use super::mem_pool_types::{
-    AccountDetails, CurrentQueue, FutureQueue, MemPoolInput, MemPoolItem, MemPoolStatus, PoolingInstant, QueueTag,
-    TransactionOrder, TransactionOrderWithTag, TxOrigin,
+    AccountDetails, CurrentQueue, FutureQueue, MemPoolInput, MemPoolItem, PoolingInstant, QueueTag, TransactionOrder,
+    TransactionOrderWithTag, TxOrigin,
 };
 use super::TransactionImportResult;
 use crate::client::{AccountData, BlockChainTrait};
@@ -207,12 +207,9 @@ impl MemPool {
         }
     }
 
-    /// Returns current status for this pool
-    pub fn status(&self) -> MemPoolStatus {
-        MemPoolStatus {
-            pending: self.current.len(),
-            future: self.future.len(),
-        }
+    /// Returns the number of transactions in the pool
+    pub fn num_pending_transactions(&self) -> usize {
+        self.current.len()
     }
 
     /// Add signed transaction to pool to be verified and imported.

--- a/core/src/miner/mem_pool_types.rs
+++ b/core/src/miner/mem_pool_types.rs
@@ -375,15 +375,6 @@ impl MemPoolInput {
 }
 
 #[derive(Debug)]
-/// Current status of the pool
-pub struct MemPoolStatus {
-    /// Number of pending transactions (ready to go to block)
-    pub pending: usize,
-    /// Number of future transactions (waiting for transactions with lower seqs first)
-    pub future: usize,
-}
-
-#[derive(Debug)]
 /// Details of account
 pub struct AccountDetails {
     /// Most recent account seq

--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -16,7 +16,7 @@
 
 use super::mem_pool::{Error as MemPoolError, MemPool};
 use super::mem_pool_types::{MemPoolInput, TxOrigin};
-use super::{fetch_account_creator, MinerService, MinerStatus, TransactionImportResult};
+use super::{fetch_account_creator, MinerService, TransactionImportResult};
 use crate::account_provider::{AccountProvider, Error as AccountProviderError};
 use crate::block::{ClosedBlock, IsBlock};
 use crate::client::{
@@ -438,12 +438,8 @@ impl Miner {
 impl MinerService for Miner {
     type State = TopLevelState;
 
-    fn status(&self) -> MinerStatus {
-        let status = self.mem_pool.read().status();
-        MinerStatus {
-            transactions_in_pending_queue: status.pending,
-            transactions_in_future_queue: status.future,
-        }
+    fn num_pending_transactions(&self) -> usize {
+        self.mem_pool.read().num_pending_transactions()
     }
 
     fn authoring_params(&self) -> AuthoringParams {
@@ -592,10 +588,10 @@ impl MinerService for Miner {
 
             match import {
                 Ok(_) => {
-                    ctrace!(OWN_TX, "Status: {:?}", mem_pool.status());
+                    ctrace!(OWN_TX, "Number of pending transactions: {:?}", mem_pool.num_pending_transactions());
                 }
                 Err(ref e) => {
-                    ctrace!(OWN_TX, "Status: {:?}", mem_pool.status());
+                    ctrace!(OWN_TX, "Number of pending transactions: {:?}", mem_pool.num_pending_transactions());
                     cwarn!(OWN_TX, "Error importing transaction: {:?}", e);
                 }
             }

--- a/core/src/miner/mod.rs
+++ b/core/src/miner/mod.rs
@@ -42,8 +42,8 @@ pub trait MinerService: Send + Sync {
     /// Type representing chain state
     type State: TopStateView + 'static;
 
-    /// Returns miner's status.
-    fn status(&self) -> MinerStatus;
+    /// Returns the number of pending transactions.
+    fn num_pending_transactions(&self) -> usize;
 
     /// Get current authoring parameters.
     fn authoring_params(&self) -> AuthoringParams;
@@ -121,15 +121,6 @@ pub trait MinerService: Send + Sync {
 
     /// Stop sealing.
     fn stop_sealing(&self);
-}
-
-/// Mining status
-#[derive(Debug)]
-pub struct MinerStatus {
-    /// Number of transactions in queue with state `pending` (ready to be included in block)
-    pub transactions_in_pending_queue: usize,
-    /// Number of transactions in queue with state `future` (not yet ready to be included in block)
-    pub transactions_in_future_queue: usize,
 }
 
 /// Represents the result of importing tranasction.


### PR DESCRIPTION
The only information in the structs is the number of pending transactions,
so we don't need such abstraction anymore.