### PR TITLE
[WIP] Make the block executor be able to share the state

### DIFF
--- a/core/src/blockchain/blockchain.rs
+++ b/core/src/blockchain/blockchain.rs
@@ -391,10 +391,11 @@ pub trait BlockProvider: HeaderProvider + BodyProvider + InvoiceProvider {
         let header = self.block_header_data(hash)?;
         let body = self.block_body(hash)?;
 
-        let mut block = RlpStream::new_list(2);
+        let mut block = RlpStream::new_list(3);
         let body_rlp = body.rlp();
         block.append_raw(header.rlp().as_raw(), 1);
-        block.append_raw(body_rlp.at(0).unwrap().as_raw(), 1);
+        block.append_raw(body_rlp.at(0).unwrap().as_raw(), 1); // evidences
+        block.append_raw(body_rlp.at(1).unwrap().as_raw(), 1); // transactions
         let encoded_block = encoded::Block::new(block.out());
         debug_assert_eq!(*hash, encoded_block.hash());
         Some(encoded_block)

--- a/core/src/blockchain/body_db.rs
+++ b/core/src/blockchain/body_db.rs
@@ -120,8 +120,10 @@ impl BodyDB {
 
     /// Create a block body from a block.
     pub fn block_to_body(block: &BlockView<'_>) -> Bytes {
-        let mut body = RlpStream::new_list(1);
-        body.append_raw(block.rlp().at(1).unwrap().as_raw(), 1);
+        let mut body = RlpStream::new_list(2);
+        let rlp = block.rlp();
+        body.append_raw(rlp.at(1).unwrap().as_raw(), 1); // evidences
+        body.append_raw(rlp.at(2).unwrap().as_raw(), 1); // transactions
         body.out()
     }
 }

--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -637,6 +637,7 @@ impl BlockProducer for Client {
             self.state_db.read().clone(&parent_header.state_root()),
             &parent_header,
             author,
+            &[],
             extra_data,
         ).expect("OpenBlock::new only fails if parent state root invalid; state root of best block's header is never invalid; qed")
     }

--- a/core/src/client/importer.rs
+++ b/core/src/client/importer.rs
@@ -235,7 +235,7 @@ impl Importer {
         // Enact Verified Block
         let db = client.state_db().read().clone(&parent.state_root());
 
-        let enact_result = enact(&block.header, &block.transactions, engine, client, db, &parent);
+        let enact_result = enact(&block.header, &block.evidences, &block.transactions, engine, client, db, &parent);
         let closed_block = enact_result.map_err(|e| {
             cwarn!(CLIENT, "Block import failed for #{} ({})\nError: {:?}", header.number(), header.hash(), e);
         })?;

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -333,7 +333,7 @@ impl BlockProducer for TestBlockChainClient {
         let genesis_header = self.scheme.genesis_header();
         let db = get_temp_state_db();
 
-        let mut open_block = OpenBlock::try_new(engine, db, &genesis_header, author, extra_data)
+        let mut open_block = OpenBlock::try_new(engine, db, &genesis_header, author, &[], extra_data)
             .expect("Opening block for tests will not fail.");
         // TODO [todr] Override timestamp for predictability (set_timestamp_now kind of sucks)
         open_block.set_timestamp(*self.latest_block_timestamp.read());

--- a/core/src/consensus/mod.rs
+++ b/core/src/consensus/mod.rs
@@ -19,7 +19,7 @@ mod null_engine;
 pub(crate) mod signer;
 mod solo;
 pub mod stake;
-mod tendermint;
+pub(crate) mod tendermint;
 mod validator_set;
 
 pub use self::null_engine::NullEngine;
@@ -35,7 +35,7 @@ use crate::account_provider::AccountProvider;
 use crate::block::{ClosedBlock, ExecutedBlock};
 use crate::client::snapshot_notify::NotifySender as SnapshotNotifySender;
 use crate::client::ConsensusClient;
-use crate::consensus::tendermint::Evidence;
+pub use crate::consensus::tendermint::Evidence;
 use crate::error::Error;
 use crate::transaction::UnverifiedTransaction;
 use crate::views::HeaderView;

--- a/core/src/consensus/tendermint/engine.rs
+++ b/core/src/consensus/tendermint/engine.rs
@@ -177,7 +177,7 @@ impl ConsensusEngine for Tendermint {
     /// Block transformation functions, before the transactions.
     fn open_block_action(&self, block: &ExecutedBlock) -> Result<Option<Action>, Error> {
         Ok(Some(Action::UpdateValidators {
-            validators: NextValidators::load_from_state(block.state())?.into(),
+            validators: NextValidators::load_from_state(&*block.state())?.into(),
         }))
     }
 
@@ -198,7 +198,7 @@ impl ConsensusEngine for Tendermint {
                 parent_term_common_params.expect("TermCommonParams should exist").term_seconds()
             }
         };
-        let next_validators = NextValidators::update_weight(block.state(), block.header().author())?;
+        let next_validators = NextValidators::update_weight(&*block.state(), block.header().author())?;
         if !is_term_changed(block.header(), &parent, term_seconds) {
             return Ok(vec![Action::ChangeNextValidators {
                 validators: next_validators.into(),
@@ -224,7 +224,7 @@ impl ConsensusEngine for Tendermint {
             (current_term + custody_period, current_term + release_period)
         };
 
-        let released_addresses = Jail::load_from_state(block.state())?.released_addresses(current_term);
+        let released_addresses = Jail::load_from_state(&*block.state())?.released_addresses(current_term);
 
         Ok(vec![
             Action::CloseTerm {

--- a/core/src/encoded.rs
+++ b/core/src/encoded.rs
@@ -26,6 +26,7 @@
 use crate::block::Block as FullBlock;
 use crate::transaction::UnverifiedTransaction;
 use crate::views;
+use crate::Evidence;
 use ccrypto::blake256;
 use ckey::Ed25519Public as Public;
 use ctypes::{BlockHash, BlockNumber, Header as FullHeader, TxHash};
@@ -166,6 +167,16 @@ impl Body {
 
 // forwarders to borrowed view.
 impl Body {
+    /// Get a vector of all evidences
+    pub fn evidences(&self) -> Vec<Evidence> {
+        self.view().evidences()
+    }
+
+    ///Number of evidences in the block
+    pub fn evidences_count(&self) -> usize {
+        self.view().evidences_count()
+    }
+
     /// Get a vector of all transactions.
     pub fn transactions(&self) -> Vec<UnverifiedTransaction> {
         self.view().transactions()
@@ -286,6 +297,16 @@ impl Block {
 
 // forwarders to body view.
 impl Block {
+    /// Get a vector of all evidences
+    pub fn evidences(&self) -> Vec<Evidence> {
+        self.view().evidences()
+    }
+
+    ///Number of evidences in the block
+    pub fn evidences_count(&self) -> usize {
+        self.view().evidences_count()
+    }
+
     /// Get a vector of all transactions.
     pub fn transactions(&self) -> Vec<UnverifiedTransaction> {
         self.view().transactions()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -56,6 +56,7 @@ pub use crate::client::{
 };
 pub use crate::consensus::signer::EngineSigner;
 pub use crate::consensus::stake;
+pub use crate::consensus::tendermint::Evidence;
 pub use crate::consensus::{EngineType, TimeGapParams};
 pub use crate::db::{COL_STATE, NUM_COLUMNS};
 pub use crate::error::{BlockImportError, Error, ImportError};

--- a/core/src/scheme/scheme.rs
+++ b/core/src/scheme/scheme.rs
@@ -216,8 +216,9 @@ impl Scheme {
     pub fn genesis_block(&self) -> Bytes {
         let empty_list = RlpStream::new_list(0).out();
         let header = self.genesis_header();
-        let mut ret = RlpStream::new_list(2);
+        let mut ret = RlpStream::new_list(3);
         ret.append(&header);
+        ret.append_raw(&empty_list, 1); // evidences
         ret.append_raw(&empty_list, 1);
         ret.out()
     }

--- a/core/src/tests/helpers.rs
+++ b/core/src/tests/helpers.rs
@@ -20,8 +20,9 @@ use primitives::Bytes;
 use rlp::RlpStream;
 
 pub fn create_test_block(header: &Header) -> Bytes {
-    let mut rlp = RlpStream::new_list(2);
+    let mut rlp = RlpStream::new_list(3);
     rlp.append(header);
+    rlp.append_raw(&rlp::EMPTY_LIST_RLP, 1); // evidences
     rlp.append_raw(&rlp::EMPTY_LIST_RLP, 1);
     rlp.out()
 }

--- a/core/src/views/block.rs
+++ b/core/src/views/block.rs
@@ -16,6 +16,7 @@
 
 use super::{HeaderView, TransactionView};
 use crate::transaction::{LocalizedTransaction, UnverifiedTransaction};
+use crate::Evidence;
 use ccrypto::blake256;
 use ctypes::{BlockHash, Header, TransactionIndex, TxHash};
 use rlp::Rlp;
@@ -65,9 +66,17 @@ impl<'a> BlockView<'a> {
         HeaderView::new_from_rlp(self.rlp.at(0).unwrap())
     }
 
+    pub fn evidences(&self) -> Vec<Evidence> {
+        self.rlp.list_at(1).unwrap()
+    }
+
+    pub fn evidences_count(&self) -> usize {
+        self.rlp.at(1).iter().count()
+    }
+
     /// Return List of transactions in given block.
     pub fn transactions(&self) -> Vec<UnverifiedTransaction> {
-        self.rlp.list_at(1).unwrap()
+        self.rlp.list_at(2).unwrap()
     }
 
     /// Return List of transactions with additional localization info.
@@ -90,22 +99,22 @@ impl<'a> BlockView<'a> {
 
     /// Return number of transactions in given block, without deserializing them.
     pub fn tranasctions_count(&self) -> usize {
-        self.rlp.at(1).iter().count()
+        self.rlp.at(2).iter().count()
     }
 
     /// Return List of transactions in given block.
     pub fn transaction_views(&self) -> Vec<TransactionView<'a>> {
-        self.rlp.at(1).unwrap().iter().map(TransactionView::new_from_rlp).collect()
+        self.rlp.at(2).unwrap().iter().map(TransactionView::new_from_rlp).collect()
     }
 
     /// Return transaction hashes.
     pub fn transaction_hashes(&self) -> Vec<TxHash> {
-        self.rlp.at(1).unwrap().iter().map(|rlp| blake256(rlp.as_raw()).into()).collect()
+        self.rlp.at(2).unwrap().iter().map(|rlp| blake256(rlp.as_raw()).into()).collect()
     }
 
     /// Returns transaction at given index without deserializing unnecessary data.
     pub fn transaction_at(&self, index: TransactionIndex) -> Option<UnverifiedTransaction> {
-        self.rlp.at(1).unwrap().iter().nth(index as usize).map(|rlp| rlp.as_val().unwrap())
+        self.rlp.at(2).unwrap().iter().nth(index as usize).map(|rlp| rlp.as_val().unwrap())
     }
 
     /// Returns localized transaction at given index.

--- a/core/src/views/body.rs
+++ b/core/src/views/body.rs
@@ -16,6 +16,7 @@
 
 use super::TransactionView;
 use crate::transaction::{LocalizedTransaction, UnverifiedTransaction};
+use crate::Evidence;
 use ccrypto::blake256;
 use ctypes::{BlockHash, BlockNumber, TransactionIndex, TxHash};
 use rlp::Rlp;
@@ -45,9 +46,19 @@ impl<'a> BodyView<'a> {
         &self.rlp
     }
 
+    /// Return List of evidences in given block.
+    pub fn evidences(&self) -> Vec<Evidence> {
+        self.rlp.list_at(0).unwrap()
+    }
+
+    /// Return number of evidenecs in given block, without deserializing them.
+    pub fn evidences_count(&self) -> usize {
+        self.rlp.at(0).unwrap().item_count().unwrap()
+    }
+
     /// Return List of transactions in given block.
     pub fn transactions(&self) -> Vec<UnverifiedTransaction> {
-        self.rlp.list_at(0).unwrap()
+        self.rlp.list_at(1).unwrap()
     }
 
     /// Return List of transactions with additional localization info.
@@ -71,22 +82,22 @@ impl<'a> BodyView<'a> {
 
     /// Return number of transactions in given block, without deserializing them.
     pub fn transactions_count(&self) -> usize {
-        self.rlp.at(0).unwrap().item_count().unwrap()
+        self.rlp.at(1).unwrap().item_count().unwrap()
     }
 
     /// Return List of transactions in given block.
     pub fn transaction_views(&self) -> Vec<TransactionView<'a>> {
-        self.rlp.at(0).unwrap().iter().map(TransactionView::new_from_rlp).collect()
+        self.rlp.at(1).unwrap().iter().map(TransactionView::new_from_rlp).collect()
     }
 
     /// Return transaction hashes.
     pub fn transaction_hashes(&self) -> Vec<TxHash> {
-        self.rlp.at(0).unwrap().iter().map(|rlp| blake256(rlp.as_raw()).into()).collect()
+        self.rlp.at(1).unwrap().iter().map(|rlp| blake256(rlp.as_raw()).into()).collect()
     }
 
     /// Returns transaction at given index without deserializing unnecessary data.
     pub fn transaction_at(&self, index: TransactionIndex) -> Option<UnverifiedTransaction> {
-        self.rlp.at(0).unwrap().iter().nth(index as usize).map(|rlp| rlp.as_val().unwrap())
+        self.rlp.at(1).unwrap().iter().nth(index as usize).map(|rlp| rlp.as_val().unwrap())
     }
 
     /// Returns localized transaction at given index.

--- a/test/src/e2e.long/onChainBlockValid.test.ts
+++ b/test/src/e2e.long/onChainBlockValid.test.ts
@@ -126,7 +126,24 @@ describe("Test onChain block communication", async function() {
                 // [[]] => Some(EmptyValidatorSet)
                 [header2.toEncodeObject(), [[]]]
             ],
-            [[], []],
+            [
+                [
+                    [
+                        /* evidences */
+                    ],
+                    [
+                        /* transactions */
+                    ]
+                ],
+                [
+                    [
+                        /* evidences */
+                    ],
+                    [
+                        /* transactions */
+                    ]
+                ]
+            ],
             header2.hashing()
         );
 

--- a/test/src/sdk/core/Block.ts
+++ b/test/src/sdk/core/Block.ts
@@ -161,6 +161,7 @@ export class Block {
 
         const encoded: Buffer = RLP.encode([
             blockHeader,
+            [], // evidences
             transactions.map(tx => tx.toEncodeObject())
         ]);
 


### PR DESCRIPTION
The coordinator interfaces that need the mutex of the state require this change.

It depends on https://github.com/CodeChain-io/foundry/pull/441