### PR TITLE
Remove unnecessary genesis configurations

### DIFF
--- a/coordinator/src/app_desc/genesis.rs
+++ b/coordinator/src/app_desc/genesis.rs
@@ -15,29 +15,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use super::bytes::Bytes;
-use super::hash::H256;
-use super::seal::Seal;
-use ckey::PlatformAddress;
 use serde::Deserialize;
 
 /// Scheme genesis.
 #[derive(Debug, PartialEq, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Genesis {
-    /// Seal.
-    pub seal: Seal,
-    /// Block author, defaults to 0.
-    pub author: Option<PlatformAddress>,
-    /// Block timestamp, defaults to 0.
-    pub timestamp: Option<u64>,
-    /// Parent hash, defaults to 0.
-    pub parent_hash: Option<H256>,
-    /// Transactions root.
-    pub transactions_root: Option<H256>,
-    /// State root.
-    pub state_root: Option<H256>,
-    /// Next validator set hash.
-    pub next_validator_set_hash: Option<H256>,
     /// Extra data.
     pub extra_data: Option<Bytes>,
 }
@@ -45,49 +28,19 @@ pub struct Genesis {
 #[cfg(test)]
 mod tests {
     use super::super::bytes::Bytes;
-    use super::super::hash::{H256, H520};
-    use super::super::seal::TendermintSeal;
     use super::Genesis;
-    use super::Seal;
-    use ckey::PlatformAddress;
-    use primitives::{H256 as Core256, H520 as Core520};
     use std::str::FromStr;
 
     #[test]
     fn genesis_deserialization() {
         let s = r#"{
-            "seal": {
-                "tendermint": {
-                    "prev_view": 0,
-                    "cur_view": 0,
-                    "precommits": [
-                    "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-                    ]
-                }
-            },
-            "author": "fjjh0000AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtc0",
-            "timestamp": 0x07,
-            "parentHash": "0x9000000000000000000000000000000000000000000000000000000000000000",
             "extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
-            "stateRoot": "0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544",
-            "nextValidatorSetHash": "0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544"
         }"#;
         let deserialized: Genesis = serde_yaml::from_str(s).unwrap();
         assert_eq!(deserialized, Genesis {
-            seal: Seal::Tendermint(TendermintSeal {
-                prev_view: 0x0,
-                cur_view: 0x0,
-                precommits: vec![
-                    H520(Core520::from_str("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap()),
-                ]
-            }),
-            author: Some(PlatformAddress::from_str("fjjh0000AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtc0").unwrap()),
-            timestamp: Some(0x07),
-            parent_hash: Some(H256(Core256::from_str("9000000000000000000000000000000000000000000000000000000000000000").unwrap())),
-            transactions_root: None,
-            state_root: Some(H256(Core256::from_str("d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544").unwrap())),
-            next_validator_set_hash: Some(H256(Core256::from_str("d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544").unwrap())),
-            extra_data: Some(Bytes::from_str("0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa").unwrap()),
+            extra_data: Some(
+                Bytes::from_str("0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa").unwrap()
+            ),
         });
     }
 }

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -17,59 +17,26 @@
 use crate::Error;
 use ccrypto::BLAKE_NULL_RLP;
 use cdb::HashDB;
-use ckey::{Ed25519Public as Public, PlatformAddress};
-use coordinator::{app_desc::TendermintSeal, engine::Initializer};
+use coordinator::engine::Initializer;
 use cstate::{Metadata, NextValidatorSet, StateDB, StateWithCache, TopLevelState, TopState};
-use ctypes::{BlockHash, Header};
-use primitives::{Bytes, H256, H520};
-use rlp::{Rlp, RlpStream};
+use ctypes::Header;
+use primitives::{Bytes, H256};
+use rlp::RlpStream;
 
 pub struct Genesis {
-    parent_hash: BlockHash,
-    /// The genesis block's author field.
-    author: Public,
-    /// The genesis block's timestamp field.
-    timestamp: u64,
-    /// Transactions root of the genesis block. Should be BLAKE_NULL_RLP.
-    transactions_root: H256,
     /// The genesis block's extra data field.
     extra_data: Bytes,
-    /// Each seal field, expressed as RLP, concatenated.
-    seal_rlp: Bytes,
-
     state_root: H256,
 }
 
 impl Genesis {
     // get parameters
     pub fn new(s: coordinator::app_desc::Genesis, coordinator: &impl Initializer) -> Self {
-        let seal_rlp = Self::seal_to_bytes(s.seal);
         let db = StateDB::new_with_memorydb();
         let (_, state_root) = Self::initialize_state(db, coordinator).expect("DB error while creating genesis block");
         Genesis {
-            parent_hash: s.parent_hash.map_or_else(H256::zero, Into::into).into(),
-            author: s.author.map_or_else(Public::default, PlatformAddress::into_pubkey),
-            timestamp: s.timestamp.map_or(0, Into::into),
-            transactions_root: s.transactions_root.map_or_else(|| BLAKE_NULL_RLP, Into::into),
             extra_data: s.extra_data.map_or_else(Vec::new, Into::into),
-            seal_rlp,
             state_root,
-        }
-    }
-
-    fn seal_to_bytes(seal: coordinator::app_desc::Seal) -> Bytes {
-        match seal {
-            coordinator::app_desc::Seal::Tendermint(TendermintSeal {
-                prev_view,
-                cur_view,
-                precommits,
-            }) => {
-                let mut stream = RlpStream::new_list(3);
-                let precommits: Vec<H520> = precommits.into_iter().map(Into::into).collect();
-                stream.append(&prev_view).append(&cur_view).append_list(&precommits);
-                stream.out()
-            }
-            coordinator::app_desc::Seal::Generic(bytes) => bytes.into_vec(),
         }
     }
 
@@ -100,18 +67,15 @@ impl Genesis {
 
     pub fn header(&self) -> Header {
         let mut header: Header = Default::default();
-        header.set_parent_hash(self.parent_hash);
-        header.set_timestamp(self.timestamp);
+        header.set_parent_hash(H256::zero().into());
+        header.set_timestamp(0);
         header.set_number(0);
-        header.set_author(self.author);
-        header.set_transactions_root(self.transactions_root);
+        header.set_author(Default::default());
+        header.set_transactions_root(BLAKE_NULL_RLP);
         header.set_extra_data(self.extra_data.clone());
         header.set_state_root(self.state_root);
         header.set_next_validator_set_hash(BLAKE_NULL_RLP /* This will be calculated from state after https://github.com/CodeChain-io/foundry/issues/142*/);
-        header.set_seal({
-            let r = Rlp::new(&self.seal_rlp);
-            r.iter().map(|f| f.as_raw().to_vec()).collect()
-        });
+        header.set_seal(Vec::new());
         ctrace!(SPEC, "Genesis header is {:?}", header);
         ctrace!(SPEC, "Genesis header hash is {}", header.hash());
         header


### PR DESCRIPTION
We only need a field to change genesis header's hash.