### PR TITLE
Remove Obsolete commands 

### DIFF
--- a/foundry/foundry.yml
+++ b/foundry/foundry.yml
@@ -256,13 +256,6 @@ args:
         takes_value: false
         conflicts_with:
             - no-miner
-    - work-queue-size:
-        long: work-queue-size
-        value_name: ITEMS
-        help: Specify the number of historical work packages which are kept cached lest a solution is found for them later. High values take more memory but result in fewer unusable solutions.
-        takes_value: true
-        conflicts_with:
-            - no-miner
     - no-discovery:
         long: no-discovery
         help: Do not use discovery

--- a/foundry/foundry.yml
+++ b/foundry/foundry.yml
@@ -250,12 +250,6 @@ args:
         takes_value: true
         conflicts_with:
             - no-miner
-    - no-reseal-timer:
-        long: no-reseal-timer
-        help: Do not use reseal timer.
-        takes_value: false
-        conflicts_with:
-            - no-miner
     - no-discovery:
         long: no-discovery
         help: Do not use discovery

--- a/foundry/foundry.yml
+++ b/foundry/foundry.yml
@@ -243,13 +243,6 @@ args:
         takes_value: true
         conflicts_with:
             - no-miner
-    - reseal-max-period:
-        long: reseal-max-period
-        value_name: MS
-        help: Specify the maximum time since last block to enable force-sealing. MS is time measured in milliseconds.
-        takes_value: true
-        conflicts_with:
-            - no-miner
     - no-discovery:
         long: no-discovery
         help: Do not use discovery


### PR DESCRIPTION
Some foundry commands have not been used in the code and they do not have any functionalities. In this PR, we remove them. 