### PR TITLE
Remove unused configs

### DIFF
--- a/core/src/miner/miner.rs
+++ b/core/src/miner/miner.rs
@@ -52,11 +52,6 @@ pub struct MinerOptions {
     pub mem_pool_size: usize,
     /// Maximum memory usage of transactions in the queue (current / future).
     pub mem_pool_memory_limit: Option<usize>,
-    /// A value which is used to check whether a new transaciton can replace a transaction in the memory pool with the same signer.
-    /// If the fee of the new transaction is `new_fee` and the fee of the transaction in the memory pool is `old_fee`,
-    /// then `new_fee > old_fee + old_fee >> mem_pool_fee_bump_shift` should be satisfied to replace.
-    /// Local transactions ignore this option.
-    pub mem_pool_fee_bump_shift: usize,
 }
 
 impl Default for MinerOptions {
@@ -67,7 +62,6 @@ impl Default for MinerOptions {
             reseal_min_period: Duration::from_secs(2),
             mem_pool_size: 8192,
             mem_pool_memory_limit: Some(2 * 1024 * 1024),
-            mem_pool_fee_bump_shift: 3,
         }
     }
 }

--- a/demo/config0.toml
+++ b/demo/config0.toml
@@ -1,15 +1,12 @@
 [codechain]
-quiet = false
 base_path = "."
 password_path = "./password.json"
 
 [mining]
 mem_pool_mem_limit = 4 # MB
 mem_pool_size = 32768
-mem_pool_fee_bump_shift = 3 # 12.5%
 reseal_on_txs = "all"
 reseal_min_period = 0
-self_nomination_enable = false
 allowed_past_gap = 30000
 allowed_future_gap = 5000
 engine_signer = "rjmxg19kCmkCxROEoV0QYsrDpOYsjQwusCtN5_oKMEzk-I6kgtAtc0"

--- a/demo/config1.toml
+++ b/demo/config1.toml
@@ -1,15 +1,12 @@
 [codechain]
-quiet = false
 base_path = "."
 password_path = "./password.json"
 
 [mining]
 mem_pool_mem_limit = 4 # MB
 mem_pool_size = 32768
-mem_pool_fee_bump_shift = 3 # 12.5%
 reseal_on_txs = "all"
 reseal_min_period = 0
-self_nomination_enable = false
 allowed_past_gap = 30000
 allowed_future_gap = 5000
 engine_signer = "szff1322BHP3gsOuwFPDf-K8zvqSmNz4rj3CJirlQKFKWA_3c-Ytc0"

--- a/demo/config2.toml
+++ b/demo/config2.toml
@@ -1,15 +1,12 @@
 [codechain]
-quiet = false
 base_path = "."
 password_path = "./password.json"
 
 [mining]
 mem_pool_mem_limit = 4 # MB
 mem_pool_size = 32768
-mem_pool_fee_bump_shift = 3 # 12.5%
 reseal_on_txs = "all"
 reseal_min_period = 0
-self_nomination_enable = false
 allowed_past_gap = 30000
 allowed_future_gap = 5000
 engine_signer = "qwfj0xwkJQLV5iEGeaGeRfPA-TJX56Mnuq9fQD9coasmhanhck4tc0"

--- a/demo/config3.toml
+++ b/demo/config3.toml
@@ -1,15 +1,12 @@
 [codechain]
-quiet = false
 base_path = "."
 password_path = "./password.json"
 
 [mining]
 mem_pool_mem_limit = 4 # MB
 mem_pool_size = 32768
-mem_pool_fee_bump_shift = 3 # 12.5%
 reseal_on_txs = "all"
 reseal_min_period = 0
-self_nomination_enable = false
 allowed_past_gap = 30000
 allowed_future_gap = 5000
 engine_signer = "dbqtds3w6QnzEf0RXuQS7c_N6IzFBzcBAfdjWme5y0U5DxzLS14tc0"

--- a/foundry/config/presets/config.dev.toml
+++ b/foundry/config/presets/config.dev.toml
@@ -1,14 +1,11 @@
 [codechain]
-quiet = false
 base_path = "."
 
 [mining]
 mem_pool_mem_limit = 4 # MB
 mem_pool_size = 32768
-mem_pool_fee_bump_shift = 3 # 12.5%
 reseal_on_txs = "all"
 reseal_min_period = 0
-self_nomination_enable = false
 allowed_past_gap = 30000
 allowed_future_gap = 5000
 

--- a/foundry/config/presets/config.prod.toml
+++ b/foundry/config/presets/config.prod.toml
@@ -1,12 +1,9 @@
 [codechain]
-quiet = false
 base_path = "."
 
 [mining]
 mem_pool_mem_limit = 512 # MB
 mem_pool_size = 524288
-self_nomination_enable =false
-mem_pool_fee_bump_shift = 3 # 12.5%
 reseal_on_txs = "all"
 reseal_min_period = 4000
 allowed_past_gap = 30000

--- a/foundry/foundry.yml
+++ b/foundry/foundry.yml
@@ -56,10 +56,6 @@ args:
         long: instance-id
         help: Specify instance id for logging. Used when running multiple instances of CodeChain.
         takes_value: true
-    - quiet:
-        short: q
-        long: quiet
-        help: Do not show any synchronization information in the console.
     - base-path:
         long: base-path
         value_name: PATH
@@ -181,25 +177,9 @@ args:
     - no-miner:
         long: no-miner
         help: Do not mine.
-    - author:
-        long: author
-        help: Specify the block author (aka "coinbase") address for sending block rewards from sealed blocks.
-        takes_value: true
     - engine-signer:
         long: engine-signer
         help: Specify the address which should be used to sign consensus messages and issue blocks.
-        takes_value: true
-    - self-nomination-metadata:
-        long: self-nomination-metadata
-        help: Specify metadata which should be used to do self nomination.
-        takes_value: true
-    - self-nomination-target-deposit:
-        long: self-nomination-target-deposit
-        help: Specify the amount of deposit need to provide deposite for candidatory in the process of self nomination.
-        takes_value: true
-    - self-nomination-interval:
-        long: self-nomination-interval
-        help: Specify the time(ms) interval for self nomination process.
         takes_value: true
     - enable-auto-self-nomination:
         long: enable-auto-self-nomination
@@ -207,11 +187,6 @@ args:
     - password-path:
         long: password-path
         help: Specify the password file path.
-        takes_value: true
-    - mem-pool-fee-bump-shift:
-        long: mem-pool-fee-bump-shift
-        value_name: INTEGER
-        help: A value which is used to check whether a new transaciton can replace a transaction in the memory pool with the same signer and seq. If the fee of the new transaction is `new_fee` and the fee of the transaction in the memory pool is `old_fee`, then `new_fee > old_fee + old_fee >> mem_pool_fee_bump_shift` should be satisfied to replace.
         takes_value: true
     - mem-pool-mem-limit:
         long: mem-pool-mem-limit

--- a/foundry/run_node.rs
+++ b/foundry/run_node.rs
@@ -146,14 +146,10 @@ fn new_miner(
                 Err(e) => return Err(format!("{}", e)),
                 _ => (),
             },
-            None if config.mining.author.is_some() => {
-                return Err("PBFT type engine needs not an author but an engine signer for mining. Specify the engine signer using --engine-signer option."
-                    .to_string())
-            }
             None => (),
         },
         EngineType::Solo => miner
-            .set_author(ap, config.mining.author.map_or(Public::default(), PlatformAddress::into_pubkey))
+            .set_author(ap, config.mining.engine_signer.map_or(Public::default(), PlatformAddress::into_pubkey))
             .expect("set_author never fails when Solo is used"),
     }
 

--- a/integration-test/config.tendermint-solo.toml
+++ b/integration-test/config.tendermint-solo.toml
@@ -1,15 +1,12 @@
 [codechain]
-quiet = false
 base_path = "."
 password_path = "./password.json"
 
 [mining]
 mem_pool_mem_limit = 4 # MB
 mem_pool_size = 32768
-mem_pool_fee_bump_shift = 3 # 12.5%
 reseal_on_txs = "all"
 reseal_min_period = 0
-self_nomination_enable = false
 allowed_past_gap = 30000
 allowed_future_gap = 5000
 engine_signer = "rjmxg19kCmkCxROEoV0QYsrDpOYsjQwusCtN5_oKMEzk-I6kgtAtc0"


### PR DESCRIPTION
* quiet: It was not used.
* author: Originally used in PoW consensus. Foundry does not use PoW.
* self_nomination_metadata, self_target_deposit,
self_nomination_enable, self_nomination_interval: They are related to
CodeChain dynamic validator. Foundry does not enforce a specific
validator rule.
* mem_pool_fee_bump_shift: It was used to manage mempool. In Foundry,
modules will manage the mem pool.