### PR TITLE
Hotfix the duplicate connection bug

### DIFF
--- a/network/src/p2p/handler.rs
+++ b/network/src/p2p/handler.rs
@@ -516,13 +516,15 @@ impl IoHandler<Message> for Handler {
                         remote_node_id,
                         token
                     );
-                    assert_eq!(
-                        None,
-                        self.remote_node_ids_reverse.write().insert(remote_node_id, token),
-                        "{}:{} is already registered",
-                        remote_node_id,
-                        token
-                    );
+                    if !self.remote_node_ids_reverse.write().contains_key(&remote_node_id) {
+                        assert_eq!(
+                            None,
+                            self.remote_node_ids_reverse.write().insert(remote_node_id, token),
+                            "{}:{} is already registered",
+                            remote_node_id,
+                            token
+                        );
+                    }
 
                     let t = inbound_connections.insert(token, connection);
                     assert!(t.is_none());
@@ -546,13 +548,15 @@ impl IoHandler<Message> for Handler {
                         remote_node_id,
                         token
                     );
-                    assert_eq!(
-                        None,
-                        self.remote_node_ids_reverse.write().insert(remote_node_id, token),
-                        "{}:{} is already registered",
-                        remote_node_id,
-                        token
-                    );
+                    if !self.remote_node_ids_reverse.write().contains_key(&remote_node_id) {
+                        assert_eq!(
+                            None,
+                            self.remote_node_ids_reverse.write().insert(remote_node_id, token),
+                            "{}:{} is already registered",
+                            remote_node_id,
+                            token
+                        );
+                    }
 
                     let mut network_message_size = 0;
                     for (name, versions) in self.client.extension_versions() {

--- a/network/src/p2p/handler.rs
+++ b/network/src/p2p/handler.rs
@@ -516,6 +516,8 @@ impl IoHandler<Message> for Handler {
                         remote_node_id,
                         token
                     );
+                    // FIXME the if condition below is a hotfix.
+                    // `self.remote_node_ids_reverse.write().contains_key(&remote_node_id)` always should be false
                     if !self.remote_node_ids_reverse.write().contains_key(&remote_node_id) {
                         assert_eq!(
                             None,
@@ -548,6 +550,8 @@ impl IoHandler<Message> for Handler {
                         remote_node_id,
                         token
                     );
+                    // FIXME the if condition below is a hotfix.
+                    // `self.remote_node_ids_reverse.write().contains_key(&remote_node_id)` always should be false
                     if !self.remote_node_ids_reverse.write().contains_key(&remote_node_id) {
                         assert_eq!(
                             None,

--- a/sync/src/block/extension.rs
+++ b/sync/src/block/extension.rs
@@ -477,6 +477,8 @@ impl NetworkExtension<Event> for Extension {
         cinfo!(SYNC, "New peer detected #{}", id);
         self.send_status(id);
 
+        // FIXME the if condition below is a hotfix.
+        // `self.connected_nodes.contains(id)` always should be false
         if !self.connected_nodes.contains(id) {
             let t = self.connected_nodes.insert(*id);
             debug_assert!(t, "{} is already added to peer list", id);
@@ -488,6 +490,8 @@ impl NetworkExtension<Event> for Extension {
             request_id: None,
         };
 
+        // FIXME the if condition below is a hotfix.
+        // `self.requests.contains(id)` always should be false
         if !self.requests.contains_key(id) {
             let t = self.requests.insert(*id, Vec::new());
             debug_assert_eq!(None, t);


### PR DESCRIPTION
I copied the commit from https://github.com/CodeChain-io/foundry/pull/499
This PR is a hotfix for https://github.com/CodeChain-io/foundry/issues/274

I tried to import two commits in the #499 PR. However "Fix the mismatch number of peer connections" made Foundry not to connect each other.

