### PR TITLE
Read max_body_size from state

### DIFF
--- a/coordinator/src/context/storage_access.rs
+++ b/coordinator/src/context/storage_access.rs
@@ -22,6 +22,8 @@ pub trait StorageAccess: Send {
     /// Returns a subspace of the given `storage_id` in the underlying storage.
     fn sub_storage(&mut self, storage_id: StorageId) -> Box<dyn SubStorageAccess>;
 
+    fn max_body_size(&self) -> u64;
+
     /// Create a recoverable checkpoint of this state
     fn create_checkpoint(&mut self);
     /// Revert to the last checkpoint and discard it

--- a/core/src/miner/mem_pool.rs
+++ b/core/src/miner/mem_pool.rs
@@ -410,5 +410,9 @@ pub mod test {
         fn discard_checkpoint(&mut self) {
             unimplemented!()
         }
+
+        fn max_body_size(&self) -> u64 {
+            unimplemented!()
+        }
     }
 }

--- a/state/src/impls/top_level.rs
+++ b/state/src/impls/top_level.rs
@@ -145,6 +145,13 @@ impl StorageAccess for TopLevelState {
     fn discard_checkpoint(&mut self) {
         StateWithCheckpoint::discard_checkpoint(self, TOP_CHECKPOINT)
     }
+
+    fn max_body_size(&self) -> u64 {
+        let metadata_in_state = TopStateView::metadata(self)
+            .expect("Corrupted database; returns error only when a trie node cannot be found in the DB.");
+        let metadata = metadata_in_state.expect("metadata is initialized when generating genesis state");
+        metadata.chain_params().max_body_size()
+    }
 }
 
 impl StateWithCache for TopLevelState {


### PR DESCRIPTION
Previously coordinator cached max_body_size when initializing the
genesis block. It was not a correct implementation. When we modify the
max_body_size in the state DB, the cached content and the DB content
will not be the same.

This commit makes the coordinator read max_body_size from the DB. Now,
we only have a source of truth.