### PR TITLE
Add missing stateful export service for both general_meeting and voting modules 

### DIFF
--- a/voting/src/general_meeting.rs
+++ b/voting/src/general_meeting.rs
@@ -349,6 +349,11 @@ impl UserModule for Module {
                 assert_eq!(arg, "unused");
                 Skeleton::new(Arc::clone(&self.ctx) as Arc<RwLock<dyn GeneralMeetingManager>>)
             }
+            "stateful" => {
+                let arg: String = serde_cbor::from_slice(ctor_arg).unwrap();
+                assert_eq!(arg, "unused");
+                Skeleton::new(Arc::clone(&self.ctx) as Arc<RwLock<dyn Stateful>>)
+            }
             "tx_owner" => {
                 let arg: String = serde_cbor::from_slice(ctor_arg).unwrap();
                 assert_eq!(arg, "unused");

--- a/voting/src/voting.rs
+++ b/voting/src/voting.rs
@@ -329,6 +329,11 @@ impl UserModule for Module {
                 assert_eq!(arg, "unused");
                 Skeleton::new(Arc::clone(&self.ctx) as Arc<RwLock<dyn VoteManager>>)
             }
+            "stateful" => {
+                let arg: String = serde_cbor::from_slice(ctor_arg).unwrap();
+                assert_eq!(arg, "unused");
+                Skeleton::new(Arc::clone(&self.ctx) as Arc<RwLock<dyn Stateful>>)
+            }
             "tx_owner" => {
                 let arg: String = serde_cbor::from_slice(ctor_arg).unwrap();
                 assert_eq!(arg, "unused");


### PR DESCRIPTION
If a module supposes to write in its own state, it should consider to export `stateful` as a service. In this PR, we add missing `stateful` export service for both `general_meeting` and `voting` modules.