### PR TITLE
Save the genesis state in DB

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -102,9 +102,13 @@ impl Client {
 
         if state_db.is_empty() {
             // it's genesis
-            let (db, root) = Self::initialize_state(state_db, &*coordinator)?;
+            let (new_state_db, root) = Self::initialize_state(state_db, &*coordinator)?;
             scheme.set_state_root(root);
-            state_db = db;
+            state_db = new_state_db;
+
+            let mut batch = DBTransaction::new();
+            state_db.journal_under(&mut batch, 0, *scheme.genesis_header().hash())?;
+            db.write(batch)?
         }
 
         let gb = scheme.genesis_block();


### PR DESCRIPTION
There was no code that save Genesis state in DB.
It may be saved when Foundry saves block number 1, but it is not normal.

Corresponding CodeChain code writes the data to DB: https://github.com/CodeChain-io/codechain/blob/b82ca0ce594f67ef6179d2453c2b996f8648c584/core/src/client/client.rs#L104