### PR TITLE
Implement tests for CreateVotePaper transaction

### DIFF
--- a/voting/src/general_meeting.rs
+++ b/voting/src/general_meeting.rs
@@ -388,7 +388,7 @@ impl UserModule for Module {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(transparent)]
 pub struct GeneralMeetingId {
-    id: H256,
+    pub id: H256,
 }
 
 impl GeneralMeetingId {

--- a/voting/src/voting.rs
+++ b/voting/src/voting.rs
@@ -47,11 +47,11 @@ const VOTE_TX_TYPE: &str = "Vote";
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TxCreateVotePaper {
-    general_meeting_id: GeneralMeetingId,
-    agenda_number: u32,
-    number_of_shares: u32,
-    voter_name: String,
-    voter_public_key: Public,
+    pub general_meeting_id: GeneralMeetingId,
+    pub agenda_number: u32,
+    pub number_of_shares: u32,
+    pub voter_name: String,
+    pub voter_public_key: Public,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -103,10 +103,10 @@ impl Context {
                 if meeting.get_tallying_time().get_time() < self.block_header.as_ref().unwrap().timestamp() {
                     return Err(ExecuteError::VoteAfterTallyingTime)
                 }
-                if 0 == agenda_number && agenda_number > meeting.get_number_of_agendas() {
+                if agenda_number == 0 || agenda_number > meeting.get_number_of_agendas() {
                     return Err(ExecuteError::InvalidAgendaNumber)
                 }
-                if meeting.get_end_time().get_time() > self.block_header.as_ref().unwrap().timestamp() {
+                if meeting.get_end_time().get_time() < self.block_header.as_ref().unwrap().timestamp() {
                     return Err(ExecuteError::VoteAfterEndTime)
                 }
                 let vote_paper = VotePaper::new(meeting_id.clone(), agenda_number, name, shares, voter_public_key);

--- a/voting/tests/common/mock_coordinator.rs
+++ b/voting/tests/common/mock_coordinator.rs
@@ -103,6 +103,7 @@ impl UserModule for MockCoordinator {
         let scenario: String = serde_cbor::from_slice(arg).unwrap();
         match scenario.as_str() {
             "create_meeting" => scenarios::test_create_meeting(self.ctx.as_ref()),
+            "create_vote_paper" => scenarios::test_create_vote_paper(self.ctx.as_ref()),
             _ => panic!(),
         }
         Vec::new()

--- a/voting/tests/integration_test.rs
+++ b/voting/tests/integration_test.rs
@@ -183,3 +183,10 @@ fn create_meeting() {
     let coordinator = modules.get_mut("coordinator").unwrap().as_mut();
     coordinator.debug(&serde_cbor::to_vec(&"create_meeting").unwrap());
 }
+
+#[test]
+fn create_vote_paper() {
+    let mut modules = setup();
+    let coordinator = modules.get_mut("coordinator").unwrap().as_mut();
+    coordinator.debug(&serde_cbor::to_vec(&"create_vote_paper").unwrap());
+}


### PR DESCRIPTION
Some parts of the previous implementation that was needed for tests seemed to be incomplete. In this PR, first, we complete the previous implementation, then implement a test for the CreateVotePaper transaction. 