### PR TITLE
Fill up GraphQlHandlerProvider impl for TestCoordinator

### DIFF
--- a/coordinator/src/test_coordinator.rs
+++ b/coordinator/src/test_coordinator.rs
@@ -142,14 +142,12 @@ impl TxFilter for TestCoordinator {
 
 impl GraphQlHandlerProvider for TestCoordinator {
     fn get(&self) -> Vec<(String, Arc<dyn super::module::HandleGraphQlRequest>)> {
-        unimplemented!()
+        vec![]
     }
 
     fn new_session_for_query(&self, _storage: &mut dyn StorageAccess) -> crate::module::SessionId {
-        unimplemented!()
+        0
     }
 
-    fn end_session_for_query(&self, _session: crate::module::SessionId) {
-        unimplemented!()
-    }
+    fn end_session_for_query(&self, _session: crate::module::SessionId) {}
 }


### PR DESCRIPTION
unimplemented!()s in the previous impl caused panick during some tests.
Made the trait methods return reasonable default values.